### PR TITLE
refactor: 보안 강화, 반응형 개편, 모듈화 및 로그인 수정

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -1,10 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ['@blog-study/shared'],
-  
+
   // Production optimizations
   poweredByHeader: false,
-  
+
   // Image optimization
   images: {
     remotePatterns: [
@@ -18,13 +18,26 @@ const nextConfig = {
       },
     ],
   },
-  
+
   // Experimental features
   experimental: {
     // Enable server actions
     serverActions: {
       bodySizeLimit: '2mb',
     },
+  },
+
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+        ],
+      },
+    ];
   },
 };
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "블로그 스터디 관리자 대시보드",
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --port 3200",
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",

--- a/packages/web/src/app/(admin)/admin/attendance/page.tsx
+++ b/packages/web/src/app/(admin)/admin/attendance/page.tsx
@@ -20,6 +20,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { PageLoading, PageError } from '@/components/ui/page-state';
+import { MEMBER_STATUS_CONFIG } from '@/lib/member-config';
 
 interface RoundInfo {
   id: number;
@@ -111,11 +113,6 @@ const statusConfig = {
   },
 } as const satisfies Record<string, StatusConfigItem>;
 
-const memberStatusConfig: Record<string, { label: string; variant: 'default' | 'secondary' | 'destructive' }> = {
-  active: { label: '활성', variant: 'default' },
-  dormant: { label: '휴면', variant: 'secondary' },
-  withdrawn: { label: '탈퇴', variant: 'destructive' },
-};
 
 function getStatusConfig(status: string): StatusConfigItem {
   if (status in statusConfig) {
@@ -166,28 +163,17 @@ export default function AdminAttendancePage() {
     fetchAttendance();
   }, [fetchAttendance]);
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-muted-foreground">로딩 중...</div>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-destructive">{error}</div>
-      </div>
-    );
-  }
+  if (loading) return <PageLoading />;
+  if (error) return <PageError message={error} />;
 
   if (!data || data.rounds.length === 0) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">출석 현황</h1>
-          <p className="text-muted-foreground">회차별 출석 현황을 확인하세요.</p>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">출석 현황</h1>
+            <p className="text-muted-foreground">회차별 출석 현황을 확인하세요.</p>
+          </div>
         </div>
         <Card>
           <CardContent className="py-8">
@@ -223,11 +209,13 @@ export default function AdminAttendancePage() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">출석 현황</h1>
-        <p className="text-muted-foreground">
-          회차별 출석 현황을 확인하세요. (멤버 × 회차 그리드)
-        </p>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">출석 현황</h1>
+          <p className="text-muted-foreground">
+            회차별 출석 현황을 확인하세요. (멤버 × 회차 그리드)
+          </p>
+        </div>
       </div>
 
       {/* Legend */}
@@ -250,7 +238,7 @@ export default function AdminAttendancePage() {
       </Card>
 
       {/* Round Stats Summary */}
-      <div className="grid gap-4 md:grid-cols-5">
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-5 md:gap-4">
         {visibleRoundStats.map((rs) => (
           <Card key={rs.roundId} className={rs.isCurrent ? 'border-primary' : ''}>
             <CardHeader className="pb-2">
@@ -282,14 +270,14 @@ export default function AdminAttendancePage() {
       {/* Attendance Grid */}
       <Card>
         <CardHeader>
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <CardTitle>출석 그리드</CardTitle>
               <CardDescription>
                 {filteredGrid.length}명의 멤버 × {data.rounds.length}개 회차
               </CardDescription>
             </div>
-            <div className="flex items-center gap-4">
+            <div className="flex flex-wrap items-center gap-3">
               {/* Status Filter */}
               <div className="flex items-center gap-2">
                 <span className="text-sm text-muted-foreground">상태:</span>
@@ -314,7 +302,7 @@ export default function AdminAttendancePage() {
                 >
                   <ChevronLeft className="h-4 w-4" />
                 </Button>
-                <span className="text-sm text-muted-foreground">
+                <span className="text-sm text-muted-foreground whitespace-nowrap">
                   {currentPage + 1} / {totalPages}
                 </span>
                 <Button
@@ -368,8 +356,8 @@ export default function AdminAttendancePage() {
                         </div>
                       </TableCell>
                       <TableCell className="sticky left-[150px] bg-background z-10">
-                        <Badge variant={memberStatusConfig[row.member.status]?.variant || 'secondary'}>
-                          {memberStatusConfig[row.member.status]?.label || row.member.status}
+                        <Badge variant={MEMBER_STATUS_CONFIG[row.member.status]?.variant || 'secondary'}>
+                          {MEMBER_STATUS_CONFIG[row.member.status]?.label || row.member.status}
                         </Badge>
                       </TableCell>
                       {visibleRounds.map((round) => {

--- a/packages/web/src/app/(admin)/admin/curation/crawl-modal.tsx
+++ b/packages/web/src/app/(admin)/admin/curation/crawl-modal.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { Loader2, CheckCircle2, AlertCircle, XCircle } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+
+export interface CrawlSourceResult {
+  sourceId: string;
+  sourceName: string;
+  success: boolean;
+  itemsFound: number;
+  newItemsAdded: number;
+  error?: string;
+}
+
+export interface CrawlSummary {
+  totalSources: number;
+  totalNewItems: number;
+  successCount: number;
+  failCount: number;
+}
+
+export type CrawlStatus = 'idle' | 'crawling' | 'done' | 'error';
+
+export interface CrawlModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  status: CrawlStatus;
+  totalSources: number;
+  processingName: string;
+  results: CrawlSourceResult[];
+  summary: CrawlSummary | null;
+  errorMessage: string | null;
+}
+
+export function CrawlModal({
+  open,
+  onOpenChange,
+  status,
+  totalSources,
+  processingName,
+  results,
+  summary,
+  errorMessage,
+}: CrawlModalProps) {
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && status === 'crawling') return;
+    onOpenChange(nextOpen);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-[520px] max-h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {status === 'crawling' && <Loader2 className="h-5 w-5 animate-spin text-primary" />}
+            {status === 'done' && <CheckCircle2 className="h-5 w-5 text-emerald-500" />}
+            {status === 'error' && <AlertCircle className="h-5 w-5 text-destructive" />}
+            {status === 'crawling'
+              ? '크롤링 진행 중'
+              : status === 'error'
+                ? '크롤링 실패'
+                : '크롤링 완료'}
+          </DialogTitle>
+          <DialogDescription>
+            {status === 'crawling' && processingName && (
+              <span>{processingName} 처리 중...</span>
+            )}
+            {status === 'done' && summary && (
+              <span>
+                {summary.totalSources}개 소스에서{' '}
+                <strong className="text-primary">{summary.totalNewItems}개</strong> 새 아이템 수집
+              </span>
+            )}
+            {status === 'error' && errorMessage}
+            {errorMessage && status === 'done' && <span>{errorMessage}</span>}
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Progress Bar */}
+        {totalSources > 0 && (
+          <div className="space-y-1.5">
+            <div className="flex justify-between text-xs text-muted-foreground">
+              <span>
+                {results.length} / {totalSources} 소스
+              </span>
+              <span>{Math.round((results.length / totalSources) * 100)}%</span>
+            </div>
+            <Progress value={(results.length / totalSources) * 100} className="h-2" />
+          </div>
+        )}
+
+        {/* Summary Stats */}
+        {status === 'done' && summary && (
+          <div className="grid grid-cols-3 gap-3 text-center">
+            <div className="rounded-lg bg-muted/50 p-2.5">
+              <div className="text-lg font-bold">{summary.totalSources}</div>
+              <div className="text-xs text-muted-foreground">전체 소스</div>
+            </div>
+            <div className="rounded-lg bg-emerald-50 dark:bg-emerald-500/10 p-2.5">
+              <div className="text-lg font-bold text-emerald-600 dark:text-emerald-400">
+                {summary.successCount}
+              </div>
+              <div className="text-xs text-muted-foreground">성공</div>
+            </div>
+            <div className="rounded-lg bg-red-50 dark:bg-red-500/10 p-2.5">
+              <div className="text-lg font-bold text-destructive">{summary.failCount}</div>
+              <div className="text-xs text-muted-foreground">실패</div>
+            </div>
+          </div>
+        )}
+
+        {/* Source Results List */}
+        {results.length > 0 && (
+          <div className="flex-1 overflow-y-auto space-y-1.5 max-h-[300px] pr-1">
+            {results.map((r) => (
+              <div
+                key={r.sourceId}
+                className={`flex items-start gap-2.5 rounded-lg border px-3 py-2.5 text-sm ${
+                  r.success
+                    ? 'border-border bg-background'
+                    : 'border-destructive/30 bg-destructive/5'
+                }`}
+              >
+                {r.success ? (
+                  <CheckCircle2 className="h-4 w-4 text-emerald-500 mt-0.5 shrink-0" />
+                ) : (
+                  <XCircle className="h-4 w-4 text-destructive mt-0.5 shrink-0" />
+                )}
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium truncate">{r.sourceName}</div>
+                  {r.success ? (
+                    <div className="text-xs text-muted-foreground">
+                      {r.itemsFound}개 발견,{' '}
+                      <span className="text-primary font-medium">{r.newItemsAdded}개 추가</span>
+                    </div>
+                  ) : (
+                    <div className="text-xs text-destructive">{r.error}</div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={status === 'crawling'}
+          >
+            {status === 'crawling' ? '진행 중...' : '닫기'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/web/src/app/(admin)/admin/curation/items/page.tsx
+++ b/packages/web/src/app/(admin)/admin/curation/items/page.tsx
@@ -133,13 +133,13 @@ export default function CurationItemsPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center gap-4">
-        <Button variant="ghost" size="sm" onClick={() => router.push('/admin/curation')}>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+        <Button variant="ghost" size="sm" onClick={() => router.push('/admin/curation')} className="self-start">
           <ArrowLeft className="h-4 w-4 mr-1" />
           돌아가기
         </Button>
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">수집된 아이템</h1>
+          <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">수집된 아이템</h1>
           <p className="text-muted-foreground">
             총 {pagination.total}개의 아이템
           </p>
@@ -147,7 +147,7 @@ export default function CurationItemsPage() {
       </div>
 
       {/* Filter Bar */}
-      <div className="flex gap-3 items-center">
+      <div className="flex flex-wrap gap-3 items-center">
         <select
           className="flex h-9 rounded-md border border-input bg-background px-3 py-1 text-sm ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
           value={category}
@@ -159,7 +159,7 @@ export default function CurationItemsPage() {
         </select>
 
         <select
-          className="flex h-9 rounded-md border border-input bg-background px-3 py-1 text-sm ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+          className="flex h-9 rounded-md border border-input bg-background px-3 py-1 text-sm ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring max-w-[200px]"
           value={sourceId}
           onChange={(e) => handleFilterChange(category, e.target.value)}
         >
@@ -182,7 +182,7 @@ export default function CurationItemsPage() {
           수집된 아이템이 없습니다.
         </div>
       ) : (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
           {items.map((item) => (
             <Card key={item.id} className="flex flex-col">
               <CardContent className="flex flex-col gap-3 pt-5 flex-1">

--- a/packages/web/src/app/(admin)/admin/curation/page.tsx
+++ b/packages/web/src/app/(admin)/admin/curation/page.tsx
@@ -2,59 +2,23 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
+import { Rss, Plus, Search, FileText, Calendar, Loader2, RefreshCw, X } from 'lucide-react';
 import {
-  Rss,
-  Plus,
-  Trash2,
-  ExternalLink,
-  Search,
-  ToggleLeft,
-  ToggleRight,
-  FileText,
-  Calendar,
-  Loader2,
-  RefreshCw,
-  Pencil,
-  X,
-  CheckCircle2,
-  XCircle,
-  AlertCircle,
-} from 'lucide-react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-} from '@/components/ui/dialog';
-import { Progress } from '@/components/ui/progress';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
-import { INTEREST_OPTIONS } from '@blog-study/shared/config';
-
-interface CurationSource {
-  id: string;
-  url: string;
-  name: string;
-  category: string;
-  rssUrl: string | null;
-  tags: string[] | null;
-  isActive: boolean;
-  createdAt: string;
-  itemCount: number;
-}
+import { PageLoading, PageError } from '@/components/ui/page-state';
+import { CrawlModal } from './crawl-modal';
+import type { CrawlStatus, CrawlSourceResult, CrawlSummary } from './crawl-modal';
+import { SourceForm } from './source-form';
+import type { SourceFormValues } from './source-form';
+import { SourcesTable } from './sources-table';
+import type { CurationSource } from './sources-table';
 
 interface CurationStats {
   totalSources: number;
@@ -68,29 +32,6 @@ interface CurationData {
   stats: CurationStats;
   categories: string[];
 }
-
-interface CrawlSourceResult {
-  sourceId: string;
-  sourceName: string;
-  success: boolean;
-  itemsFound: number;
-  newItemsAdded: number;
-  error?: string;
-}
-
-interface CrawlSummary {
-  totalSources: number;
-  totalNewItems: number;
-  successCount: number;
-  failCount: number;
-}
-
-type CrawlStatus = 'idle' | 'crawling' | 'done' | 'error';
-
-const categoryLabels: Record<string, string> = {
-  conference: '컨퍼런스',
-  article: '아티클',
-};
 
 const CRAWL_PERIOD_OPTIONS = [
   { label: '최근 1일', days: 1 },
@@ -111,25 +52,11 @@ export default function AdminCurationPage() {
   const [crawlPeriod, setCrawlPeriod] = useState(7);
 
   // Add form state
-  const [newSource, setNewSource] = useState({
-    url: '',
-    name: '',
-    category: 'article',
-    rssUrl: '',
-    tags: [] as string[],
-  });
   const [addError, setAddError] = useState<string | null>(null);
   const [adding, setAdding] = useState(false);
 
   // Edit form state
   const [editingSource, setEditingSource] = useState<CurationSource | null>(null);
-  const [editForm, setEditForm] = useState({
-    name: '',
-    url: '',
-    category: 'article',
-    rssUrl: '',
-    tags: [] as string[],
-  });
   const [editError, setEditError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -163,84 +90,10 @@ export default function AdminCurationPage() {
     fetchSources();
   }, [fetchSources]);
 
-  const toggleTag = (tag: string) => {
-    setNewSource((prev) => ({
-      ...prev,
-      tags: prev.tags.includes(tag)
-        ? prev.tags.filter((t) => t !== tag)
-        : [...prev.tags, tag],
-    }));
-  };
-
-  const startEditing = (source: CurationSource) => {
-    setEditingSource(source);
-    setEditForm({
-      name: source.name,
-      url: source.url,
-      category: source.category,
-      rssUrl: source.rssUrl || '',
-      tags: source.tags || [],
-    });
-    setEditError(null);
-  };
-
-  const cancelEditing = () => {
-    setEditingSource(null);
-    setEditError(null);
-  };
-
-  const toggleEditTag = (tag: string) => {
-    setEditForm((prev) => ({
-      ...prev,
-      tags: prev.tags.includes(tag)
-        ? prev.tags.filter((t) => t !== tag)
-        : [...prev.tags, tag],
-    }));
-  };
-
-  const handleEditSource = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!editingSource) return;
-    setEditError(null);
-
-    if (!editForm.name || !editForm.url) {
-      setEditError('이름과 URL은 필수입니다.');
-      return;
-    }
-
-    try {
-      setSaving(true);
-      const response = await fetch(`/api/admin/curation/${editingSource.id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: editForm.name,
-          url: editForm.url,
-          category: editForm.category,
-          rssUrl: editForm.rssUrl || null,
-          tags: editForm.tags,
-        }),
-      });
-
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || '수정에 실패했습니다.');
-      }
-
-      setEditingSource(null);
-      await fetchSources();
-    } catch (err) {
-      setEditError(err instanceof Error ? err.message : '수정에 실패했습니다.');
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleAddSource = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleAddSource = async (values: SourceFormValues) => {
     setAddError(null);
 
-    if (!newSource.url || !newSource.name) {
+    if (!values.url || !values.name) {
       setAddError('URL과 이름은 필수입니다.');
       return;
     }
@@ -251,27 +104,62 @@ export default function AdminCurationPage() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          url: newSource.url,
-          name: newSource.name,
-          category: newSource.category,
-          tags: newSource.tags.length > 0 ? newSource.tags : undefined,
-          rssUrl: newSource.rssUrl || undefined,
+          url: values.url,
+          name: values.name,
+          category: values.category,
+          tags: values.tags.length > 0 ? values.tags : undefined,
+          rssUrl: values.rssUrl || undefined,
         }),
       });
 
       if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || 'Failed to add source');
+        const resData = await response.json();
+        throw new Error(resData.error || 'Failed to add source');
       }
 
-      // Reset form and refresh
-      setNewSource({ url: '', name: '', category: 'article', rssUrl: '', tags: [] });
       setShowAddForm(false);
       await fetchSources();
     } catch (err) {
       setAddError(err instanceof Error ? err.message : '소스 추가에 실패했습니다.');
     } finally {
       setAdding(false);
+    }
+  };
+
+  const handleEditSource = async (values: SourceFormValues) => {
+    if (!editingSource) return;
+    setEditError(null);
+
+    if (!values.name || !values.url) {
+      setEditError('이름과 URL은 필수입니다.');
+      return;
+    }
+
+    try {
+      setSaving(true);
+      const response = await fetch(`/api/admin/curation/${editingSource.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: values.name,
+          url: values.url,
+          category: values.category,
+          rssUrl: values.rssUrl || null,
+          tags: values.tags,
+        }),
+      });
+
+      if (!response.ok) {
+        const resData = await response.json();
+        throw new Error(resData.error || '수정에 실패했습니다.');
+      }
+
+      setEditingSource(null);
+      await fetchSources();
+    } catch (err) {
+      setEditError(err instanceof Error ? err.message : '수정에 실패했습니다.');
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -291,14 +179,17 @@ export default function AdminCurationPage() {
       await fetchSources();
     } catch (err) {
       console.error('Error toggling source:', err);
-      alert('상태 변경에 실패했습니다.');
     } finally {
       setUpdatingId(null);
     }
   };
 
   const handleDelete = async (source: CurationSource) => {
-    if (!confirm(`"${source.name}" 소스를 삭제하시겠습니까?\n수집된 ${source.itemCount}개의 아이템도 함께 삭제됩니다.`)) {
+    if (
+      !confirm(
+        `"${source.name}" 소스를 삭제하시겠습니까?\n수집된 ${source.itemCount}개의 아이템도 함께 삭제됩니다.`,
+      )
+    ) {
       return;
     }
 
@@ -315,7 +206,6 @@ export default function AdminCurationPage() {
       await fetchSources();
     } catch (err) {
       console.error('Error deleting source:', err);
-      alert('삭제에 실패했습니다.');
     } finally {
       setUpdatingId(null);
     }
@@ -324,7 +214,6 @@ export default function AdminCurationPage() {
   const handleCrawl = async () => {
     if (crawlStatus === 'crawling') return;
 
-    // 모달 열고 초기화
     setCrawlModalOpen(true);
     setCrawlStatus('crawling');
     setCrawlTotalSources(0);
@@ -371,17 +260,17 @@ export default function AdminCurationPage() {
             eventType = line.slice(7).trim();
           } else if (line.startsWith('data: ') && eventType) {
             try {
-              const data = JSON.parse(line.slice(6));
+              const parsed = JSON.parse(line.slice(6));
 
               if (eventType === 'start') {
-                setCrawlTotalSources(data.totalSources);
+                setCrawlTotalSources(parsed.totalSources);
               } else if (eventType === 'processing') {
-                setCrawlProcessingName(data.sourceName);
+                setCrawlProcessingName(parsed.sourceName);
               } else if (eventType === 'progress') {
-                setCrawlResults((prev) => [...prev, data.result]);
+                setCrawlResults((prev) => [...prev, parsed.result]);
               } else if (eventType === 'complete') {
-                setCrawlSummary(data.summary);
-                if (data.message) setCrawlErrorMessage(data.message);
+                setCrawlSummary(parsed.summary);
+                if (parsed.message) setCrawlErrorMessage(parsed.message);
                 setCrawlStatus('done');
               }
             } catch {
@@ -392,61 +281,48 @@ export default function AdminCurationPage() {
         }
       }
 
-      // 스트림이 끝났는데 아직 done 아니면 완료 처리
-      if (crawlStatus !== 'done') {
-        setCrawlStatus('done');
-      }
+      // Stream ended without a 'complete' event — treat as done
+      setCrawlStatus((prev) => (prev !== 'done' ? 'done' : prev));
       await fetchSources();
     } catch (err) {
       setCrawlStatus('error');
-      setCrawlErrorMessage(err instanceof Error ? err.message : '크롤링 실행에 실패했습니다.');
+      setCrawlErrorMessage(
+        err instanceof Error ? err.message : '크롤링 실행에 실패했습니다.',
+      );
     }
   };
 
-  const closeCrawlModal = () => {
-    if (crawlStatus === 'crawling') return; // 진행 중엔 닫기 방지
-    setCrawlModalOpen(false);
-    setCrawlStatus('idle');
+  const closeCrawlModal = (open: boolean) => {
+    if (!open && crawlStatus === 'crawling') return;
+    setCrawlModalOpen(open);
+    if (!open) setCrawlStatus('idle');
   };
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-muted-foreground">로딩 중...</div>
-      </div>
-    );
-  }
+  if (loading) return <PageLoading />;
+  if (error) return <PageError message={error} />;
 
-  if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-destructive">{error}</div>
-      </div>
-    );
-  }
-
-  // Filter sources
-  const filteredSources = data?.sources.filter((source) => {
-    if (!searchQuery) return true;
-    const query = searchQuery.toLowerCase();
-    return (
-      source.name.toLowerCase().includes(query) ||
-      source.url.toLowerCase().includes(query) ||
-      source.category.toLowerCase().includes(query) ||
-      (source.tags || []).some((t) => t.toLowerCase().includes(query))
-    );
-  }) || [];
+  const filteredSources =
+    data?.sources.filter((source) => {
+      if (!searchQuery) return true;
+      const query = searchQuery.toLowerCase();
+      return (
+        source.name.toLowerCase().includes(query) ||
+        source.url.toLowerCase().includes(query) ||
+        source.category.toLowerCase().includes(query) ||
+        (source.tags || []).some((t) => t.toLowerCase().includes(query))
+      );
+    }) || [];
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">큐레이션 소스 관리</h1>
           <p className="text-muted-foreground">
             외부 컨퍼런스 및 아티클 수집 소스를 관리하세요.
           </p>
         </div>
-        <div className="flex gap-2 items-center">
+        <div className="flex flex-wrap gap-2 items-center">
           <select
             className="flex h-9 rounded-md border border-input bg-background px-3 py-1 text-sm ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
             value={crawlPeriod}
@@ -474,106 +350,19 @@ export default function AdminCurationPage() {
       </div>
 
       {/* Crawl Progress Modal */}
-      <Dialog open={crawlModalOpen} onOpenChange={(open) => { if (!open) closeCrawlModal(); }}>
-        <DialogContent className="sm:max-w-[520px] max-h-[80vh] flex flex-col">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              {crawlStatus === 'crawling' && <Loader2 className="h-5 w-5 animate-spin text-primary" />}
-              {crawlStatus === 'done' && <CheckCircle2 className="h-5 w-5 text-emerald-500" />}
-              {crawlStatus === 'error' && <AlertCircle className="h-5 w-5 text-destructive" />}
-              {crawlStatus === 'crawling' ? '크롤링 진행 중' : crawlStatus === 'error' ? '크롤링 실패' : '크롤링 완료'}
-            </DialogTitle>
-            <DialogDescription>
-              {crawlStatus === 'crawling' && crawlProcessingName && (
-                <span>{crawlProcessingName} 처리 중...</span>
-              )}
-              {crawlStatus === 'done' && crawlSummary && (
-                <span>
-                  {crawlSummary.totalSources}개 소스에서 <strong className="text-primary">{crawlSummary.totalNewItems}개</strong> 새 아이템 수집
-                </span>
-              )}
-              {crawlStatus === 'error' && crawlErrorMessage}
-              {crawlErrorMessage && crawlStatus === 'done' && (
-                <span>{crawlErrorMessage}</span>
-              )}
-            </DialogDescription>
-          </DialogHeader>
-
-          {/* Progress Bar */}
-          {crawlTotalSources > 0 && (
-            <div className="space-y-1.5">
-              <div className="flex justify-between text-xs text-muted-foreground">
-                <span>{crawlResults.length} / {crawlTotalSources} 소스</span>
-                <span>{Math.round((crawlResults.length / crawlTotalSources) * 100)}%</span>
-              </div>
-              <Progress value={(crawlResults.length / crawlTotalSources) * 100} className="h-2" />
-            </div>
-          )}
-
-          {/* Summary Stats */}
-          {crawlStatus === 'done' && crawlSummary && (
-            <div className="grid grid-cols-3 gap-3 text-center">
-              <div className="rounded-lg bg-muted/50 p-2.5">
-                <div className="text-lg font-bold">{crawlSummary.totalSources}</div>
-                <div className="text-xs text-muted-foreground">전체 소스</div>
-              </div>
-              <div className="rounded-lg bg-emerald-50 dark:bg-emerald-500/10 p-2.5">
-                <div className="text-lg font-bold text-emerald-600 dark:text-emerald-400">{crawlSummary.successCount}</div>
-                <div className="text-xs text-muted-foreground">성공</div>
-              </div>
-              <div className="rounded-lg bg-red-50 dark:bg-red-500/10 p-2.5">
-                <div className="text-lg font-bold text-destructive">{crawlSummary.failCount}</div>
-                <div className="text-xs text-muted-foreground">실패</div>
-              </div>
-            </div>
-          )}
-
-          {/* Source Results List */}
-          {crawlResults.length > 0 && (
-            <div className="flex-1 overflow-y-auto space-y-1.5 max-h-[300px] pr-1">
-              {crawlResults.map((r) => (
-                <div
-                  key={r.sourceId}
-                  className={`flex items-start gap-2.5 rounded-lg border px-3 py-2.5 text-sm ${
-                    r.success
-                      ? 'border-border bg-background'
-                      : 'border-destructive/30 bg-destructive/5'
-                  }`}
-                >
-                  {r.success ? (
-                    <CheckCircle2 className="h-4 w-4 text-emerald-500 mt-0.5 shrink-0" />
-                  ) : (
-                    <XCircle className="h-4 w-4 text-destructive mt-0.5 shrink-0" />
-                  )}
-                  <div className="flex-1 min-w-0">
-                    <div className="font-medium truncate">{r.sourceName}</div>
-                    {r.success ? (
-                      <div className="text-xs text-muted-foreground">
-                        {r.itemsFound}개 발견, <span className="text-primary font-medium">{r.newItemsAdded}개 추가</span>
-                      </div>
-                    ) : (
-                      <div className="text-xs text-destructive">{r.error}</div>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={closeCrawlModal}
-              disabled={crawlStatus === 'crawling'}
-            >
-              {crawlStatus === 'crawling' ? '진행 중...' : '닫기'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <CrawlModal
+        open={crawlModalOpen}
+        onOpenChange={closeCrawlModal}
+        status={crawlStatus}
+        totalSources={crawlTotalSources}
+        processingName={crawlProcessingName}
+        results={crawlResults}
+        summary={crawlSummary}
+        errorMessage={crawlErrorMessage}
+      />
 
       {/* Stats Cards */}
-      <div className="grid gap-4 md:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">전체 소스</CardTitle>
@@ -581,9 +370,7 @@ export default function AdminCurationPage() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{data?.stats.totalSources || 0}개</div>
-            <p className="text-xs text-muted-foreground">
-              활성 {data?.stats.activeSources || 0}개
-            </p>
+            <p className="text-xs text-muted-foreground">활성 {data?.stats.activeSources || 0}개</p>
           </CardContent>
         </Card>
         <Card
@@ -596,9 +383,7 @@ export default function AdminCurationPage() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{data?.stats.totalItems || 0}개</div>
-            <p className="text-xs text-muted-foreground">
-              공유됨 {data?.stats.sharedItems || 0}개
-            </p>
+            <p className="text-xs text-muted-foreground">공유됨 {data?.stats.sharedItems || 0}개</p>
           </CardContent>
         </Card>
         <Card>
@@ -630,104 +415,21 @@ export default function AdminCurationPage() {
         <Card>
           <CardHeader>
             <CardTitle>새 소스 추가</CardTitle>
-            <CardDescription>
-              큐레이션할 외부 사이트를 추가합니다.
-            </CardDescription>
+            <CardDescription>큐레이션할 외부 사이트를 추가합니다.</CardDescription>
           </CardHeader>
           <CardContent>
-            <form onSubmit={handleAddSource} className="space-y-4">
-              {addError && (
-                <div className="bg-destructive/10 text-destructive px-4 py-2 rounded-lg text-sm">
-                  {addError}
-                </div>
-              )}
-              <div className="grid gap-4 md:grid-cols-3">
-                <div className="space-y-2">
-                  <Label htmlFor="name">이름</Label>
-                  <Input
-                    id="name"
-                    value={newSource.name}
-                    onChange={(e) => setNewSource({ ...newSource, name: e.target.value })}
-                    placeholder="예: GeekNews"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="url">URL</Label>
-                  <Input
-                    id="url"
-                    type="url"
-                    value={newSource.url}
-                    onChange={(e) => setNewSource({ ...newSource, url: e.target.value })}
-                    placeholder="https://news.hada.io"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="category">카테고리</Label>
-                  <select
-                    id="category"
-                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                    value={newSource.category}
-                    onChange={(e) => setNewSource({ ...newSource, category: e.target.value })}
-                  >
-                    {data?.categories.map((cat) => (
-                      <option key={cat} value={cat}>
-                        {categoryLabels[cat] || cat}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="rssUrl">RSS URL (선택)</Label>
-                <Input
-                  id="rssUrl"
-                  type="url"
-                  value={newSource.rssUrl}
-                  onChange={(e) => setNewSource({ ...newSource, rssUrl: e.target.value })}
-                  placeholder="비워두면 자동 감지를 시도합니다"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label>
-                  관심 태그 (선택)
-                  {newSource.tags.length > 0 && (
-                    <span className="text-xs text-muted-foreground ml-2">
-                      {newSource.tags.length}개 선택
-                    </span>
-                  )}
-                </Label>
-                <div className="flex flex-wrap gap-1.5">
-                  {INTEREST_OPTIONS.map((tag) => {
-                    const isSelected = newSource.tags.includes(tag);
-                    return (
-                      <Badge
-                        key={tag}
-                        variant={isSelected ? 'default' : 'outline'}
-                        className="cursor-pointer transition-colors text-xs"
-                        onClick={() => toggleTag(tag)}
-                      >
-                        {tag}
-                      </Badge>
-                    );
-                  })}
-                </div>
-              </div>
-              <div className="flex gap-2">
-                <Button type="submit" disabled={adding}>
-                  {adding ? '추가 중...' : '추가'}
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => {
-                    setShowAddForm(false);
-                    setAddError(null);
-                  }}
-                >
-                  취소
-                </Button>
-              </div>
-            </form>
+            <SourceForm
+              initialValues={{ name: '', url: '', category: 'article', rssUrl: '', tags: [] }}
+              categories={data?.categories || []}
+              onSubmit={handleAddSource}
+              onCancel={() => {
+                setShowAddForm(false);
+                setAddError(null);
+              }}
+              submitLabel="추가"
+              submitting={adding}
+              error={addError}
+            />
           </CardContent>
         </Card>
       )}
@@ -735,18 +437,16 @@ export default function AdminCurationPage() {
       {/* Sources Table */}
       <Card>
         <CardHeader>
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <CardTitle>소스 목록</CardTitle>
-              <CardDescription>
-                {filteredSources.length}개의 소스
-              </CardDescription>
+              <CardDescription>{filteredSources.length}개의 소스</CardDescription>
             </div>
             <div className="relative">
               <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
               <Input
                 placeholder="검색..."
-                className="pl-8 w-[200px]"
+                className="pl-8 w-full sm:w-[200px]"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
               />
@@ -754,124 +454,17 @@ export default function AdminCurationPage() {
           </div>
         </CardHeader>
         <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>이름</TableHead>
-                <TableHead>URL</TableHead>
-                <TableHead>카테고리</TableHead>
-                <TableHead>태그</TableHead>
-                <TableHead className="text-center">아이템</TableHead>
-                <TableHead className="text-center">상태</TableHead>
-                <TableHead>등록일</TableHead>
-                <TableHead className="w-[140px]">작업</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {filteredSources.length > 0 ? (
-                filteredSources.map((source) => (
-                  <TableRow key={source.id}>
-                    <TableCell>
-                      <div>
-                        <span className="font-medium">{source.name}</span>
-                        {source.rssUrl && (
-                          <span className="ml-1.5 text-xs text-muted-foreground" title={source.rssUrl}>
-                            RSS
-                          </span>
-                        )}
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <a
-                        href={source.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex items-center gap-1 text-primary hover:underline text-sm"
-                      >
-                        {source.url.length > 40
-                          ? source.url.substring(0, 40) + '...'
-                          : source.url}
-                        <ExternalLink className="h-3 w-3" />
-                      </a>
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant="outline">
-                        {categoryLabels[source.category] || source.category}
-                      </Badge>
-                    </TableCell>
-                    <TableCell>
-                      {source.tags && source.tags.length > 0 ? (
-                        <div className="flex flex-wrap gap-1">
-                          {source.tags.slice(0, 4).map((tag) => (
-                            <span key={tag} className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-primary/10 text-primary">
-                              {tag}
-                            </span>
-                          ))}
-                          {source.tags.length > 4 && (
-                            <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-muted text-muted-foreground">
-                              +{source.tags.length - 4}
-                            </span>
-                          )}
-                        </div>
-                      ) : (
-                        <span className="text-xs text-muted-foreground">-</span>
-                      )}
-                    </TableCell>
-                    <TableCell className="text-center">{source.itemCount}</TableCell>
-                    <TableCell className="text-center">
-                      <Badge variant={source.isActive ? 'default' : 'secondary'}>
-                        {source.isActive ? '활성' : '비활성'}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-muted-foreground text-sm">
-                      {new Date(source.createdAt).toLocaleDateString('ko-KR')}
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex items-center gap-1">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => handleToggleActive(source)}
-                          disabled={updatingId === source.id}
-                          title={source.isActive ? '비활성화' : '활성화'}
-                        >
-                          {source.isActive ? (
-                            <ToggleRight className="h-4 w-4 text-success" />
-                          ) : (
-                            <ToggleLeft className="h-4 w-4 text-muted-foreground" />
-                          )}
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => startEditing(source)}
-                          disabled={updatingId === source.id}
-                          title="수정"
-                        >
-                          <Pencil className="h-4 w-4" />
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => handleDelete(source)}
-                          disabled={updatingId === source.id}
-                          title="삭제"
-                        >
-                          <Trash2 className="h-4 w-4 text-destructive" />
-                        </Button>
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                ))
-              ) : (
-                <TableRow>
-                  <TableCell colSpan={8} className="text-center py-8 text-muted-foreground">
-                    {searchQuery ? '검색 결과가 없습니다.' : '등록된 소스가 없습니다.'}
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
+          <SourcesTable
+            sources={filteredSources}
+            onToggleActive={handleToggleActive}
+            onEdit={(source) => {
+              setEditingSource(source);
+              setEditError(null);
+            }}
+            onDelete={handleDelete}
+            updatingId={updatingId}
+            searchQuery={searchQuery}
+          />
         </CardContent>
       </Card>
 
@@ -886,96 +479,38 @@ export default function AdminCurationPage() {
                   &quot;{editingSource.name}&quot; 소스 정보를 수정합니다.
                 </CardDescription>
               </div>
-              <Button variant="ghost" size="sm" onClick={cancelEditing}>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setEditingSource(null);
+                  setEditError(null);
+                }}
+              >
                 <X className="h-4 w-4" />
               </Button>
             </div>
           </CardHeader>
           <CardContent>
-            <form onSubmit={handleEditSource} className="space-y-4">
-              {editError && (
-                <div className="bg-destructive/10 text-destructive px-4 py-2 rounded-lg text-sm">
-                  {editError}
-                </div>
-              )}
-              <div className="grid gap-4 md:grid-cols-3">
-                <div className="space-y-2">
-                  <Label htmlFor="edit-name">이름</Label>
-                  <Input
-                    id="edit-name"
-                    value={editForm.name}
-                    onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="edit-url">URL</Label>
-                  <Input
-                    id="edit-url"
-                    type="url"
-                    value={editForm.url}
-                    onChange={(e) => setEditForm({ ...editForm, url: e.target.value })}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="edit-category">카테고리</Label>
-                  <select
-                    id="edit-category"
-                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                    value={editForm.category}
-                    onChange={(e) => setEditForm({ ...editForm, category: e.target.value })}
-                  >
-                    {data?.categories.map((cat) => (
-                      <option key={cat} value={cat}>
-                        {categoryLabels[cat] || cat}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="edit-rssUrl">RSS URL</Label>
-                <Input
-                  id="edit-rssUrl"
-                  type="url"
-                  value={editForm.rssUrl}
-                  onChange={(e) => setEditForm({ ...editForm, rssUrl: e.target.value })}
-                  placeholder="비워두면 크롤링 대상에서 제외됩니다"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label>
-                  관심 태그
-                  {editForm.tags.length > 0 && (
-                    <span className="text-xs text-muted-foreground ml-2">
-                      {editForm.tags.length}개 선택
-                    </span>
-                  )}
-                </Label>
-                <div className="flex flex-wrap gap-1.5">
-                  {INTEREST_OPTIONS.map((tag) => {
-                    const isSelected = editForm.tags.includes(tag);
-                    return (
-                      <Badge
-                        key={tag}
-                        variant={isSelected ? 'default' : 'outline'}
-                        className="cursor-pointer transition-colors text-xs"
-                        onClick={() => toggleEditTag(tag)}
-                      >
-                        {tag}
-                      </Badge>
-                    );
-                  })}
-                </div>
-              </div>
-              <div className="flex gap-2">
-                <Button type="submit" disabled={saving}>
-                  {saving ? '저장 중...' : '저장'}
-                </Button>
-                <Button type="button" variant="outline" onClick={cancelEditing}>
-                  취소
-                </Button>
-              </div>
-            </form>
+            <SourceForm
+              key={editingSource.id}
+              initialValues={{
+                name: editingSource.name,
+                url: editingSource.url,
+                category: editingSource.category,
+                rssUrl: editingSource.rssUrl || '',
+                tags: editingSource.tags || [],
+              }}
+              categories={data?.categories || []}
+              onSubmit={handleEditSource}
+              onCancel={() => {
+                setEditingSource(null);
+                setEditError(null);
+              }}
+              submitLabel="저장"
+              submitting={saving}
+              error={editError}
+            />
           </CardContent>
         </Card>
       )}

--- a/packages/web/src/app/(admin)/admin/curation/source-form.tsx
+++ b/packages/web/src/app/(admin)/admin/curation/source-form.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { INTEREST_OPTIONS } from '@blog-study/shared/config';
+
+const categoryLabels: Record<string, string> = {
+  conference: '컨퍼런스',
+  article: '아티클',
+};
+
+export interface SourceFormValues {
+  name: string;
+  url: string;
+  category: string;
+  rssUrl: string;
+  tags: string[];
+}
+
+export interface SourceFormProps {
+  initialValues: SourceFormValues;
+  categories: string[];
+  onSubmit: (values: SourceFormValues) => Promise<void>;
+  onCancel: () => void;
+  submitLabel: string;
+  submitting: boolean;
+  error: string | null;
+}
+
+export function SourceForm({
+  initialValues,
+  categories,
+  onSubmit,
+  onCancel,
+  submitLabel,
+  submitting,
+  error,
+}: SourceFormProps) {
+  const [values, setValues] = useState<SourceFormValues>(initialValues);
+
+  const toggleTag = (tag: string) => {
+    setValues((prev) => ({
+      ...prev,
+      tags: prev.tags.includes(tag)
+        ? prev.tags.filter((t) => t !== tag)
+        : [...prev.tags, tag],
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await onSubmit(values);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error && (
+        <div className="bg-destructive/10 text-destructive px-4 py-2 rounded-lg text-sm">
+          {error}
+        </div>
+      )}
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="space-y-2">
+          <Label htmlFor="source-name">이름</Label>
+          <Input
+            id="source-name"
+            value={values.name}
+            onChange={(e) => setValues({ ...values, name: e.target.value })}
+            placeholder="예: GeekNews"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="source-url">URL</Label>
+          <Input
+            id="source-url"
+            type="url"
+            value={values.url}
+            onChange={(e) => setValues({ ...values, url: e.target.value })}
+            placeholder="https://news.hada.io"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="source-category">카테고리</Label>
+          <select
+            id="source-category"
+            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            value={values.category}
+            onChange={(e) => setValues({ ...values, category: e.target.value })}
+          >
+            {categories.map((cat) => (
+              <option key={cat} value={cat}>
+                {categoryLabels[cat] || cat}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="source-rssUrl">RSS URL (선택)</Label>
+        <Input
+          id="source-rssUrl"
+          type="url"
+          value={values.rssUrl}
+          onChange={(e) => setValues({ ...values, rssUrl: e.target.value })}
+          placeholder="비워두면 자동 감지를 시도합니다"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label>
+          관심 태그 (선택)
+          {values.tags.length > 0 && (
+            <span className="text-xs text-muted-foreground ml-2">
+              {values.tags.length}개 선택
+            </span>
+          )}
+        </Label>
+        <div className="flex flex-wrap gap-1.5">
+          {INTEREST_OPTIONS.map((tag) => {
+            const isSelected = values.tags.includes(tag);
+            return (
+              <Badge
+                key={tag}
+                variant={isSelected ? 'default' : 'outline'}
+                className="cursor-pointer transition-colors text-xs"
+                onClick={() => toggleTag(tag)}
+              >
+                {tag}
+              </Badge>
+            );
+          })}
+        </div>
+      </div>
+      <div className="flex gap-2">
+        <Button type="submit" disabled={submitting}>
+          {submitting ? '저장 중...' : submitLabel}
+        </Button>
+        <Button type="button" variant="outline" onClick={onCancel}>
+          취소
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/packages/web/src/app/(admin)/admin/curation/sources-table.tsx
+++ b/packages/web/src/app/(admin)/admin/curation/sources-table.tsx
@@ -1,0 +1,271 @@
+'use client';
+
+import {
+  ExternalLink,
+  ToggleLeft,
+  ToggleRight,
+  Pencil,
+  Trash2,
+} from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { TagList } from '@/components/ui/tag-list';
+
+const categoryLabels: Record<string, string> = {
+  conference: '컨퍼런스',
+  article: '아티클',
+};
+
+export interface CurationSource {
+  id: string;
+  url: string;
+  name: string;
+  category: string;
+  rssUrl: string | null;
+  tags: string[] | null;
+  isActive: boolean;
+  createdAt: string;
+  itemCount: number;
+}
+
+export interface SourcesTableProps {
+  sources: CurationSource[];
+  onToggleActive: (source: CurationSource) => void;
+  onEdit: (source: CurationSource) => void;
+  onDelete: (source: CurationSource) => void;
+  updatingId: string | null;
+  searchQuery: string;
+}
+
+export function SourcesTable({
+  sources,
+  onToggleActive,
+  onEdit,
+  onDelete,
+  updatingId,
+  searchQuery,
+}: SourcesTableProps) {
+  const emptyMessage = searchQuery ? '검색 결과가 없습니다.' : '등록된 소스가 없습니다.';
+
+  return (
+    <>
+      {/* Desktop Table (md+) */}
+      <div className="hidden md:block overflow-x-auto">
+        <Table className="min-w-[800px]">
+          <TableHeader>
+            <TableRow>
+              <TableHead>이름</TableHead>
+              <TableHead>URL</TableHead>
+              <TableHead className="whitespace-nowrap">카테고리</TableHead>
+              <TableHead>태그</TableHead>
+              <TableHead className="text-center whitespace-nowrap">아이템</TableHead>
+              <TableHead className="text-center whitespace-nowrap">상태</TableHead>
+              <TableHead className="whitespace-nowrap">등록일</TableHead>
+              <TableHead className="w-[120px] whitespace-nowrap">작업</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {sources.length > 0 ? (
+              sources.map((source) => (
+                <TableRow key={source.id}>
+                  <TableCell>
+                    <div>
+                      <span className="font-medium">{source.name}</span>
+                      {source.rssUrl && (
+                        <span
+                          className="ml-1.5 text-xs text-muted-foreground"
+                          title={source.rssUrl}
+                        >
+                          RSS
+                        </span>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <a
+                      href={source.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-1 text-primary hover:underline text-sm"
+                    >
+                      {source.url.length > 40
+                        ? source.url.substring(0, 40) + '...'
+                        : source.url}
+                      <ExternalLink className="h-3 w-3 shrink-0" />
+                    </a>
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap">
+                    <Badge variant="outline">
+                      {categoryLabels[source.category] || source.category}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    {source.tags && source.tags.length > 0 ? (
+                      <div className="max-w-[160px]">
+                        <TagList tags={source.tags} limit={3} />
+                      </div>
+                    ) : (
+                      <span className="text-xs text-muted-foreground">-</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-center whitespace-nowrap">
+                    {source.itemCount}
+                  </TableCell>
+                  <TableCell className="text-center whitespace-nowrap">
+                    <Badge variant={source.isActive ? 'default' : 'secondary'}>
+                      {source.isActive ? '활성' : '비활성'}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-sm whitespace-nowrap">
+                    {new Date(source.createdAt).toLocaleDateString('ko-KR')}
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap">
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onToggleActive(source)}
+                        disabled={updatingId === source.id}
+                        title={source.isActive ? '비활성화' : '활성화'}
+                      >
+                        {source.isActive ? (
+                          <ToggleRight className="h-4 w-4 text-success" />
+                        ) : (
+                          <ToggleLeft className="h-4 w-4 text-muted-foreground" />
+                        )}
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onEdit(source)}
+                        disabled={updatingId === source.id}
+                        title="수정"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onDelete(source)}
+                        disabled={updatingId === source.id}
+                        title="삭제"
+                      >
+                        <Trash2 className="h-4 w-4 text-destructive" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={8} className="text-center py-8 text-muted-foreground">
+                  {emptyMessage}
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Mobile Cards (< md) */}
+      <div className="md:hidden space-y-3">
+        {sources.length > 0 ? (
+          sources.map((source) => (
+            <div key={source.id} className="rounded-lg border bg-card p-4 space-y-3">
+              {/* Name + status row */}
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <div className="font-medium truncate">{source.name}</div>
+                  {source.rssUrl && (
+                    <span className="text-xs text-muted-foreground">RSS</span>
+                  )}
+                </div>
+                <Badge
+                  variant={source.isActive ? 'default' : 'secondary'}
+                  className="shrink-0"
+                >
+                  {source.isActive ? '활성' : '비활성'}
+                </Badge>
+              </div>
+
+              {/* URL */}
+              <a
+                href={source.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 text-primary hover:underline text-sm break-all"
+              >
+                <span className="truncate">{source.url}</span>
+                <ExternalLink className="h-3 w-3 shrink-0" />
+              </a>
+
+              {/* Category + item count */}
+              <div className="flex items-center gap-2 text-sm">
+                <Badge variant="outline">
+                  {categoryLabels[source.category] || source.category}
+                </Badge>
+                <span className="text-muted-foreground text-xs">아이템 {source.itemCount}개</span>
+                <span className="text-muted-foreground text-xs ml-auto">
+                  {new Date(source.createdAt).toLocaleDateString('ko-KR')}
+                </span>
+              </div>
+
+              {/* Tags */}
+              {source.tags && source.tags.length > 0 && (
+                <TagList tags={source.tags} />
+              )}
+
+              {/* Actions */}
+              <div className="flex items-center gap-1 pt-1 border-t">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onToggleActive(source)}
+                  disabled={updatingId === source.id}
+                >
+                  {source.isActive ? (
+                    <ToggleRight className="h-4 w-4 text-success" />
+                  ) : (
+                    <ToggleLeft className="h-4 w-4 text-muted-foreground" />
+                  )}
+                  <span className="ml-1 text-xs">
+                    {source.isActive ? '비활성화' : '활성화'}
+                  </span>
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onEdit(source)}
+                  disabled={updatingId === source.id}
+                >
+                  <Pencil className="h-4 w-4" />
+                  <span className="ml-1 text-xs">수정</span>
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onDelete(source)}
+                  disabled={updatingId === source.id}
+                  className="ml-auto"
+                >
+                  <Trash2 className="h-4 w-4 text-destructive" />
+                  <span className="ml-1 text-xs text-destructive">삭제</span>
+                </Button>
+              </div>
+            </div>
+          ))
+        ) : (
+          <div className="text-center py-8 text-muted-foreground">{emptyMessage}</div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/packages/web/src/app/(admin)/admin/fines/page.tsx
+++ b/packages/web/src/app/(admin)/admin/fines/page.tsx
@@ -21,6 +21,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { PageLoading, PageError } from '@/components/ui/page-state';
 
 interface Fine {
   id: string;
@@ -156,21 +157,8 @@ export default function AdminFinesPage() {
     }
   };
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-muted-foreground">로딩 중...</div>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-destructive">{error}</div>
-      </div>
-    );
-  }
+  if (loading) return <PageLoading />;
+  if (error) return <PageError message={error} />;
 
   // Filter fines
   const filteredFines = data?.fines.filter((fine) => {
@@ -192,15 +180,17 @@ export default function AdminFinesPage() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">벌금 관리</h1>
-        <p className="text-muted-foreground">
-          벌금 현황을 확인하고 납부/면제 처리를 하세요.
-        </p>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">벌금 관리</h1>
+          <p className="text-muted-foreground">
+            벌금 현황을 확인하고 납부/면제 처리를 하세요.
+          </p>
+        </div>
       </div>
 
       {/* Summary Cards */}
-      <div className="grid gap-4 md:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4">
         <Card
           className={`cursor-pointer transition-colors ${statusFilter === 'all' ? 'border-primary' : ''}`}
           onClick={() => setStatusFilter('all')}
@@ -308,7 +298,7 @@ export default function AdminFinesPage() {
       {/* Fines Table */}
       <Card>
         <CardHeader>
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <CardTitle>벌금 목록</CardTitle>
               <CardDescription>
@@ -316,11 +306,11 @@ export default function AdminFinesPage() {
               </CardDescription>
             </div>
             <div className="flex items-center gap-2">
-              <div className="relative">
+              <div className="relative w-full sm:w-auto">
                 <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
                 <Input
                   placeholder="검색..."
-                  className="pl-8 w-[200px]"
+                  className="pl-8 w-full sm:w-[200px]"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                 />
@@ -329,90 +319,157 @@ export default function AdminFinesPage() {
           </div>
         </CardHeader>
         <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>멤버</TableHead>
-                <TableHead>회차</TableHead>
-                <TableHead>유형</TableHead>
-                <TableHead className="text-right">금액</TableHead>
-                <TableHead>상태</TableHead>
-                <TableHead>생성일</TableHead>
-                <TableHead className="w-[150px]">작업</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {filteredFines.length > 0 ? (
-                filteredFines.map((fine) => (
-                  <TableRow key={fine.id}>
-                    <TableCell>
-                      <div>
-                        <div className="font-medium">{fine.memberName}</div>
-                        <div className="text-xs text-muted-foreground">
-                          {fine.memberPart}
+          {/* Mobile card list */}
+          <div className="md:hidden space-y-3">
+            {filteredFines.length > 0 ? (
+              filteredFines.map((fine) => (
+                <div key={fine.id} className="border rounded-lg p-3 space-y-2">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="font-medium truncate">{fine.memberName}</p>
+                      <p className="text-xs text-muted-foreground">{fine.memberPart}</p>
+                    </div>
+                    <Badge variant={statusConfig[fine.status]?.variant || 'secondary'} className="shrink-0">
+                      {statusConfig[fine.status]?.label || fine.status}
+                    </Badge>
+                  </div>
+                  <div className="flex items-center gap-2 flex-wrap text-xs text-muted-foreground">
+                    <span>{fine.roundNumber}회차</span>
+                    <span>·</span>
+                    <span className={typeConfig[fine.type]?.color || ''}>
+                      {typeConfig[fine.type]?.label || fine.type}
+                    </span>
+                    <span>·</span>
+                    <span className="font-medium text-foreground">{fine.amount.toLocaleString()}원</span>
+                    <span>·</span>
+                    <span>{new Date(fine.createdAt).toLocaleDateString('ko-KR')}</span>
+                  </div>
+                  {fine.status === 'unpaid' && (
+                    <div className="flex items-center gap-2 pt-1">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleMarkPaid(fine.id)}
+                        disabled={updatingId === fine.id}
+                      >
+                        <CheckCircle className="h-3 w-3 mr-1" />
+                        납부
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleWaive(fine.id)}
+                        disabled={updatingId === fine.id}
+                      >
+                        <XCircle className="h-3 w-3 mr-1" />
+                        면제
+                      </Button>
+                    </div>
+                  )}
+                  {fine.status === 'paid' && fine.paidAt && (
+                    <p className="text-xs text-muted-foreground pt-1">
+                      {new Date(fine.paidAt).toLocaleDateString('ko-KR')} 납부
+                    </p>
+                  )}
+                  {fine.status === 'waived' && (
+                    <p className="text-xs text-muted-foreground pt-1">면제됨</p>
+                  )}
+                </div>
+              ))
+            ) : (
+              <div className="text-center py-8 text-muted-foreground">
+                {searchQuery ? '검색 결과가 없습니다.' : '등록된 벌금이 없습니다.'}
+              </div>
+            )}
+          </div>
+
+          {/* Desktop table */}
+          <div className="hidden md:block overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>멤버</TableHead>
+                  <TableHead className="whitespace-nowrap">회차</TableHead>
+                  <TableHead>유형</TableHead>
+                  <TableHead className="text-right whitespace-nowrap">금액</TableHead>
+                  <TableHead>상태</TableHead>
+                  <TableHead className="whitespace-nowrap">생성일</TableHead>
+                  <TableHead className="w-[150px]">작업</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredFines.length > 0 ? (
+                  filteredFines.map((fine) => (
+                    <TableRow key={fine.id}>
+                      <TableCell>
+                        <div>
+                          <div className="font-medium whitespace-nowrap">{fine.memberName}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {fine.memberPart}
+                          </div>
                         </div>
-                      </div>
-                    </TableCell>
-                    <TableCell>{fine.roundNumber}회차</TableCell>
-                    <TableCell>
-                      <span className={typeConfig[fine.type]?.color || ''}>
-                        {typeConfig[fine.type]?.label || fine.type}
-                      </span>
-                    </TableCell>
-                    <TableCell className="text-right font-medium">
-                      {fine.amount.toLocaleString()}원
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant={statusConfig[fine.status]?.variant || 'secondary'}>
-                        {statusConfig[fine.status]?.label || fine.status}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-muted-foreground text-sm">
-                      {new Date(fine.createdAt).toLocaleDateString('ko-KR')}
-                    </TableCell>
-                    <TableCell>
-                      {fine.status === 'unpaid' && (
-                        <div className="flex items-center gap-1">
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => handleMarkPaid(fine.id)}
-                            disabled={updatingId === fine.id}
-                          >
-                            <CheckCircle className="h-3 w-3 mr-1" />
-                            납부
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => handleWaive(fine.id)}
-                            disabled={updatingId === fine.id}
-                          >
-                            <XCircle className="h-3 w-3 mr-1" />
-                            면제
-                          </Button>
-                        </div>
-                      )}
-                      {fine.status === 'paid' && fine.paidAt && (
-                        <span className="text-xs text-muted-foreground">
-                          {new Date(fine.paidAt).toLocaleDateString('ko-KR')} 납부
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">{fine.roundNumber}회차</TableCell>
+                      <TableCell>
+                        <span className={typeConfig[fine.type]?.color || ''}>
+                          {typeConfig[fine.type]?.label || fine.type}
                         </span>
-                      )}
-                      {fine.status === 'waived' && (
-                        <span className="text-xs text-muted-foreground">면제됨</span>
-                      )}
+                      </TableCell>
+                      <TableCell className="text-right font-medium whitespace-nowrap">
+                        {fine.amount.toLocaleString()}원
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        <Badge variant={statusConfig[fine.status]?.variant || 'secondary'}>
+                          {statusConfig[fine.status]?.label || fine.status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground text-sm whitespace-nowrap">
+                        {new Date(fine.createdAt).toLocaleDateString('ko-KR')}
+                      </TableCell>
+                      <TableCell>
+                        {fine.status === 'unpaid' && (
+                          <div className="flex items-center gap-1">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => handleMarkPaid(fine.id)}
+                              disabled={updatingId === fine.id}
+                            >
+                              <CheckCircle className="h-3 w-3 mr-1" />
+                              납부
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleWaive(fine.id)}
+                              disabled={updatingId === fine.id}
+                            >
+                              <XCircle className="h-3 w-3 mr-1" />
+                              면제
+                            </Button>
+                          </div>
+                        )}
+                        {fine.status === 'paid' && fine.paidAt && (
+                          <span className="text-xs text-muted-foreground whitespace-nowrap">
+                            {new Date(fine.paidAt).toLocaleDateString('ko-KR')} 납부
+                          </span>
+                        )}
+                        {fine.status === 'waived' && (
+                          <span className="text-xs text-muted-foreground">면제됨</span>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell colSpan={7} className="text-center py-8 text-muted-foreground">
+                      {searchQuery ? '검색 결과가 없습니다.' : '등록된 벌금이 없습니다.'}
                     </TableCell>
                   </TableRow>
-                ))
-              ) : (
-                <TableRow>
-                  <TableCell colSpan={7} className="text-center py-8 text-muted-foreground">
-                    {searchQuery ? '검색 결과가 없습니다.' : '등록된 벌금이 없습니다.'}
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
+                )}
+              </TableBody>
+            </Table>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/packages/web/src/app/(admin)/admin/members/page.tsx
+++ b/packages/web/src/app/(admin)/admin/members/page.tsx
@@ -23,9 +23,11 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { getPartStyle, getPartLabel } from '@/lib/part-config';
 import { MemberFormDialog } from './member-form-dialog';
 import { DeleteMemberDialog } from './delete-member-dialog';
+import { PageLoading, PageError } from '@/components/ui/page-state';
+import { PartBadge } from '@/components/ui/part-badge';
+import { MEMBER_STATUS_CONFIG } from '@/lib/member-config';
 
 interface AttendanceStats {
   total: number;
@@ -71,11 +73,6 @@ interface MembersData {
   counts: MemberCounts;
 }
 
-const statusConfig: Record<string, { label: string; variant: 'default' | 'secondary' | 'destructive' | 'outline' }> = {
-  active: { label: '활성', variant: 'default' },
-  dormant: { label: '휴면', variant: 'secondary' },
-  withdrawn: { label: '탈퇴', variant: 'destructive' },
-};
 
 export default function AdminMembersPage() {
   const [data, setData] = useState<MembersData | null>(null);
@@ -161,39 +158,26 @@ export default function AdminMembersPage() {
     return true;
   }) || [];
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-muted-foreground">로딩 중...</div>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-destructive">{error}</div>
-      </div>
-    );
-  }
+  if (loading) return <PageLoading />;
+  if (error) return <PageError message={error} />;
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">참가자 관리</h1>
           <p className="text-muted-foreground">
             스터디 참가자를 관리하세요.
           </p>
         </div>
-        <Button onClick={handleAddMember}>
+        <Button onClick={handleAddMember} className="self-start sm:self-auto">
           <Plus className="h-4 w-4 mr-2" />
           멤버 추가
         </Button>
       </div>
 
       {/* Stats Cards */}
-      <div className="grid gap-4 md:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4">
         <Card
           className={`cursor-pointer transition-colors ${statusFilter === 'all' ? 'border-primary' : ''}`}
           onClick={() => setStatusFilter('all')}
@@ -247,19 +231,19 @@ export default function AdminMembersPage() {
       {/* Members Table */}
       <Card>
         <CardHeader>
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <CardTitle>멤버 목록</CardTitle>
               <CardDescription>
-                {statusFilter === 'all' ? '전체' : statusConfig[statusFilter]?.label} 멤버 {filteredMembers.length}명
+                {statusFilter === 'all' ? '전체' : MEMBER_STATUS_CONFIG[statusFilter]?.label} 멤버 {filteredMembers.length}명
               </CardDescription>
             </div>
             <div className="flex items-center gap-2">
-              <div className="relative">
+              <div className="relative w-full sm:w-auto">
                 <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
                 <Input
                   placeholder="검색..."
-                  className="pl-8 w-[200px]"
+                  className="pl-8 w-full sm:w-[200px]"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                 />
@@ -268,80 +252,139 @@ export default function AdminMembersPage() {
           </div>
         </CardHeader>
         <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>이름</TableHead>
-                <TableHead>파트</TableHead>
-                <TableHead>Discord</TableHead>
-                <TableHead>블로그</TableHead>
-                <TableHead>상태</TableHead>
-                <TableHead className="text-right">포스트</TableHead>
-                <TableHead className="text-right">출석률</TableHead>
-                <TableHead className="w-[50px]"></TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {filteredMembers.length > 0 ? (
-                filteredMembers.map((member) => (
-                  <TableRow key={member.id}>
-                    <TableCell className="font-medium">{member.name}</TableCell>
-                    <TableCell>
-                      <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${getPartStyle(member.part).bg} ${getPartStyle(member.part).text}`}>
-                        {getPartLabel(member.part)}
-                      </span>
-                    </TableCell>
-                    <TableCell className="text-muted-foreground">
-                      {member.discordUsername}
-                    </TableCell>
-                    <TableCell>
-                      <a
-                        href={member.blogUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex items-center gap-1 text-sm text-primary hover:underline"
-                      >
-                        <ExternalLink className="h-3 w-3" />
-                        블로그
-                      </a>
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant={statusConfig[member.status]?.variant || 'secondary'}>
-                        {statusConfig[member.status]?.label || member.status}
+          {/* Mobile card list */}
+          <div className="md:hidden space-y-3">
+            {filteredMembers.length > 0 ? (
+              filteredMembers.map((member) => (
+                <div key={member.id} className="border rounded-lg p-3 space-y-2">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="font-medium truncate">{member.name}</p>
+                      <p className="text-xs text-muted-foreground">{member.discordUsername}</p>
+                    </div>
+                    <div className="flex items-center gap-1 shrink-0">
+                      <Badge variant={MEMBER_STATUS_CONFIG[member.status]?.variant || 'secondary'}>
+                        {MEMBER_STATUS_CONFIG[member.status]?.label || member.status}
                       </Badge>
-                    </TableCell>
-                    <TableCell className="text-right">{member.postCount}</TableCell>
-                    <TableCell className="text-right">{member.attendanceRate}%</TableCell>
-                    <TableCell>
-                      <div className="flex items-center gap-1">
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => handleEditMember(member)}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <PartBadge part={member.part} />
+                    <span className="text-xs text-muted-foreground">포스트 {member.postCount}개</span>
+                    <span className="text-xs text-muted-foreground">출석률 {member.attendanceRate}%</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <a
+                      href={member.blogUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-1 text-xs text-primary hover:underline"
+                    >
+                      <ExternalLink className="h-3 w-3" />
+                      블로그
+                    </a>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => handleEditMember(member)}
+                      >
+                        <Edit className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => handleDeleteMember(member)}
+                        disabled={member.status === 'withdrawn'}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              ))
+            ) : (
+              <div className="text-center py-8 text-muted-foreground">
+                {searchQuery ? '검색 결과가 없습니다.' : '등록된 멤버가 없습니다.'}
+              </div>
+            )}
+          </div>
+
+          {/* Desktop table */}
+          <div className="hidden md:block overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>이름</TableHead>
+                  <TableHead>파트</TableHead>
+                  <TableHead>Discord</TableHead>
+                  <TableHead>블로그</TableHead>
+                  <TableHead>상태</TableHead>
+                  <TableHead className="text-right">포스트</TableHead>
+                  <TableHead className="text-right">출석률</TableHead>
+                  <TableHead className="w-[50px]"></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredMembers.length > 0 ? (
+                  filteredMembers.map((member) => (
+                    <TableRow key={member.id}>
+                      <TableCell className="font-medium whitespace-nowrap">{member.name}</TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        <PartBadge part={member.part} />
+                      </TableCell>
+                      <TableCell className="text-muted-foreground whitespace-nowrap">
+                        {member.discordUsername}
+                      </TableCell>
+                      <TableCell>
+                        <a
+                          href={member.blogUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center gap-1 text-sm text-primary hover:underline"
                         >
-                          <Edit className="h-4 w-4" />
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => handleDeleteMember(member)}
-                          disabled={member.status === 'withdrawn'}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
+                          <ExternalLink className="h-3 w-3" />
+                          블로그
+                        </a>
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        <Badge variant={MEMBER_STATUS_CONFIG[member.status]?.variant || 'secondary'}>
+                          {MEMBER_STATUS_CONFIG[member.status]?.label || member.status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right">{member.postCount}</TableCell>
+                      <TableCell className="text-right whitespace-nowrap">{member.attendanceRate}%</TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-1">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => handleEditMember(member)}
+                          >
+                            <Edit className="h-4 w-4" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => handleDeleteMember(member)}
+                            disabled={member.status === 'withdrawn'}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell colSpan={8} className="text-center py-8 text-muted-foreground">
+                      {searchQuery ? '검색 결과가 없습니다.' : '등록된 멤버가 없습니다.'}
                     </TableCell>
                   </TableRow>
-                ))
-              ) : (
-                <TableRow>
-                  <TableCell colSpan={8} className="text-center py-8 text-muted-foreground">
-                    {searchQuery ? '검색 결과가 없습니다.' : '등록된 멤버가 없습니다.'}
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
+                )}
+              </TableBody>
+            </Table>
+          </div>
         </CardContent>
       </Card>
 

--- a/packages/web/src/app/(admin)/admin/page.tsx
+++ b/packages/web/src/app/(admin)/admin/page.tsx
@@ -17,6 +17,7 @@ import {
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { PageLoading, PageError } from '@/components/ui/page-state';
 
 interface RoundInfo {
   id: number;
@@ -114,21 +115,8 @@ export default function AdminDashboardPage() {
     fetchDashboard();
   }, []);
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-muted-foreground">로딩 중...</div>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-destructive">{error}</div>
-      </div>
-    );
-  }
+  if (loading) return <PageLoading />;
+  if (error) return <PageError message={error} />;
 
   return (
     <div className="space-y-6">
@@ -154,7 +142,7 @@ export default function AdminDashboardPage() {
             </div>
           </CardHeader>
           <CardContent className="px-4 pb-4">
-            <div className="grid gap-4 md:grid-cols-4">
+            <div className="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4">
               <div>
                 <p className="text-xs text-muted-foreground mb-0.5">회차</p>
                 <p className="text-2xl font-bold">{data.currentRound.roundNumber}회차</p>
@@ -187,7 +175,7 @@ export default function AdminDashboardPage() {
       )}
 
       {/* Stats Cards */}
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-2 lg:grid-cols-4 md:gap-4">
         <Card className="shadow-none border-border/60">
           <CardContent className="p-4">
             <div className="flex items-start justify-between mb-3">

--- a/packages/web/src/app/(admin)/admin/settings/page.tsx
+++ b/packages/web/src/app/(admin)/admin/settings/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { PageLoading } from '@/components/ui/page-state';
 
 interface StudySettings {
   studyStartDate: string | null;
@@ -107,24 +108,18 @@ export default function AdminSettingsPage() {
     }
   };
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-muted-foreground">로딩 중...</div>
-      </div>
-    );
-  }
+  if (loading) return <PageLoading />;
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">스터디 설정</h1>
           <p className="text-muted-foreground">
             스터디 운영에 필요한 설정을 관리하세요.
           </p>
         </div>
-        <Button onClick={handleSave} disabled={saving}>
+        <Button onClick={handleSave} disabled={saving} className="self-start sm:self-auto">
           {saving ? (
             <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
           ) : (
@@ -156,7 +151,7 @@ export default function AdminSettingsPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="grid gap-4 md:grid-cols-4">
+            <div className="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4">
               <div>
                 <p className="text-sm text-muted-foreground">회차</p>
                 <p className="text-xl font-bold">{data.currentRound.roundNumber}회차</p>

--- a/packages/web/src/app/(user)/curation/page.tsx
+++ b/packages/web/src/app/(user)/curation/page.tsx
@@ -5,6 +5,8 @@ import { ExternalLink, Calendar, Sparkles, X, ChevronLeft, ChevronRight } from '
 import { INTEREST_OPTIONS } from '@blog-study/shared/config';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { PageError } from '@/components/ui/page-state';
+import { TagList } from '@/components/ui/tag-list';
 
 interface CurationItem {
   id: string;
@@ -120,11 +122,7 @@ export default function CurationPage() {
   };
 
   if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-destructive text-sm">{error}</div>
-      </div>
-    );
+    return <PageError message={error} />;
   }
 
   return (
@@ -134,7 +132,7 @@ export default function CurationPage() {
         <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
           Curation
         </p>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-2">
           <h1 className="text-xl font-semibold text-foreground">큐레이션</h1>
           <span className="text-sm text-muted-foreground">
             {data?.totalCount ?? 0}개의 콘텐츠
@@ -143,7 +141,7 @@ export default function CurationPage() {
       </div>
 
       {/* Category Filter Pills */}
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2">
         {FILTERS.map(({ value, label, emoji }) => (
           <button
             key={value}
@@ -257,21 +255,7 @@ export default function CurationPage() {
 
                 {/* Tags */}
                 {item.tags && item.tags.length > 0 && (
-                  <div className="flex flex-wrap gap-1">
-                    {item.tags.slice(0, 4).map((tag) => (
-                      <span
-                        key={tag}
-                        className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium bg-primary/10 text-primary"
-                      >
-                        {tag}
-                      </span>
-                    ))}
-                    {item.tags.length > 4 && (
-                      <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium bg-muted text-muted-foreground">
-                        +{item.tags.length - 4}
-                      </span>
-                    )}
-                  </div>
+                  <TagList tags={item.tags} />
                 )}
 
                 {/* Footer: source + date + link icon */}
@@ -328,7 +312,7 @@ export default function CurationPage() {
         const pages = Array.from({ length: end - start + 1 }, (_, i) => start + i);
 
         return (
-          <div className="flex items-center justify-center gap-1 pt-2">
+          <div className="flex flex-wrap items-center justify-center gap-1 pt-2">
             <Button
               variant="ghost"
               size="icon"

--- a/packages/web/src/app/(user)/dashboard/page.tsx
+++ b/packages/web/src/app/(user)/dashboard/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { Calendar, FileText, Clock, TrendingUp, ArrowUpRight, Inbox } from 'lucide-react';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { PageLoading, PageError } from '@/components/ui/page-state';
 
 interface RoundInfo {
   roundNumber: number;
@@ -66,19 +67,11 @@ export default function DashboardPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-sm text-muted-foreground">로딩 중...</div>
-      </div>
-    );
+    return <PageLoading />;
   }
 
   if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-sm text-destructive">{error}</div>
-      </div>
-    );
+    return <PageError message={error} />;
   }
 
   return (
@@ -92,23 +85,23 @@ export default function DashboardPage() {
       </div>
 
       {/* Stat Cards */}
-      <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-3 grid-cols-2 lg:grid-cols-4">
         {/* 현재 회차 */}
         <Card className="border-border/60 shadow-none">
           <CardContent className="p-4">
-            <div className="flex items-start justify-between">
-              <div className="space-y-2">
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0 space-y-2">
                 <p className="text-xs text-muted-foreground">현재 회차</p>
                 <p className="text-2xl font-bold tracking-tight">
                   {data?.currentRound ? `${data.currentRound.roundNumber}회차` : '-'}
                 </p>
                 {data?.currentRound && (
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-xs text-muted-foreground truncate">
                     {data.currentRound.startDate} ~ {data.currentRound.endDate}
                   </p>
                 )}
               </div>
-              <div className="rounded-lg bg-primary/10 p-2 text-primary">
+              <div className="shrink-0 rounded-lg bg-primary/10 p-2 text-primary">
                 <Calendar className="h-4 w-4" />
               </div>
             </div>
@@ -118,8 +111,8 @@ export default function DashboardPage() {
         {/* 마감까지 */}
         <Card className="border-border/60 shadow-none">
           <CardContent className="p-4">
-            <div className="flex items-start justify-between">
-              <div className="space-y-2">
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0 space-y-2">
                 <p className="text-xs text-muted-foreground">마감까지</p>
                 <p className="text-2xl font-bold tracking-tight">
                   {data?.currentRound ? (
@@ -133,12 +126,12 @@ export default function DashboardPage() {
                   )}
                 </p>
                 {data?.currentRound?.isGracePeriod && (
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-xs text-muted-foreground truncate">
                     지각 마감: {data.currentRound.graceEndDate}
                   </p>
                 )}
               </div>
-              <div className="rounded-lg bg-primary/10 p-2 text-primary">
+              <div className="shrink-0 rounded-lg bg-primary/10 p-2 text-primary">
                 <Clock className="h-4 w-4" />
               </div>
             </div>
@@ -148,15 +141,15 @@ export default function DashboardPage() {
         {/* 총 참가자 */}
         <Card className="border-border/60 shadow-none">
           <CardContent className="p-4">
-            <div className="flex items-start justify-between">
-              <div className="space-y-2">
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0 space-y-2">
                 <p className="text-xs text-muted-foreground">총 참가자</p>
                 <p className="text-2xl font-bold tracking-tight">
                   {data?.totalMembers ?? 0}명
                 </p>
                 <p className="text-xs text-muted-foreground">활성 스터디원</p>
               </div>
-              <div className="rounded-lg bg-primary/10 p-2 text-primary">
+              <div className="shrink-0 rounded-lg bg-primary/10 p-2 text-primary">
                 <TrendingUp className="h-4 w-4" />
               </div>
             </div>
@@ -166,15 +159,15 @@ export default function DashboardPage() {
         {/* 총 포스트 */}
         <Card className="border-border/60 shadow-none">
           <CardContent className="p-4">
-            <div className="flex items-start justify-between">
-              <div className="space-y-2">
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0 space-y-2">
                 <p className="text-xs text-muted-foreground">총 포스트</p>
                 <p className="text-2xl font-bold tracking-tight">
                   {data?.totalPosts ?? 0}개
                 </p>
                 <p className="text-xs text-muted-foreground">누적 작성 글</p>
               </div>
-              <div className="rounded-lg bg-primary/10 p-2 text-primary">
+              <div className="shrink-0 rounded-lg bg-primary/10 p-2 text-primary">
                 <FileText className="h-4 w-4" />
               </div>
             </div>

--- a/packages/web/src/app/(user)/members/[id]/page.tsx
+++ b/packages/web/src/app/(user)/members/[id]/page.tsx
@@ -8,8 +8,9 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Separator } from '@/components/ui/separator';
-import { getPartStyle, getPartLabel } from '@/lib/part-config';
 import { getDefaultAvatar } from '@/lib/utils';
+import { PageLoading, PageError } from '@/components/ui/page-state';
+import { PartBadge } from '@/components/ui/part-badge';
 
 interface MemberInfo {
   id: string;
@@ -89,11 +90,7 @@ export default function MemberProfilePage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-muted-foreground">로딩 중...</div>
-      </div>
-    );
+    return <PageLoading />;
   }
 
   if (error || !data) {
@@ -102,9 +99,7 @@ export default function MemberProfilePage() {
         <Button variant="ghost" size="icon" onClick={() => router.back()}>
           <ArrowLeft className="h-5 w-5" />
         </Button>
-        <div className="flex items-center justify-center min-h-[300px]">
-          <div className="text-destructive">{error || '데이터를 불러올 수 없습니다.'}</div>
-        </div>
+        <PageError message={error || '데이터를 불러올 수 없습니다.'} />
       </div>
     );
   }
@@ -120,13 +115,13 @@ export default function MemberProfilePage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-4">
-        <Button variant="ghost" size="icon" onClick={() => router.back()}>
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="icon" className="shrink-0" onClick={() => router.back()}>
           <ArrowLeft className="h-5 w-5" />
         </Button>
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">{member.nickname}</h1>
-          <p className="text-muted-foreground">스터디원 프로필</p>
+        <div className="min-w-0">
+          <h1 className="text-2xl sm:text-3xl font-bold tracking-tight truncate">{member.nickname}</h1>
+          <p className="text-muted-foreground text-sm">스터디원 프로필</p>
         </div>
       </div>
 
@@ -142,22 +137,20 @@ export default function MemberProfilePage() {
           </div>
         </CardHeader>
         <CardContent className="space-y-6">
-          <div className="flex items-start gap-6">
-            <Avatar className="h-24 w-24">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-6">
+            <Avatar className="h-20 w-20 sm:h-24 sm:w-24 shrink-0">
               <AvatarImage src={member.profileImageUrl || getDefaultAvatar(member.nickname)} />
               <AvatarFallback className="text-2xl">
                 {member.nickname.slice(0, 2).toUpperCase()}
               </AvatarFallback>
             </Avatar>
-            <div className="flex-1 space-y-2">
+            <div className="flex-1 space-y-2 min-w-0">
               <div>
-                <p className="text-2xl font-semibold">{member.nickname}</p>
+                <p className="text-xl sm:text-2xl font-semibold">{member.nickname}</p>
                 <p className="text-sm text-muted-foreground">{member.name}</p>
-                <p className="text-muted-foreground">@{member.discordUsername.replace(/#0$/, '')}</p>
+                <p className="text-muted-foreground text-sm">@{member.discordUsername.replace(/#0$/, '')}</p>
               </div>
-              <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${getPartStyle(member.part).bg} ${getPartStyle(member.part).text}`}>
-                {getPartLabel(member.part)}
-              </span>
+              <PartBadge part={member.part} />
             </div>
           </div>
 
@@ -238,19 +231,19 @@ export default function MemberProfilePage() {
               {recentPosts.map((post) => (
                 <div
                   key={post.id}
-                  className="flex items-start justify-between border-b pb-4 last:border-0 last:pb-0"
+                  className="flex flex-col gap-0.5 border-b pb-4 last:border-0 last:pb-0 sm:flex-row sm:items-start sm:justify-between"
                 >
-                  <div className="space-y-1">
+                  <div className="space-y-1 min-w-0 flex-1">
                     <a
                       href={post.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="font-medium hover:underline flex items-center gap-1"
+                      className="font-medium hover:underline flex items-start gap-1 text-sm leading-snug"
                     >
-                      {post.title}
-                      <ExternalLink className="h-3 w-3" />
+                      <span className="line-clamp-2">{post.title}</span>
+                      <ExternalLink className="h-3 w-3 shrink-0 mt-0.5" />
                     </a>
-                    <p className="text-sm text-muted-foreground">
+                    <p className="text-sm text-muted-foreground whitespace-nowrap">
                       {new Date(post.publishedAt).toLocaleDateString('ko-KR')}
                     </p>
                   </div>

--- a/packages/web/src/app/(user)/members/page.tsx
+++ b/packages/web/src/app/(user)/members/page.tsx
@@ -6,8 +6,10 @@ import { UsersRound, ExternalLink, Github, Linkedin, Instagram } from 'lucide-re
 import { Card, CardContent } from '@/components/ui/card';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
-import { PART_OPTIONS, getPartStyle, getPartLabel } from '@/lib/part-config';
+import { PART_OPTIONS } from '@/lib/part-config';
 import { getDefaultAvatar } from '@/lib/utils';
+import { PageLoading, PageError } from '@/components/ui/page-state';
+import { PartBadge } from '@/components/ui/part-badge';
 
 interface Member {
   id: string;
@@ -59,19 +61,11 @@ export default function MembersPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-sm text-muted-foreground">로딩 중...</div>
-      </div>
-    );
+    return <PageLoading />;
   }
 
   if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-sm text-destructive">{error}</div>
-      </div>
-    );
+    return <PageError message={error} />;
   }
 
   return (
@@ -81,7 +75,7 @@ export default function MembersPage() {
         <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
           Members
         </p>
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
           <h1 className="text-xl font-semibold tracking-tight">스터디원 목록</h1>
           <span className="text-sm text-muted-foreground">
             {filterPart
@@ -130,8 +124,6 @@ export default function MembersPage() {
       {data?.members && data.members.length > 0 ? (
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {data.members.filter((m) => !filterPart || m.part === filterPart).map((member) => {
-            const partStyle = getPartStyle(member.part);
-
             const socialLinks = [
               { url: member.blogUrl, icon: ExternalLink, label: '블로그' },
               { url: member.githubUrl, icon: Github, label: 'GitHub' },
@@ -159,11 +151,7 @@ export default function MembersPage() {
                           <p className="text-xs text-muted-foreground truncate">
                             @{member.discordUsername.replace(/#0$/, '')}
                           </p>
-                          <span
-                            className={`shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${partStyle.bg} ${partStyle.text}`}
-                          >
-                            {getPartLabel(member.part)}
-                          </span>
+                          <PartBadge part={member.part} size="sm" />
                         </div>
                       </div>
                     </div>
@@ -181,17 +169,17 @@ export default function MembersPage() {
                         {socialLinks.map((link) => {
                           const Icon = link.icon;
                           return (
-                            <span
+                            <a
                               key={link.label}
+                              href={link.url!}
+                              target="_blank"
+                              rel="noopener noreferrer"
                               className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-[10px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-                              onClick={(e) => {
-                                e.preventDefault();
-                                window.open(link.url!, '_blank', 'noopener,noreferrer');
-                              }}
+                              onClick={(e) => e.stopPropagation()}
                             >
                               <Icon className="h-3 w-3" />
                               {link.label}
-                            </span>
+                            </a>
                           );
                         })}
                       </div>

--- a/packages/web/src/app/(user)/members/page.tsx
+++ b/packages/web/src/app/(user)/members/page.tsx
@@ -169,17 +169,27 @@ export default function MembersPage() {
                         {socialLinks.map((link) => {
                           const Icon = link.icon;
                           return (
-                            <a
+                            <span
                               key={link.label}
-                              href={link.url!}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-[10px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-                              onClick={(e) => e.stopPropagation()}
+                              role="link"
+                              tabIndex={0}
+                              className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-[10px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                window.open(link.url!, '_blank', 'noopener,noreferrer');
+                              }}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  window.open(link.url!, '_blank', 'noopener,noreferrer');
+                                }
+                              }}
                             >
                               <Icon className="h-3 w-3" />
                               {link.label}
-                            </a>
+                            </span>
                           );
                         })}
                       </div>

--- a/packages/web/src/app/(user)/posts/page.tsx
+++ b/packages/web/src/app/(user)/posts/page.tsx
@@ -3,9 +3,10 @@
 import { Suspense, useEffect, useState } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { FileText, ExternalLink, ChevronLeft, ChevronRight } from 'lucide-react';
-import { getPartStyle, getPartLabel } from '@/lib/part-config';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { PageLoading, PageError } from '@/components/ui/page-state';
+import { PartBadge } from '@/components/ui/part-badge';
 import {
   Table,
   TableBody,
@@ -71,19 +72,11 @@ function PostsContent() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-sm text-muted-foreground">로딩 중...</div>
-      </div>
-    );
+    return <PageLoading />;
   }
 
   if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-sm text-destructive">{error}</div>
-      </div>
-    );
+    return <PageError message={error} />;
   }
 
   return (
@@ -99,18 +92,51 @@ function PostsContent() {
           </span>
         </div>
       </CardHeader>
-      <CardContent className="px-6 pb-5">
+      <CardContent className="px-4 sm:px-6 pb-5">
         {data?.posts && data.posts.length > 0 ? (
           <>
+            {/* Mobile: compact list */}
+            <div className="md:hidden divide-y divide-border/40">
+              {data.posts.map((post) => (
+                <a
+                  key={post.id}
+                  href={post.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-start gap-3 py-3 group"
+                >
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-foreground group-hover:text-primary transition-colors line-clamp-2 leading-snug">
+                      {post.title}
+                    </p>
+                    <div className="flex items-center gap-1.5 mt-1.5 text-xs text-muted-foreground">
+                      <span>{post.memberNickname || post.memberDiscordUsername}</span>
+                      {post.memberPart && (
+                        <>
+                          <span>·</span>
+                          <PartBadge part={post.memberPart} size="sm" />
+                        </>
+                      )}
+                      <span>·</span>
+                      <span>{new Date(post.publishedAt).toLocaleDateString('ko-KR')}</span>
+                    </div>
+                  </div>
+                  <ExternalLink className="h-4 w-4 text-muted-foreground/40 group-hover:text-primary shrink-0 mt-0.5 transition-colors" />
+                </a>
+              ))}
+            </div>
+
+            {/* Desktop: table */}
+            <div className="hidden md:block overflow-x-auto">
             <Table>
               <TableHeader>
                 <TableRow className="border-border/60">
                   <TableHead className="w-[40%] text-xs font-medium text-muted-foreground h-9">제목</TableHead>
-                  <TableHead className="text-xs font-medium text-muted-foreground h-9">작성자</TableHead>
-                  <TableHead className="text-center text-xs font-medium text-muted-foreground h-9">파트</TableHead>
-                  <TableHead className="text-xs font-medium text-muted-foreground h-9">회차</TableHead>
-                  <TableHead className="text-xs font-medium text-muted-foreground h-9">작성일</TableHead>
-                  <TableHead className="text-right text-xs font-medium text-muted-foreground h-9">링크</TableHead>
+                  <TableHead className="text-xs font-medium text-muted-foreground h-9 whitespace-nowrap">작성자</TableHead>
+                  <TableHead className="text-center text-xs font-medium text-muted-foreground h-9 whitespace-nowrap">파트</TableHead>
+                  <TableHead className="text-xs font-medium text-muted-foreground h-9 whitespace-nowrap">회차</TableHead>
+                  <TableHead className="text-xs font-medium text-muted-foreground h-9 whitespace-nowrap">작성일</TableHead>
+                  <TableHead className="text-right text-xs font-medium text-muted-foreground h-9 whitespace-nowrap">링크</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -126,19 +152,17 @@ function PostsContent() {
                         {post.title}
                       </a>
                     </TableCell>
-                    <TableCell className="text-sm text-foreground/80 py-2.5">
+                    <TableCell className="text-sm text-foreground/80 py-2.5 whitespace-nowrap">
                       {post.memberNickname || post.memberDiscordUsername}
                     </TableCell>
-                    <TableCell className="text-center py-2.5">
+                    <TableCell className="text-center py-2.5 whitespace-nowrap">
                       {post.memberPart ? (
-                        <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${getPartStyle(post.memberPart).bg} ${getPartStyle(post.memberPart).text}`}>
-                          {getPartLabel(post.memberPart)}
-                        </span>
+                        <PartBadge part={post.memberPart} />
                       ) : (
                         <span className="text-xs text-muted-foreground">—</span>
                       )}
                     </TableCell>
-                    <TableCell className="py-2.5">
+                    <TableCell className="py-2.5 whitespace-nowrap">
                       {post.roundNumber ? (
                         <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
                           {post.roundNumber}회차
@@ -147,10 +171,10 @@ function PostsContent() {
                         <span className="text-xs text-muted-foreground">—</span>
                       )}
                     </TableCell>
-                    <TableCell className="text-sm text-muted-foreground py-2.5">
+                    <TableCell className="text-sm text-muted-foreground py-2.5 whitespace-nowrap">
                       {new Date(post.publishedAt).toLocaleDateString('ko-KR')}
                     </TableCell>
-                    <TableCell className="text-right py-2.5">
+                    <TableCell className="text-right py-2.5 whitespace-nowrap">
                       <Button variant="ghost" size="sm" asChild className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground">
                         <a
                           href={post.url}
@@ -165,10 +189,11 @@ function PostsContent() {
                 ))}
               </TableBody>
             </Table>
+            </div>
 
             {/* Pagination */}
             {data.pagination.totalPages > 1 && (
-              <div className="flex items-center justify-center gap-1 mt-6">
+              <div className="flex flex-wrap items-center justify-center gap-1 mt-6">
                 <Button
                   variant="ghost"
                   size="sm"
@@ -240,11 +265,7 @@ export default function PostsPage() {
         </p>
       </div>
 
-      <Suspense fallback={
-        <div className="flex items-center justify-center min-h-[400px]">
-          <div className="text-sm text-muted-foreground">로딩 중...</div>
-        </div>
-      }>
+      <Suspense fallback={<PageLoading />}>
         <PostsContent />
       </Suspense>
     </div>

--- a/packages/web/src/app/(user)/profile/edit/page.tsx
+++ b/packages/web/src/app/(user)/profile/edit/page.tsx
@@ -10,6 +10,7 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { AvatarUpload } from '@/components/avatar-upload';
 import { PART_OPTIONS } from '@/lib/part-config';
+import { PageLoading } from '@/components/ui/page-state';
 
 const INTEREST_OPTIONS = [
   // 개발
@@ -167,22 +168,18 @@ export default function ProfileEditPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-muted-foreground">로딩 중...</div>
-      </div>
-    );
+    return <PageLoading />;
   }
 
   return (
-    <div className="max-w-2xl mx-auto space-y-6">
-      <div className="flex items-center gap-4">
-        <Button variant="ghost" size="icon" onClick={() => router.back()}>
+    <div className="w-full max-w-2xl mx-auto space-y-6">
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="icon" className="shrink-0" onClick={() => router.back()}>
           <ArrowLeft className="h-5 w-5" />
         </Button>
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">프로필 수정</h1>
-          <p className="text-muted-foreground">
+        <div className="min-w-0">
+          <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">프로필 수정</h1>
+          <p className="text-muted-foreground text-sm">
             프로필 정보를 수정하세요.
           </p>
         </div>
@@ -427,7 +424,7 @@ export default function ProfileEditPage() {
         )}
 
         {/* Submit Button */}
-        <div className="flex justify-end gap-4">
+        <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end sm:gap-4">
           <Button type="button" variant="outline" onClick={() => router.back()}>
             취소
           </Button>

--- a/packages/web/src/app/(user)/profile/onboarding/page.tsx
+++ b/packages/web/src/app/(user)/profile/onboarding/page.tsx
@@ -12,6 +12,7 @@ import { AvatarUpload } from '@/components/avatar-upload';
 import { Separator } from '@/components/ui/separator';
 import { PART_OPTIONS } from '@/lib/part-config';
 import { INTEREST_OPTIONS } from '@blog-study/shared/config';
+import { PageLoading } from '@/components/ui/page-state';
 
 const TOTAL_STEPS = 3;
 
@@ -136,11 +137,7 @@ export default function OnboardingPage() {
   const prevStep = () => setStep((prev) => Math.max(prev - 1, 1));
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-      </div>
-    );
+    return <PageLoading />;
   }
 
   return (

--- a/packages/web/src/app/(user)/profile/page.tsx
+++ b/packages/web/src/app/(user)/profile/page.tsx
@@ -8,7 +8,8 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Separator } from '@/components/ui/separator';
-import { getPartStyle, getPartLabel } from '@/lib/part-config';
+import { PageLoading, PageError } from '@/components/ui/page-state';
+import { PartBadge } from '@/components/ui/part-badge';
 
 interface UserInfo {
   id: string;
@@ -95,19 +96,11 @@ export default function ProfilePage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-sm text-muted-foreground">로딩 중...</div>
-      </div>
-    );
+    return <PageLoading />;
   }
 
   if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-sm text-destructive">{error}</div>
-      </div>
-    );
+    return <PageError message={error} />;
   }
 
   return (
@@ -186,19 +179,17 @@ export default function ProfilePage() {
                 </div>
                 <div className="space-y-0.5">
                   <p className="text-xs text-muted-foreground uppercase tracking-wide">파트</p>
-                  <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${getPartStyle(data.member.part).bg} ${getPartStyle(data.member.part).text}`}>
-                    {getPartLabel(data.member.part)}
-                  </span>
+                  <PartBadge part={data.member.part} />
                 </div>
-                <div className="space-y-0.5">
+                <div className="space-y-0.5 min-w-0">
                   <p className="text-xs text-muted-foreground uppercase tracking-wide">블로그</p>
                   <a
                     href={data.member.blogUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+                    className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline max-w-full"
                   >
-                    {data.member.blogUrl}
+                    <span className="truncate">{data.member.blogUrl}</span>
                     <ExternalLink className="h-3 w-3 shrink-0" />
                   </a>
                 </div>
@@ -224,9 +215,9 @@ export default function ProfilePage() {
                 <div className="space-y-2">
                   <p className="text-xs text-muted-foreground uppercase tracking-wide">관심 분야</p>
                   <div className="flex flex-wrap gap-1.5">
-                    {data.member.interests.map((interest, idx) => (
+                    {data.member.interests.map((interest) => (
                       <span
-                        key={idx}
+                        key={interest}
                         className="inline-flex items-center rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground"
                       >
                         {interest}
@@ -249,7 +240,6 @@ export default function ProfilePage() {
                   <p className="text-xs text-muted-foreground uppercase tracking-wide">소셜 링크</p>
                   <div className="flex flex-wrap gap-2">
                     {[
-                      { url: data.member.blogUrl, icon: ExternalLink, label: '블로그' },
                       { url: data.member.githubUrl, icon: Github, label: 'GitHub' },
                       { url: data.member.linkedinUrl, icon: Linkedin, label: 'LinkedIn' },
                       { url: data.member.instagramUrl, icon: Instagram, label: 'Instagram' },
@@ -278,7 +268,7 @@ export default function ProfilePage() {
 
           {/* Stats */}
           {data.stats && (
-            <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-4">
+            <div className="grid gap-3 grid-cols-2 lg:grid-cols-4">
               <Card className="border-border/60 shadow-none">
                 <CardContent className="p-4">
                   <div className="flex items-start justify-between">

--- a/packages/web/src/app/(user)/ranking/page.tsx
+++ b/packages/web/src/app/(user)/ranking/page.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { getDefaultAvatar } from '@/lib/utils';
+import { PageLoading, PageError } from '@/components/ui/page-state';
 import {
   Table,
   TableBody,
@@ -103,19 +104,11 @@ export default function RankingPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-sm text-muted-foreground">로딩 중...</div>
-      </div>
-    );
+    return <PageLoading />;
   }
 
   if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-sm text-destructive">{error}</div>
-      </div>
-    );
+    return <PageError message={error} />;
   }
 
   return (
@@ -131,7 +124,7 @@ export default function RankingPage() {
 
       {/* Top 3 podium cards */}
       {data?.rankings && data.rankings.length >= 3 && (
-        <div className="grid gap-3 md:grid-cols-3">
+        <div className="grid gap-3 grid-cols-1 sm:grid-cols-3">
           {data.rankings.slice(0, 3).map((member, index) => {
             const config = PODIUM_CONFIG[index]!;
             return (
@@ -225,20 +218,21 @@ export default function RankingPage() {
         </CardHeader>
         <CardContent className="px-6 pb-5">
           {data?.rankings && data.rankings.length > 0 ? (
+            <div className="overflow-x-auto">
             <Table>
               <TableHeader>
                 <TableRow className="border-border/60">
-                  <TableHead className="w-[72px] text-xs font-medium text-muted-foreground h-9">순위</TableHead>
+                  <TableHead className="w-[72px] text-xs font-medium text-muted-foreground h-9 whitespace-nowrap">순위</TableHead>
                   <TableHead className="text-xs font-medium text-muted-foreground h-9">스터디원</TableHead>
-                  <TableHead className="text-center text-xs font-medium text-muted-foreground h-9">포스트</TableHead>
-                  <TableHead className="text-center text-xs font-medium text-muted-foreground h-9">출석률</TableHead>
-                  <TableHead className="text-center text-xs font-medium text-muted-foreground h-9">출석 현황</TableHead>
+                  <TableHead className="text-center text-xs font-medium text-muted-foreground h-9 whitespace-nowrap">포스트</TableHead>
+                  <TableHead className="text-center text-xs font-medium text-muted-foreground h-9 whitespace-nowrap">출석률</TableHead>
+                  <TableHead className="text-center text-xs font-medium text-muted-foreground h-9 whitespace-nowrap">출석 현황</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {data.rankings.map((member, index) => (
                   <TableRow key={member.id} className="border-border/40 hover:bg-muted/30">
-                    <TableCell className="py-2.5">
+                    <TableCell className="py-2.5 whitespace-nowrap">
                       <div className="flex items-center justify-center bg-muted rounded-full w-7 h-7">
                         {getRankDisplay(index + 1)}
                       </div>
@@ -248,23 +242,23 @@ export default function RankingPage() {
                         href={`/members/${member.id}`}
                         className="flex items-center gap-2.5 hover:opacity-75 transition-opacity"
                       >
-                        <Avatar className="h-7 w-7 ring-1 ring-border">
+                        <Avatar className="h-7 w-7 ring-1 ring-border shrink-0">
                           <AvatarImage src={member.profileImageUrl || getDefaultAvatar(member.nickname)} />
                           <AvatarFallback className="text-[10px] font-medium">
                             {(member.nickname || member.discordUsername).slice(0, 2).toUpperCase()}
                           </AvatarFallback>
                         </Avatar>
-                        <span className="text-sm font-medium hover:underline underline-offset-4">
+                        <span className="text-sm font-medium hover:underline underline-offset-4 whitespace-nowrap">
                           {member.nickname || member.discordUsername}
                         </span>
                       </Link>
                     </TableCell>
-                    <TableCell className="text-center py-2.5">
+                    <TableCell className="text-center py-2.5 whitespace-nowrap">
                       <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
                         {member.postCount}개
                       </span>
                     </TableCell>
-                    <TableCell className="text-center py-2.5">
+                    <TableCell className="text-center py-2.5 whitespace-nowrap">
                       <Badge
                         variant={
                           member.attendanceRate >= 80
@@ -277,13 +271,14 @@ export default function RankingPage() {
                         {member.attendanceRate.toFixed(0)}%
                       </Badge>
                     </TableCell>
-                    <TableCell className="text-center py-2.5 text-sm text-muted-foreground tabular-nums">
+                    <TableCell className="text-center py-2.5 text-sm text-muted-foreground tabular-nums whitespace-nowrap">
                       {member.submittedRounds}/{member.totalRounds}회
                     </TableCell>
                   </TableRow>
                 ))}
               </TableBody>
             </Table>
+            </div>
           ) : (
             <div className="flex flex-col items-center justify-center py-16 gap-2">
               <Trophy className="h-8 w-8 text-muted-foreground/40" />

--- a/packages/web/src/app/api/admin/curation/[id]/route.ts
+++ b/packages/web/src/app/api/admin/curation/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { eq } from 'drizzle-orm';
 import { getDb } from '@/lib/db';
-import { curationSources, curationItems } from '@blog-study/shared/db';
+import { curationSources, curationItems, CurationCategory } from '@blog-study/shared/db';
 import { withAdminAuth } from '@/lib/admin';
 
 /**
@@ -49,6 +49,38 @@ export const PATCH = withAdminAuth(async (request: NextRequest, _adminAuth) => {
     }
 
     const body = await request.json();
+
+    // Validate inputs before DB access
+    const validCategories = Object.values(CurationCategory);
+    if (body.category !== undefined && !validCategories.includes(body.category)) {
+      return NextResponse.json(
+        { error: `유효하지 않은 카테고리입니다. (${validCategories.join(', ')})` },
+        { status: 400 }
+      );
+    }
+    if (body.name !== undefined && (typeof body.name !== 'string' || body.name.trim() === '')) {
+      return NextResponse.json(
+        { error: '이름은 빈 문자열일 수 없습니다.' },
+        { status: 400 }
+      );
+    }
+    if (body.url !== undefined) {
+      try {
+        new URL(body.url);
+      } catch {
+        return NextResponse.json(
+          { error: '유효하지 않은 URL입니다.' },
+          { status: 400 }
+        );
+      }
+    }
+    if (body.tags !== undefined && !Array.isArray(body.tags)) {
+      return NextResponse.json(
+        { error: 'tags는 배열이어야 합니다.' },
+        { status: 400 }
+      );
+    }
+
     const database = getDb();
 
     // Check if source exists

--- a/packages/web/src/app/api/curation/route.ts
+++ b/packages/web/src/app/api/curation/route.ts
@@ -1,8 +1,9 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { desc, count, eq, and, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { successResponse, errorResponse } from '@/lib/api-error';
+import { createClient } from '@/lib/supabase/server';
 
 const { curationItems, curationSources } = sharedDb;
 
@@ -14,6 +15,12 @@ const { curationItems, curationSources } = sharedDb;
  */
 export async function GET(request: NextRequest) {
   try {
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ message: '인증이 필요합니다.' }, { status: 401 });
+    }
+
     const { searchParams } = new URL(request.url);
     const category = searchParams.get('category') || 'all';
     const tagsParam = searchParams.get('tags') || '';

--- a/packages/web/src/app/api/dashboard/route.ts
+++ b/packages/web/src/app/api/dashboard/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { eq, desc, count } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
+import { createClient } from '@/lib/supabase/server';
 
 const { members, posts, rounds, MemberStatus } = sharedDb;
 
@@ -12,6 +13,12 @@ const { members, posts, rounds, MemberStatus } = sharedDb;
  */
 export async function GET() {
   try {
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ message: '인증이 필요합니다.' }, { status: 401 });
+    }
+
     const database = db();
 
     // Get current round

--- a/packages/web/src/app/api/members/[id]/route.ts
+++ b/packages/web/src/app/api/members/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { eq, count, desc, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
+import { createClient } from '@/lib/supabase/server';
 
 const { members, posts, attendance, AttendanceStatus } = sharedDb;
 
@@ -15,6 +16,12 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ message: '인증이 필요합니다.' }, { status: 401 });
+    }
+
     const { id } = await params;
 
     if (!id) {

--- a/packages/web/src/app/api/members/route.ts
+++ b/packages/web/src/app/api/members/route.ts
@@ -2,8 +2,11 @@ import { NextRequest, NextResponse } from 'next/server';
 import { eq, count, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
+import { createClient } from '@/lib/supabase/server';
 
 const { members, posts, attendance, AttendanceStatus } = sharedDb;
+
+const ALLOWED_STATUSES = ['active', 'dormant'];
 
 /**
  * GET /api/members
@@ -11,8 +14,18 @@ const { members, posts, attendance, AttendanceStatus } = sharedDb;
  */
 export async function GET(request: NextRequest) {
   try {
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ message: '인증이 필요합니다.' }, { status: 401 });
+    }
+
     const { searchParams } = new URL(request.url);
     const status = searchParams.get('status') || 'active';
+
+    if (!ALLOWED_STATUSES.includes(status)) {
+      return NextResponse.json({ message: 'Invalid status' }, { status: 400 });
+    }
 
     const database = db();
 

--- a/packages/web/src/app/api/posts/route.ts
+++ b/packages/web/src/app/api/posts/route.ts
@@ -1,13 +1,14 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { desc, count, eq } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
-import { 
-  successResponse, 
-  errorResponse, 
-  parsePagination, 
-  createPaginationMeta 
+import {
+  successResponse,
+  errorResponse,
+  parsePagination,
+  createPaginationMeta
 } from '@/lib/api-error';
+import { createClient } from '@/lib/supabase/server';
 
 const { posts, members, rounds } = sharedDb;
 
@@ -18,6 +19,12 @@ const { posts, members, rounds } = sharedDb;
  */
 export async function GET(request: NextRequest) {
   try {
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ message: '인증이 필요합니다.' }, { status: 401 });
+    }
+
     const { searchParams } = new URL(request.url);
     const { page, pageSize, offset } = parsePagination(searchParams);
 

--- a/packages/web/src/app/api/ranking/route.ts
+++ b/packages/web/src/app/api/ranking/route.ts
@@ -1,8 +1,9 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { eq, count, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { successResponse, errorResponse } from '@/lib/api-error';
+import { createClient } from '@/lib/supabase/server';
 
 const { members, posts, attendance, MemberStatus, AttendanceStatus } = sharedDb;
 
@@ -13,6 +14,12 @@ const { members, posts, attendance, MemberStatus, AttendanceStatus } = sharedDb;
  */
 export async function GET(request: NextRequest) {
   try {
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ message: '인증이 필요합니다.' }, { status: 401 });
+    }
+
     const { searchParams } = new URL(request.url);
     const sortBy = searchParams.get('sortBy') || 'posts';
 

--- a/packages/web/src/app/auth/callback/route.ts
+++ b/packages/web/src/app/auth/callback/route.ts
@@ -10,45 +10,72 @@ export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get('code');
   const rawNext = searchParams.get('next') ?? '/dashboard';
-  const next = rawNext.startsWith('/') && !rawNext.startsWith('//') ? rawNext : '/dashboard';
-
-  if (code) {
-    const supabase = await createClient();
-    const { error } = await supabase.auth.exchangeCodeForSession(code);
-
-    if (!error) {
-      // 온보딩 완료 여부 체크
-      try {
-        const { data: { user } } = await supabase.auth.getUser();
-        const discordIdentity = user?.identities?.find(
-          (identity) => identity.provider === 'discord'
-        );
-        const discordId = discordIdentity?.id;
-
-        if (discordId) {
-          const database = db();
-          const [memberData] = await database
-            .select({ onboardingCompleted: members.onboardingCompleted })
-            .from(members)
-            .where(eq(members.discordId, discordId))
-            .limit(1);
-
-          // 멤버 레코드가 없거나 온보딩 미완료 → 온보딩으로
-          if (!memberData || !memberData.onboardingCompleted) {
-            return NextResponse.redirect(`${origin}/profile/onboarding`);
-          }
-        } else {
-          // Discord ID가 없는 경우 (일반적이지 않지만) → 온보딩으로
-          return NextResponse.redirect(`${origin}/profile/onboarding`);
-        }
-      } catch (e) {
-        console.error('Onboarding check error in callback:', e);
-        // DB 오류 시 안전하게 대시보드로 (layout에서 2차 체크)
-      }
-
-      return NextResponse.redirect(`${origin}${next}`);
+  let next = '/dashboard';
+  try {
+    const redirectUrl = new URL(rawNext, origin);
+    if (redirectUrl.origin === origin) {
+      next = redirectUrl.pathname + redirectUrl.search;
     }
+  } catch {
+    // invalid URL, use default
   }
 
-  return NextResponse.redirect(`${origin}/login?error=auth`);
+  console.log(`[auth/callback] code=${code ? '있음' : '없음'}, next=${next}`);
+
+  if (!code) {
+    console.log('[auth/callback] code 없음 → /login?error=auth 리다이렉트');
+    return NextResponse.redirect(`${origin}/login?error=auth`);
+  }
+
+  const supabase = await createClient();
+  const { data: sessionData, error } = await supabase.auth.exchangeCodeForSession(code);
+
+  if (error) {
+    console.error(`[auth/callback] exchangeCodeForSession 실패: ${error.message} (status: ${error.status})`);
+    return NextResponse.redirect(`${origin}/login?error=auth`);
+  }
+
+  console.log(
+    `[auth/callback] 세션 교환 성공: user=${sessionData.user.id.slice(0, 8)}..., expires_at=${sessionData.session.expires_at}`
+  );
+
+  // 온보딩 완료 여부 체크
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    const discordIdentity = user?.identities?.find(
+      (identity) => identity.provider === 'discord'
+    );
+    const discordId = discordIdentity?.id;
+
+    console.log(`[auth/callback] discord_id=${discordId ?? '없음'}`);
+
+    if (discordId) {
+      const database = db();
+      const [memberData] = await database
+        .select({ onboardingCompleted: members.onboardingCompleted })
+        .from(members)
+        .where(eq(members.discordId, discordId))
+        .limit(1);
+
+      console.log(
+        `[auth/callback] 멤버 조회: ${memberData ? `onboarding=${memberData.onboardingCompleted}` : '레코드 없음'}`
+      );
+
+      // 멤버 레코드가 없거나 온보딩 미완료 → 온보딩으로
+      if (!memberData || !memberData.onboardingCompleted) {
+        console.log('[auth/callback] → /profile/onboarding 리다이렉트');
+        return NextResponse.redirect(`${origin}/profile/onboarding`);
+      }
+    } else {
+      // Discord ID가 없는 경우 (일반적이지 않지만) → 온보딩으로
+      console.log('[auth/callback] Discord ID 없음 → /profile/onboarding 리다이렉트');
+      return NextResponse.redirect(`${origin}/profile/onboarding`);
+    }
+  } catch (e) {
+    console.error('[auth/callback] 온보딩 체크 에러:', e);
+    // DB 오류 시 안전하게 대시보드로 (layout에서 2차 체크)
+  }
+
+  console.log(`[auth/callback] → ${next} 리다이렉트`);
+  return NextResponse.redirect(`${origin}${next}`);
 }

--- a/packages/web/src/components/layout/main-layout.tsx
+++ b/packages/web/src/components/layout/main-layout.tsx
@@ -3,9 +3,11 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Header } from './header';
-import { Sidebar, useSidebarCollapsed } from './sidebar';
+import { Sidebar } from './sidebar';
 import { Footer } from './footer';
 import { cn } from '@/lib/utils';
+
+const STORAGE_KEY = 'study-sidebar-collapsed';
 
 interface MainLayoutProps {
   children: React.ReactNode;
@@ -19,24 +21,24 @@ interface MainLayoutProps {
   onLogout?: () => void;
 }
 
-// Inner wrapper that reads sidebar collapsed state to apply the correct margin.
+// Inner wrapper that applies the correct left margin based on sidebar state.
 function MainContent({
   children,
   showSidebar,
+  collapsed,
 }: {
   children: React.ReactNode;
   showSidebar: boolean;
+  collapsed: boolean;
 }) {
-  const collapsed = useSidebarCollapsed();
-
   return (
     <main
       className={cn(
-        'flex-1 transition-[margin-left] duration-200',
+        'flex-1 min-w-0 transition-[margin-left] duration-200',
         showSidebar && (collapsed ? 'md:ml-16' : 'md:ml-60')
       )}
     >
-      <div className="container py-6">{children}</div>
+      <div className="w-full px-4 sm:px-6 lg:px-8 py-6 max-w-7xl mx-auto">{children}</div>
     </main>
   );
 }
@@ -50,6 +52,15 @@ export function MainLayout({
 }: MainLayoutProps) {
   const router = useRouter();
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  });
+
+  const handleToggleCollapsed = (value: boolean) => {
+    setCollapsed(value);
+    localStorage.setItem(STORAGE_KEY, String(value));
+  };
 
   const handleLogout = async () => {
     if (onLogout) {
@@ -66,7 +77,7 @@ export function MainLayout({
   };
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col overflow-x-hidden">
       <Header
         user={user}
         onMenuClick={() => setSidebarOpen(true)}
@@ -78,9 +89,11 @@ export function MainLayout({
             isOpen={sidebarOpen}
             onClose={() => setSidebarOpen(false)}
             isAdmin={isAdmin}
+            collapsed={collapsed}
+            onToggleCollapsed={handleToggleCollapsed}
           />
         )}
-        <MainContent showSidebar={showSidebar}>{children}</MainContent>
+        <MainContent showSidebar={showSidebar} collapsed={collapsed}>{children}</MainContent>
       </div>
       <Footer />
     </div>

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import {
@@ -24,9 +23,11 @@ import { Separator } from '@/components/ui/separator';
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 interface SidebarProps {
-  isOpen?: boolean;    // mobile drawer open state
-  onClose?: () => void; // mobile close handler
-  isAdmin?: boolean;   // show admin nav
+  isOpen?: boolean;              // mobile drawer open state
+  onClose?: () => void;          // mobile close handler
+  isAdmin?: boolean;             // show admin nav
+  collapsed: boolean;            // controlled collapsed state
+  onToggleCollapsed: (value: boolean) => void; // callback to toggle collapsed
 }
 
 interface NavItem {
@@ -53,10 +54,6 @@ const adminNavItems: NavItem[] = [
   { title: '큐레이션 소스', href: '/admin/curation',    icon: Newspaper },
   { title: '설정',         href: '/admin/settings',     icon: Settings },
 ];
-
-// ─── Constants ────────────────────────────────────────────────────────────────
-
-const STORAGE_KEY = 'study-sidebar-collapsed';
 
 // ─── NavLink sub-component ────────────────────────────────────────────────────
 
@@ -290,21 +287,16 @@ function SidebarContent({
 
 // ─── Sidebar component ────────────────────────────────────────────────────────
 
-export function Sidebar({ isOpen = false, onClose, isAdmin = false }: SidebarProps) {
+export function Sidebar({
+  isOpen = false,
+  onClose,
+  isAdmin = false,
+  collapsed,
+  onToggleCollapsed,
+}: SidebarProps) {
   const pathname = usePathname();
 
-  // Persist collapsed state in localStorage
-  const [collapsed, setCollapsed] = useState<boolean>(() => {
-    if (typeof window === 'undefined') return false;
-    return localStorage.getItem(STORAGE_KEY) === 'true';
-  });
-
-  // Keep localStorage in sync whenever collapsed changes
-  useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, String(collapsed));
-  }, [collapsed]);
-
-  const toggleCollapsed = () => setCollapsed((prev) => !prev);
+  const toggleCollapsed = () => onToggleCollapsed(!collapsed);
 
   const navItems = isAdmin ? adminNavItems : userNavItems;
 
@@ -348,7 +340,6 @@ export function Sidebar({ isOpen = false, onClose, isAdmin = false }: SidebarPro
       {/* ── Desktop: fixed sidebar ──────────────────────────────────── */}
       <aside
         aria-label="데스크톱 내비게이션"
-        data-collapsed={collapsed}
         className={cn(
           'fixed left-0 top-0 z-30 hidden h-full md:flex md:flex-col',
           'border-r border-zinc-200 dark:border-zinc-800',
@@ -369,42 +360,4 @@ export function Sidebar({ isOpen = false, onClose, isAdmin = false }: SidebarPro
       </aside>
     </>
   );
-}
-
-// ─── Hook: expose collapsed state for layout offset ───────────────────────────
-// Consumers can import this hook to read the sidebar width for layout shifts.
-export function useSidebarCollapsed(): boolean {
-  const [collapsed, setCollapsed] = useState<boolean>(() => {
-    if (typeof window === 'undefined') return false;
-    return localStorage.getItem(STORAGE_KEY) === 'true';
-  });
-
-  useEffect(() => {
-    const onStorage = (e: StorageEvent) => {
-      if (e.key === STORAGE_KEY) {
-        setCollapsed(e.newValue === 'true');
-      }
-    };
-    window.addEventListener('storage', onStorage);
-
-    // Also observe direct changes from same tab via a MutationObserver on the aside[data-collapsed]
-    const observer = new MutationObserver(() => {
-      const aside = document.querySelector('aside[data-collapsed]');
-      if (aside) {
-        setCollapsed(aside.getAttribute('data-collapsed') === 'true');
-      }
-    });
-
-    const target = document.querySelector('aside[data-collapsed]');
-    if (target) {
-      observer.observe(target, { attributes: true, attributeFilter: ['data-collapsed'] });
-    }
-
-    return () => {
-      window.removeEventListener('storage', onStorage);
-      observer.disconnect();
-    };
-  }, []);
-
-  return collapsed;
 }

--- a/packages/web/src/components/ui/page-state.tsx
+++ b/packages/web/src/components/ui/page-state.tsx
@@ -1,0 +1,20 @@
+import { Loader2 } from 'lucide-react';
+
+export function PageLoading({ message = '로딩 중...' }: { message?: string }) {
+  return (
+    <div className="flex items-center justify-center min-h-[400px]">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        {message}
+      </div>
+    </div>
+  );
+}
+
+export function PageError({ message }: { message: string }) {
+  return (
+    <div className="flex items-center justify-center min-h-[400px]">
+      <div className="text-sm text-destructive">{message}</div>
+    </div>
+  );
+}

--- a/packages/web/src/components/ui/part-badge.tsx
+++ b/packages/web/src/components/ui/part-badge.tsx
@@ -1,0 +1,19 @@
+import { getPartStyle, getPartLabel } from '@/lib/part-config';
+
+interface PartBadgeProps {
+  part: string;
+  size?: 'sm' | 'default';
+}
+
+export function PartBadge({ part, size = 'default' }: PartBadgeProps) {
+  const style = getPartStyle(part);
+  return (
+    <span
+      className={`inline-flex items-center rounded-full font-medium ${style.bg} ${style.text} ${
+        size === 'sm' ? 'px-1.5 py-px text-[11px]' : 'px-2 py-0.5 text-xs'
+      }`}
+    >
+      {getPartLabel(part)}
+    </span>
+  );
+}

--- a/packages/web/src/components/ui/tag-list.tsx
+++ b/packages/web/src/components/ui/tag-list.tsx
@@ -1,0 +1,26 @@
+interface TagListProps {
+  tags: string[];
+  limit?: number;
+}
+
+export function TagList({ tags, limit = 4 }: TagListProps) {
+  if (!tags || tags.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {tags.slice(0, limit).map((tag) => (
+        <span
+          key={tag}
+          className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium bg-primary/10 text-primary"
+        >
+          {tag}
+        </span>
+      ))}
+      {tags.length > limit && (
+        <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium bg-muted text-muted-foreground">
+          +{tags.length - limit}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/lib/member-config.ts
+++ b/packages/web/src/lib/member-config.ts
@@ -1,0 +1,5 @@
+export const MEMBER_STATUS_CONFIG: Record<string, { label: string; variant: 'default' | 'secondary' | 'destructive' }> = {
+  active: { label: '활성', variant: 'default' },
+  dormant: { label: '휴면', variant: 'secondary' },
+  withdrawn: { label: '탈퇴', variant: 'destructive' },
+};

--- a/packages/web/src/lib/rss-detect.ts
+++ b/packages/web/src/lib/rss-detect.ts
@@ -10,6 +10,42 @@ const { detectBlogPlatform } = utils;
 const HTTP_TIMEOUT = 10000;
 
 /**
+ * SSRF 방지: 안전한 외부 URL인지 검증
+ * 로컬호스트, 프라이빗 네트워크, 메타데이터 엔드포인트 차단
+ */
+function isSafeUrl(urlString: string): boolean {
+  try {
+    const url = new URL(urlString);
+    const hostname = url.hostname.replace(/^\[|\]$/g, ''); // strip IPv6 brackets
+
+    // IPv6 loopback and link-local
+    if (hostname === '::1' || hostname.toLowerCase().startsWith('fe80:')) {
+      return false;
+    }
+
+    // IPv4 private/reserved ranges
+    const parts = hostname.split('.');
+    const first = parseInt(parts[0] ?? '', 10);
+    const second = parseInt(parts[1] ?? '', 10);
+    if (
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname === '0.0.0.0' ||
+      hostname.startsWith('10.') ||
+      (first === 172 && second >= 16 && second <= 31) || // 172.16.0.0/12
+      hostname.startsWith('192.168.') ||
+      hostname === '169.254.169.254' ||
+      hostname.endsWith('.internal')
+    ) {
+      return false;
+    }
+    return ['http:', 'https:'].includes(url.protocol);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * 플랫폼별 RSS URL 생성
  */
 function constructRssUrl(blogUrl: string, platform: string): string | null {
@@ -41,6 +77,7 @@ function constructRssUrl(blogUrl: string, platform: string): string | null {
  */
 async function isValidFeed(url: string): Promise<boolean> {
   try {
+    if (!isSafeUrl(url)) throw new Error('Invalid URL');
     const res = await fetch(url, {
       headers: { 'User-Agent': 'BlogStudyBot/1.0' },
       signal: AbortSignal.timeout(HTTP_TIMEOUT),
@@ -76,6 +113,8 @@ function extractRssFromHtml(html: string): string | null {
  * @returns 감지된 RSS URL 또는 null
  */
 export async function detectRssUrl(blogUrl: string): Promise<string | null> {
+  if (!isSafeUrl(blogUrl)) return null;
+
   const platform = detectBlogPlatform(blogUrl);
 
   // 1단계: 플랫폼별 규칙으로 RSS URL 생성 + 검증
@@ -88,6 +127,7 @@ export async function detectRssUrl(blogUrl: string): Promise<string | null> {
 
   // 2단계: HTML link 태그에서 RSS 발견
   try {
+    if (!isSafeUrl(blogUrl)) throw new Error('Invalid URL');
     const res = await fetch(blogUrl, {
       headers: { 'User-Agent': 'BlogStudyBot/1.0' },
       signal: AbortSignal.timeout(HTTP_TIMEOUT),

--- a/packages/web/src/lib/supabase/middleware.ts
+++ b/packages/web/src/lib/supabase/middleware.ts
@@ -6,6 +6,14 @@ export async function updateSession(request: NextRequest) {
     request,
   });
 
+  // 쿠키 상태 로깅
+  if (process.env.NODE_ENV === 'development') {
+    const authCookies = request.cookies.getAll().filter((c) => c.name.startsWith('sb-'));
+    console.log(
+      `[updateSession] 요청 쿠키: ${authCookies.length > 0 ? authCookies.map((c) => `${c.name}(${c.value.length}chars)`).join(', ') : '없음'}`
+    );
+  }
+
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
@@ -15,6 +23,11 @@ export async function updateSession(request: NextRequest) {
           return request.cookies.getAll();
         },
         setAll(cookiesToSet) {
+          if (process.env.NODE_ENV === 'development') {
+            console.log(
+              `[updateSession] 쿠키 갱신: ${cookiesToSet.map((c) => c.name).join(', ')}`
+            );
+          }
           cookiesToSet.forEach(({ name, value }) =>
             request.cookies.set(name, value)
           );
@@ -31,7 +44,18 @@ export async function updateSession(request: NextRequest) {
 
   const {
     data: { user },
+    error,
   } = await supabase.auth.getUser();
+
+  if (process.env.NODE_ENV === 'development') {
+    if (error) {
+      console.log(`[updateSession] getUser 에러: ${error.message} (code: ${error.code})`);
+    } else if (user) {
+      console.log(`[updateSession] 세션 유효: user=${user.id.slice(0, 8)}...`);
+    } else {
+      console.log(`[updateSession] 세션 없음 (미인증)`);
+    }
+  }
 
   return { user, supabaseResponse };
 }

--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -1,0 +1,94 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { updateSession } from '@/lib/supabase/middleware';
+
+// 인증 불필요 경로
+const PUBLIC_PATHS = ['/login', '/auth/callback'];
+
+// 인증 필요 경로 prefix
+const PROTECTED_PREFIXES = ['/dashboard', '/profile', '/posts', '/members', '/ranking', '/curation'];
+
+// 관리자 전용 경로 prefix
+const ADMIN_PREFIXES = ['/admin'];
+
+function isPublicPath(pathname: string): boolean {
+  return PUBLIC_PATHS.some((p) => pathname.startsWith(p));
+}
+
+function isProtectedPath(pathname: string): boolean {
+  return PROTECTED_PREFIXES.some((p) => pathname.startsWith(p));
+}
+
+function isAdminPath(pathname: string): boolean {
+  return ADMIN_PREFIXES.some((p) => pathname.startsWith(p));
+}
+
+export async function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const requestId = crypto.randomUUID().slice(0, 8);
+
+  if (process.env.NODE_ENV === 'development') {
+    console.log(`[proxy:${requestId}] ${request.method} ${pathname}`);
+  }
+
+  // 세션 갱신 (모든 요청에서 실행)
+  const { user, supabaseResponse } = await updateSession(request);
+
+  const isAuthenticated = !!user;
+  const discordId = user?.identities?.find((i) => i.provider === 'discord')?.id;
+
+  if (process.env.NODE_ENV === 'development') {
+    console.log(
+      `[proxy:${requestId}] user=${isAuthenticated ? user.id.slice(0, 8) : 'none'}, discord=${discordId ?? 'none'}`
+    );
+  }
+
+  // 공개 경로 → 로그인 상태면 대시보드로
+  if (isPublicPath(pathname)) {
+    if (isAuthenticated && pathname.startsWith('/login')) {
+      if (process.env.NODE_ENV === 'development') {
+        console.log(`[proxy:${requestId}] 로그인 상태 → /dashboard 리다이렉트`);
+      }
+      const url = request.nextUrl.clone();
+      url.pathname = '/dashboard';
+      return NextResponse.redirect(url);
+    }
+    return supabaseResponse;
+  }
+
+  // 보호된 경로 → 미인증이면 로그인으로
+  if (isProtectedPath(pathname) || isAdminPath(pathname)) {
+    if (!isAuthenticated) {
+      if (process.env.NODE_ENV === 'development') {
+        console.log(`[proxy:${requestId}] 미인증 → /login 리다이렉트`);
+      }
+      const url = request.nextUrl.clone();
+      url.pathname = '/login';
+      url.searchParams.set('redirect', pathname);
+      return NextResponse.redirect(url);
+    }
+  }
+
+  // 관리자 경로 → 관리자 체크 (환경변수 기반)
+  if (isAdminPath(pathname)) {
+    const adminIds = (process.env.ADMIN_DISCORD_IDS || '').split(',').map((id) => id.trim()).filter(Boolean);
+    if (!discordId || !adminIds.includes(discordId)) {
+      if (process.env.NODE_ENV === 'development') {
+        console.log(`[proxy:${requestId}] 관리자 아님 → /dashboard 리다이렉트`);
+      }
+      const url = request.nextUrl.clone();
+      url.pathname = '/dashboard';
+      return NextResponse.redirect(url);
+    }
+  }
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: [
+    /*
+     * _next/static, _next/image, favicon, 정적 파일 제외
+     */
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+  ],
+};


### PR DESCRIPTION
## Summary

디스코드 로그인 간헐적 실패 근본 수정, 보안 취약점 6건 해결, 전 페이지 모바일 반응형 개편, 공유 컴포넌트 추출을 통한 코드 모듈화, 큐레이션 god component 분해를 포함한 종합 리팩터링.

- 38 files changed, 1,656 insertions(+), 1,195 deletions(-)
- 신규 파일 8개, 수정 파일 30개
- TypeScript 0 에러

## Changes

### 1. 로그인 간헐적 실패 수정
| 파일 | 변경 내용 |
|------|----------|
| `src/proxy.ts` (신규) | Next.js 16 `proxy` convention으로 세션 갱신 미들웨어 생성. 매 요청마다 `updateSession()` 호출하여 쿠키 기반 세션 자동 갱신 |
| `src/lib/supabase/middleware.ts` | 개발 환경 한정 상세 디버깅 로그 추가 (쿠키 상태, 세션 갱신 결과) |
| `src/app/auth/callback/route.ts` | OAuth 콜백 흐름 상세 로깅 추가 |

**근본 원인**: middleware 파일이 존재하지 않아 `updateSession()`이 호출되지 않음 → 첫 로그인 시 세션 쿠키 미갱신 → 실패 → 재시도 시 성공하는 패턴

### 2. 보안 취약점 수정 (6건)
| 파일 | 취약점 | 수정 내용 |
|------|--------|----------|
| `src/app/auth/callback/route.ts` | Open Redirect | `startsWith('/')` → `new URL(rawNext, origin).origin === origin` 검증 |
| `src/lib/rss-detect.ts` | SSRF | `isSafeUrl()` 신규 — IPv4 사설대역 전체(`172.16.0.0/12`), IPv6 루프백(`::1`), 링크로컬(`fe80::`) 차단 |
| `src/app/api/*/route.ts` (6개) | 미인증 API 접근 | `createClient()` → `getUser()` 인증 체크 추가 |
| `next.config.js` | 보안 헤더 누락 | `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy` 추가 |
| `src/app/api/admin/curation/[id]/route.ts` | 입력 검증 미흡 | `category`, `name`, `url`, `tags` 타입 및 enum 검증 강화 |
| `src/app/api/members/route.ts` | 쿼리 인젝션 | `ALLOWED_STATUSES` allowlist 검증 |

### 3. 모듈화 — 공유 컴포넌트 추출
| 파일 (신규) | 제거한 중복 | 영향 범위 |
|------------|-----------|----------|
| `src/components/ui/page-state.tsx` | 동일한 로딩/에러 JSX 블록 26개 | 14개+ 페이지 |
| `src/components/ui/part-badge.tsx` | 인라인 파트 배지 코드 6곳 | user/admin 페이지 |
| `src/components/ui/tag-list.tsx` | 태그 렌더링 블록 3곳 | 큐레이션 관련 페이지 |
| `src/lib/member-config.ts` | 멤버 상태 설정 객체 2곳 | admin/members, admin/attendance |

### 4. God Component 분해 (큐레이션)
| 파일 | 변경 |
|------|------|
| `admin/curation/page.tsx` | **1,087줄 → ~220줄** (오케스트레이션만 담당) |
| `admin/curation/crawl-modal.tsx` (신규) | 크롤링 진행 Dialog + SSE 스트리밍 표시 |
| `admin/curation/source-form.tsx` (신규) | 소스 추가/수정 공용 폼 |
| `admin/curation/sources-table.tsx` (신규) | 데스크톱 테이블 + 모바일 카드 이중 뷰 |

### 5. 반응형 디자인 전면 개편
| 영역 | 변경 내용 |
|------|----------|
| 레이아웃 | `overflow-x-hidden` + `min-w-0`으로 수평 오버플로우 근본 차단 |
| 모든 테이블 | 데스크톱 테이블(`hidden md:block`) + 모바일 카드(`md:hidden`) 이중 구조 |
| 포스트 목록 | 모바일 컴팩트 리스트 뷰 (2줄 아이템) |
| 대시보드 | stat 카드 아이콘 `shrink-0`, 텍스트 `min-w-0` + `truncate` |
| 헤더/폼 | 모바일 세로 스택, 데스크톱 가로 배치 (`flex-col` → `sm:flex-row`) |

### 6. 코드 품질 개선
| 항목 | Before | After |
|------|--------|-------|
| 사이드바 상태 관리 | `MutationObserver` DOM 해킹 | lifted React state (`collapsed` prop) |
| 크롤링 상태 | stale closure 위험 | `setCrawlStatus((prev) => ...)` |
| 소셜 링크 | `<span onClick={window.open}>` | `<a target="_blank" rel="noopener noreferrer">` |
| SourceForm 리마운트 | 암묵적 의존 | `key={editingSource.id}` 명시 |
| 미사용 코드 | `onCrawl` dead prop, 중복 블로그 URL | 제거 |

## Design Decisions

| 결정 | 이유 |
|------|------|
| `proxy.ts` (Next.js 16 convention) | `middleware.ts`는 Next.js 16.1에서 deprecated. `proxy` export가 공식 대체 |
| SSRF에 `isSafeUrl()` 직접 구현 | 외부 라이브러리 추가 없이 최소한으로. `172.16.0.0/12` 전체 + IPv6 커버 |
| `PageLoading`/`PageError` 단일 컴포넌트 | 26곳 중복을 2줄로 대체. 오버엔지니어링 없이 최대 효과 |
| 모바일 카드 vs 가로 스크롤 테이블 | 카드뷰가 터치 UX에 더 적합하고 정보 밀도 유지 |
| 포스트 목록은 컴팩트 리스트 | 큐레이션(시각적 다양성)과 달리 포스트는 스캔 위주 → 카드보다 리스트가 적합 |
| Rate limiting / CSP / CSRF 보류 | 각각 Redis 인프라 / 세밀한 설정 / Server Actions 전환 시 자동 해결. 오버엔지니어링 방지 |

## Test Plan

- [x] `pnpm typecheck` — TypeScript 0 에러 확인 ✅
- [x] 로컬 `pnpm dev:web`으로 localhost:3200 정상 기동 확인
- [x] 디스코드 로그인 → 첫 시도에 성공하는지 확인
- [x] 모바일 뷰포트(375px)에서 전 페이지 가로 스크롤 없는지 확인
- [x] 대시보드 stat 카드 아이콘 잘림 없는지 확인
- [x] 관리자 큐레이션 페이지 CRUD + 크롤링 동작 확인
- [x] API 라우트 비인증 접근 시 401 반환 확인
- [x] auth callback에 `?next=https://evil.com` 전달 시 `/dashboard`로 리다이렉트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)