### PR TITLE
feat: 멤버 승인 시스템 + 6단계 상태 관리 구축

### DIFF
--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -19,8 +19,11 @@ import { relations } from 'drizzle-orm';
 // ============================================
 
 export const MemberStatus = {
+  PENDING_APPROVAL: 'pending_approval',
   ACTIVE: 'active',
+  INACTIVE: 'inactive',
   DORMANT: 'dormant',
+  OB: 'ob',
   WITHDRAWN: 'withdrawn',
 } as const;
 

--- a/packages/web/src/app/(admin)/admin/members/member-form-dialog.tsx
+++ b/packages/web/src/app/(admin)/admin/members/member-form-dialog.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { MEMBER_STATUS_CONFIG } from '@/lib/member-config';
 
 interface Member {
   id: string;
@@ -41,6 +42,7 @@ export function MemberFormDialog({
     discordUsername: '',
     blogUrl: '',
     rssUrl: '',
+    status: 'active',
   });
   const [errors, setErrors] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
@@ -56,6 +58,7 @@ export function MemberFormDialog({
         discordUsername: member.discordUsername,
         blogUrl: member.blogUrl,
         rssUrl: member.rssUrl || '',
+        status: member.status,
       });
     } else {
       setFormData({
@@ -65,6 +68,7 @@ export function MemberFormDialog({
         discordUsername: '',
         blogUrl: '',
         rssUrl: '',
+        status: 'active',
       });
     }
     setErrors([]);
@@ -139,6 +143,7 @@ export function MemberFormDialog({
           discordUsername: formData.discordUsername.trim() || formData.discordId.trim(),
           blogUrl: formData.blogUrl.trim(),
           rssUrl: formData.rssUrl.trim() || null,
+          ...(isEditing && { status: formData.status }),
         }),
       });
 
@@ -268,6 +273,26 @@ export function MemberFormDialog({
               비워두면 자동으로 감지합니다.
             </p>
           </div>
+
+          {/* Status field (edit mode only) */}
+          {isEditing && (
+            <div className="space-y-2">
+              <Label htmlFor="status">상태</Label>
+              <select
+                id="status"
+                name="status"
+                value={formData.status}
+                onChange={(e) => setFormData(prev => ({ ...prev, status: e.target.value }))}
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                {Object.entries(MEMBER_STATUS_CONFIG).map(([value, config]) => (
+                  <option key={value} value={value}>
+                    {config.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
 
           {/* Actions */}
           <div className="flex justify-end gap-2 pt-4">

--- a/packages/web/src/app/(admin)/admin/members/page.tsx
+++ b/packages/web/src/app/(admin)/admin/members/page.tsx
@@ -10,6 +10,9 @@ import {
   ExternalLink,
   Moon,
   UserX,
+  Clock,
+  UserCheck,
+  GraduationCap,
 } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -25,9 +28,11 @@ import {
 } from '@/components/ui/table';
 import { MemberFormDialog } from './member-form-dialog';
 import { DeleteMemberDialog } from './delete-member-dialog';
+import { PendingMemberCard } from './pending-member-card';
 import { PageLoading, PageError } from '@/components/ui/page-state';
 import { PartBadge } from '@/components/ui/part-badge';
 import { MEMBER_STATUS_CONFIG } from '@/lib/member-config';
+import { cn } from '@/lib/utils';
 
 interface AttendanceStats {
   total: number;
@@ -41,13 +46,17 @@ interface Member {
   discordId: string;
   discordUsername: string;
   name: string;
+  nickname: string;
   part: string;
   blogUrl: string;
   rssUrl: string | null;
   rssConsent: boolean;
   profileImageUrl: string | null;
   bio: string | null;
+  interests: string[] | null;
+  resolution: string | null;
   status: string;
+  onboardingCompleted: boolean;
   dormantUsed: boolean;
   dormantStartRound: number | null;
   postCount: number;
@@ -58,19 +67,18 @@ interface Member {
 }
 
 interface MemberCounts {
+  pending_approval: number;
   active: number;
+  inactive: number;
   dormant: number;
+  ob: number;
   withdrawn: number;
   total: number;
 }
 
 interface MembersData {
   members: Member[];
-  grouped: {
-    active: Member[];
-    dormant: Member[];
-    withdrawn: Member[];
-  };
+  grouped: Record<string, Member[]>;
   counts: MemberCounts;
 }
 
@@ -140,6 +148,32 @@ export default function AdminMembersPage() {
     fetchMembers();
   };
 
+  const handleApproveMember = async (memberId: string, targetStatus: string) => {
+    try {
+      const response = await fetch(`/api/admin/members/${memberId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: targetStatus }),
+      });
+      if (response.ok) fetchMembers();
+    } catch (err) {
+      console.error('Approve failed:', err);
+    }
+  };
+
+  const handleRejectMember = async (memberId: string) => {
+    try {
+      const response = await fetch(`/api/admin/members/${memberId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'withdrawn' }),
+      });
+      if (response.ok) fetchMembers();
+    } catch (err) {
+      console.error('Reject failed:', err);
+    }
+  };
+
   // Filter members
   const filteredMembers = data?.members.filter((member) => {
     // Status filter
@@ -177,56 +211,38 @@ export default function AdminMembersPage() {
         </Button>
       </div>
 
-      {/* Stats Cards */}
-      <div className="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4">
-        <Card
-          className={`cursor-pointer transition-colors ${statusFilter === 'all' ? 'border-primary' : ''}`}
-          onClick={() => setStatusFilter('all')}
-        >
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">전체</CardTitle>
-            <Users className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{data?.counts.total ?? 0}명</div>
-          </CardContent>
-        </Card>
-        <Card
-          className={`cursor-pointer transition-colors ${statusFilter === 'active' ? 'border-primary' : ''}`}
-          onClick={() => setStatusFilter('active')}
-        >
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">활성</CardTitle>
-            <Users className="h-4 w-4 text-success" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{data?.counts.active ?? 0}명</div>
-          </CardContent>
-        </Card>
-        <Card
-          className={`cursor-pointer transition-colors ${statusFilter === 'dormant' ? 'border-primary' : ''}`}
-          onClick={() => setStatusFilter('dormant')}
-        >
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">휴면</CardTitle>
-            <Moon className="h-4 w-4 text-warning" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{data?.counts.dormant ?? 0}명</div>
-          </CardContent>
-        </Card>
-        <Card
-          className={`cursor-pointer transition-colors ${statusFilter === 'withdrawn' ? 'border-primary' : ''}`}
-          onClick={() => setStatusFilter('withdrawn')}
-        >
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">탈퇴</CardTitle>
-            <UserX className="h-4 w-4 text-destructive" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{data?.counts.withdrawn ?? 0}명</div>
-          </CardContent>
-        </Card>
+      {/* Status Filter Tabs */}
+      <div className="flex flex-wrap gap-2">
+        {[
+          { key: 'all', label: '전체', count: data?.counts.total, icon: Users },
+          { key: 'pending_approval', label: '승인대기', count: data?.counts.pending_approval, icon: Clock },
+          { key: 'active', label: '활성', count: data?.counts.active, icon: UserCheck },
+          { key: 'ob', label: 'OB', count: data?.counts.ob, icon: GraduationCap },
+          { key: 'dormant', label: '휴면', count: data?.counts.dormant, icon: Moon },
+          { key: 'inactive', label: '비활성', count: data?.counts.inactive, icon: UserX },
+        ].map((tab) => (
+          <button
+            key={tab.key}
+            onClick={() => setStatusFilter(tab.key)}
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition-colors',
+              statusFilter === tab.key
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted text-muted-foreground hover:bg-muted/80'
+            )}
+          >
+            <tab.icon className="h-3.5 w-3.5" />
+            {tab.label}
+            <span className={cn(
+              'ml-0.5 rounded-full px-1.5 py-0.5 text-xs',
+              statusFilter === tab.key
+                ? 'bg-primary-foreground/20 text-primary-foreground'
+                : 'bg-background text-foreground'
+            )}>
+              {tab.count ?? 0}
+            </span>
+          </button>
+        ))}
       </div>
 
       {/* Members Table */}
@@ -253,106 +269,30 @@ export default function AdminMembersPage() {
           </div>
         </CardHeader>
         <CardContent>
-          {/* Mobile card list */}
-          <div className="md:hidden space-y-3">
-            {filteredMembers.length > 0 ? (
-              filteredMembers.map((member) => (
-                <div key={member.id} className="border rounded-lg p-3 space-y-2">
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0">
-                      <p className="font-medium truncate">{member.name}</p>
-                      <p className="text-xs text-muted-foreground">{member.discordUsername}</p>
-                    </div>
-                    <div className="flex items-center gap-1 shrink-0">
-                      <Badge variant={member.rssConsent ? 'outline' : 'secondary'} className="text-[10px] px-1.5 py-0">
-                        RSS {member.rssConsent ? 'ON' : 'OFF'}
-                      </Badge>
-                      <Badge variant={MEMBER_STATUS_CONFIG[member.status]?.variant || 'secondary'}>
-                        {MEMBER_STATUS_CONFIG[member.status]?.label || member.status}
-                      </Badge>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <PartBadge part={member.part} />
-                    <span className="text-xs text-muted-foreground">포스트 {member.postCount}개</span>
-                    <span className="text-xs text-muted-foreground">출석률 {member.attendanceRate}%</span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <a
-                      href={member.blogUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center gap-1 text-xs text-primary hover:underline"
-                    >
-                      <ExternalLink className="h-3 w-3" />
-                      블로그
-                    </a>
-                    <div className="flex items-center gap-1">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => handleEditMember(member)}
-                      >
-                        <Edit className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => handleDeleteMember(member)}
-                        disabled={member.status === 'withdrawn'}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-              ))
-            ) : (
-              <div className="text-center py-8 text-muted-foreground">
-                {searchQuery ? '검색 결과가 없습니다.' : '등록된 멤버가 없습니다.'}
-              </div>
-            )}
-          </div>
-
-          {/* Desktop table */}
-          <div className="hidden md:block overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>이름</TableHead>
-                  <TableHead>파트</TableHead>
-                  <TableHead>Discord</TableHead>
-                  <TableHead>블로그</TableHead>
-                  <TableHead>상태</TableHead>
-                  <TableHead className="text-right">포스트</TableHead>
-                  <TableHead className="text-right">출석률</TableHead>
-                  <TableHead className="w-[50px]"></TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
+          {statusFilter === 'pending_approval' && filteredMembers.length > 0 ? (
+            <div className="grid gap-4 md:grid-cols-2">
+              {filteredMembers.map((member) => (
+                <PendingMemberCard
+                  key={member.id}
+                  member={member}
+                  onApprove={handleApproveMember}
+                  onReject={handleRejectMember}
+                />
+              ))}
+            </div>
+          ) : (
+            <>
+              {/* Mobile card list */}
+              <div className="md:hidden space-y-3">
                 {filteredMembers.length > 0 ? (
                   filteredMembers.map((member) => (
-                    <TableRow key={member.id}>
-                      <TableCell className="font-medium whitespace-nowrap">{member.name}</TableCell>
-                      <TableCell className="whitespace-nowrap">
-                        <PartBadge part={member.part} />
-                      </TableCell>
-                      <TableCell className="text-muted-foreground whitespace-nowrap">
-                        {member.discordUsername}
-                      </TableCell>
-                      <TableCell>
-                        <a
-                          href={member.blogUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="flex items-center gap-1 text-sm text-primary hover:underline"
-                        >
-                          <ExternalLink className="h-3 w-3" />
-                          블로그
-                        </a>
-                      </TableCell>
-                      <TableCell className="whitespace-nowrap">
-                        <div className="flex items-center gap-1.5">
+                    <div key={member.id} className="border rounded-lg p-3 space-y-2">
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0">
+                          <p className="font-medium truncate">{member.name}</p>
+                          <p className="text-xs text-muted-foreground">{member.discordUsername}</p>
+                        </div>
+                        <div className="flex items-center gap-1 shrink-0">
                           <Badge variant={member.rssConsent ? 'outline' : 'secondary'} className="text-[10px] px-1.5 py-0">
                             RSS {member.rssConsent ? 'ON' : 'OFF'}
                           </Badge>
@@ -360,10 +300,22 @@ export default function AdminMembersPage() {
                             {MEMBER_STATUS_CONFIG[member.status]?.label || member.status}
                           </Badge>
                         </div>
-                      </TableCell>
-                      <TableCell className="text-right">{member.postCount}</TableCell>
-                      <TableCell className="text-right whitespace-nowrap">{member.attendanceRate}%</TableCell>
-                      <TableCell>
+                      </div>
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <PartBadge part={member.part} />
+                        <span className="text-xs text-muted-foreground">포스트 {member.postCount}개</span>
+                        <span className="text-xs text-muted-foreground">출석률 {member.attendanceRate}%</span>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <a
+                          href={member.blogUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center gap-1 text-xs text-primary hover:underline"
+                        >
+                          <ExternalLink className="h-3 w-3" />
+                          블로그
+                        </a>
                         <div className="flex items-center gap-1">
                           <Button
                             variant="ghost"
@@ -381,19 +333,98 @@ export default function AdminMembersPage() {
                             <Trash2 className="h-4 w-4" />
                           </Button>
                         </div>
-                      </TableCell>
-                    </TableRow>
+                      </div>
+                    </div>
                   ))
                 ) : (
-                  <TableRow>
-                    <TableCell colSpan={8} className="text-center py-8 text-muted-foreground">
-                      {searchQuery ? '검색 결과가 없습니다.' : '등록된 멤버가 없습니다.'}
-                    </TableCell>
-                  </TableRow>
+                  <div className="text-center py-8 text-muted-foreground">
+                    {searchQuery ? '검색 결과가 없습니다.' : statusFilter === 'pending_approval' ? '승인 대기 중인 멤버가 없습니다.' : '등록된 멤버가 없습니다.'}
+                  </div>
                 )}
-              </TableBody>
-            </Table>
-          </div>
+              </div>
+
+              {/* Desktop table */}
+              <div className="hidden md:block overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>이름</TableHead>
+                      <TableHead>파트</TableHead>
+                      <TableHead>Discord</TableHead>
+                      <TableHead>블로그</TableHead>
+                      <TableHead>상태</TableHead>
+                      <TableHead className="text-right">포스트</TableHead>
+                      <TableHead className="text-right">출석률</TableHead>
+                      <TableHead className="w-[50px]"></TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {filteredMembers.length > 0 ? (
+                      filteredMembers.map((member) => (
+                        <TableRow key={member.id}>
+                          <TableCell className="font-medium whitespace-nowrap">{member.name}</TableCell>
+                          <TableCell className="whitespace-nowrap">
+                            <PartBadge part={member.part} />
+                          </TableCell>
+                          <TableCell className="text-muted-foreground whitespace-nowrap">
+                            {member.discordUsername}
+                          </TableCell>
+                          <TableCell>
+                            <a
+                              href={member.blogUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="flex items-center gap-1 text-sm text-primary hover:underline"
+                            >
+                              <ExternalLink className="h-3 w-3" />
+                              블로그
+                            </a>
+                          </TableCell>
+                          <TableCell className="whitespace-nowrap">
+                            <div className="flex items-center gap-1.5">
+                              <Badge variant={member.rssConsent ? 'outline' : 'secondary'} className="text-[10px] px-1.5 py-0">
+                                RSS {member.rssConsent ? 'ON' : 'OFF'}
+                              </Badge>
+                              <Badge variant={MEMBER_STATUS_CONFIG[member.status]?.variant || 'secondary'}>
+                                {MEMBER_STATUS_CONFIG[member.status]?.label || member.status}
+                              </Badge>
+                            </div>
+                          </TableCell>
+                          <TableCell className="text-right">{member.postCount}</TableCell>
+                          <TableCell className="text-right whitespace-nowrap">{member.attendanceRate}%</TableCell>
+                          <TableCell>
+                            <div className="flex items-center gap-1">
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => handleEditMember(member)}
+                              >
+                                <Edit className="h-4 w-4" />
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => handleDeleteMember(member)}
+                                disabled={member.status === 'withdrawn'}
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      ))
+                    ) : (
+                      <TableRow>
+                        <TableCell colSpan={8} className="text-center py-8 text-muted-foreground">
+                          {searchQuery ? '검색 결과가 없습니다.' : statusFilter === 'pending_approval' ? '승인 대기 중인 멤버가 없습니다.' : '등록된 멤버가 없습니다.'}
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </TableBody>
+                </Table>
+              </div>
+            </>
+          )}
         </CardContent>
       </Card>
 

--- a/packages/web/src/app/(admin)/admin/members/pending-member-card.tsx
+++ b/packages/web/src/app/(admin)/admin/members/pending-member-card.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useState } from 'react';
+import { ExternalLink, Check, X, ChevronDown } from 'lucide-react';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { PartBadge } from '@/components/ui/part-badge';
+import { getDefaultAvatar } from '@/lib/utils';
+
+interface PendingMember {
+  id: string;
+  name: string;
+  nickname: string;
+  part: string;
+  blogUrl: string;
+  profileImageUrl: string | null;
+  bio: string | null;
+  interests: string[] | null;
+  resolution: string | null;
+  joinedAt: string;
+}
+
+interface PendingMemberCardProps {
+  member: PendingMember;
+  onApprove: (memberId: string, targetStatus: string) => void;
+  onReject: (memberId: string) => void;
+}
+
+export function PendingMemberCard({ member, onApprove, onReject }: PendingMemberCardProps) {
+  const [showStatusSelect, setShowStatusSelect] = useState(false);
+
+  return (
+    <Card className="relative">
+      <CardHeader className="pb-3">
+        <div className="flex items-start gap-3">
+          <img
+            src={member.profileImageUrl || getDefaultAvatar(member.name)}
+            alt={member.name}
+            className="h-12 w-12 rounded-full object-cover"
+          />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span className="font-semibold">{member.name}</span>
+              <span className="text-sm text-muted-foreground">({member.nickname})</span>
+            </div>
+            <div className="flex items-center gap-2 mt-1">
+              <PartBadge part={member.part} />
+              <a
+                href={member.blogUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+              >
+                <ExternalLink className="h-3 w-3" />
+                블로그
+              </a>
+            </div>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {member.bio && (
+          <div>
+            <p className="text-xs font-medium text-muted-foreground mb-1">자기소개</p>
+            <p className="text-sm line-clamp-3">{member.bio}</p>
+          </div>
+        )}
+        {member.interests && member.interests.length > 0 && (
+          <div>
+            <p className="text-xs font-medium text-muted-foreground mb-1">관심사</p>
+            <div className="flex flex-wrap gap-1">
+              {member.interests.map((interest) => (
+                <Badge key={interest} variant="secondary" className="text-xs">
+                  {interest}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
+        {member.resolution && (
+          <div>
+            <p className="text-xs font-medium text-muted-foreground mb-1">각오</p>
+            <p className="text-sm italic text-muted-foreground">&ldquo;{member.resolution}&rdquo;</p>
+          </div>
+        )}
+        <div className="flex items-center gap-2 pt-2 border-t">
+          {showStatusSelect ? (
+            <div className="flex items-center gap-2 w-full">
+              <Button
+                size="sm"
+                onClick={() => { onApprove(member.id, 'active'); setShowStatusSelect(false); }}
+                className="flex-1"
+              >
+                활성으로 승인
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => { onApprove(member.id, 'ob'); setShowStatusSelect(false); }}
+                className="flex-1"
+              >
+                OB로 승인
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => setShowStatusSelect(false)}
+              >
+                취소
+              </Button>
+            </div>
+          ) : (
+            <>
+              <Button
+                size="sm"
+                onClick={() => setShowStatusSelect(true)}
+                className="gap-1"
+              >
+                <Check className="h-3.5 w-3.5" />
+                승인
+                <ChevronDown className="h-3 w-3" />
+              </Button>
+              <Button
+                size="sm"
+                variant="destructive"
+                onClick={() => onReject(member.id)}
+                className="gap-1"
+              >
+                <X className="h-3.5 w-3.5" />
+                거절
+              </Button>
+            </>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/web/src/app/(user)/inactive/page.tsx
+++ b/packages/web/src/app/(user)/inactive/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { ShieldX, LogOut } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export default function InactivePage() {
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    await fetch('/api/auth/logout', { method: 'POST' });
+    router.push('/login');
+    router.refresh();
+  };
+
+  return (
+    <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center p-4">
+      <div className="mx-auto max-w-md text-center space-y-6">
+        <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+          <ShieldX className="h-10 w-10 text-red-500" />
+        </div>
+        <div className="space-y-2">
+          <h1 className="text-2xl font-bold tracking-tight">
+            계정이 비활성화되었습니다
+          </h1>
+          <p className="text-muted-foreground">
+            관리자에 의해 계정이 비활성화되었습니다.<br />
+            자세한 사항은 관리자에게 문의해주세요.
+          </p>
+        </div>
+        <div className="rounded-lg border bg-muted/50 p-4">
+          <p className="text-sm text-muted-foreground">
+            Discord 채널에서 관리자에게 문의하실 수 있습니다.
+          </p>
+        </div>
+        <Button variant="outline" onClick={handleLogout} className="gap-2">
+          <LogOut className="h-4 w-4" />
+          로그아웃
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/app/(user)/layout.tsx
+++ b/packages/web/src/app/(user)/layout.tsx
@@ -18,10 +18,9 @@ export default function UserLayout({
   const router = useRouter();
   const pathname = usePathname();
   const [user, setUser] = useState<UserInfo | null>(null);
-  const [onboardingChecked, setOnboardingChecked] = useState(false);
+  const [checkedPathname, setCheckedPathname] = useState<string | null>(null);
 
   useEffect(() => {
-    setOnboardingChecked(false);
     const fetchUser = async () => {
       try {
         const response = await fetch('/api/auth/me');
@@ -53,10 +52,10 @@ export default function UserLayout({
             imageUrl: data.profileImageUrl || data.avatarUrl,
           });
         }
-        setOnboardingChecked(true);
+        setCheckedPathname(pathname);
       } catch {
         // User not authenticated, middleware will handle redirect
-        setOnboardingChecked(true);
+        setCheckedPathname(pathname);
       }
     };
     fetchUser();
@@ -72,8 +71,8 @@ export default function UserLayout({
     }
   }, [router]);
 
-  // 온보딩 체크 중에는 로딩 표시 (무한루프 방지를 위해 온보딩 페이지는 바로 표시)
-  if (!onboardingChecked && pathname !== '/profile/onboarding') {
+  // 체크 완료 전 로딩 표시 (pathname 변경 시 자동 리셋, 온보딩 페이지는 바로 표시)
+  if (checkedPathname !== pathname && pathname !== '/profile/onboarding') {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <div className="text-muted-foreground">로딩 중...</div>

--- a/packages/web/src/app/(user)/layout.tsx
+++ b/packages/web/src/app/(user)/layout.tsx
@@ -52,9 +52,9 @@ export default function UserLayout({
             imageUrl: data.profileImageUrl || data.avatarUrl,
           });
         }
+        setOnboardingChecked(true);
       } catch {
         // User not authenticated, middleware will handle redirect
-      } finally {
         setOnboardingChecked(true);
       }
     };

--- a/packages/web/src/app/(user)/layout.tsx
+++ b/packages/web/src/app/(user)/layout.tsx
@@ -33,6 +33,19 @@ export default function UserLayout({
             return;
           }
 
+          // 상태별 차단 페이지 리다이렉트 (차단 페이지 자체는 예외)
+          const blockedPages = ['/pending', '/inactive'];
+          if (!blockedPages.includes(pathname)) {
+            if (data.status === 'pending_approval') {
+              router.push('/pending');
+              return;
+            }
+            if (data.status === 'inactive') {
+              router.push('/inactive');
+              return;
+            }
+          }
+
           setUser({
             name: data.name || data.discordUsername || data.email?.split('@')[0] || '',
             email: data.email || '',

--- a/packages/web/src/app/(user)/layout.tsx
+++ b/packages/web/src/app/(user)/layout.tsx
@@ -21,6 +21,7 @@ export default function UserLayout({
   const [onboardingChecked, setOnboardingChecked] = useState(false);
 
   useEffect(() => {
+    setOnboardingChecked(false);
     const fetchUser = async () => {
       try {
         const response = await fetch('/api/auth/me');

--- a/packages/web/src/app/(user)/pending/page.tsx
+++ b/packages/web/src/app/(user)/pending/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { Clock, LogOut } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export default function PendingApprovalPage() {
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    await fetch('/api/auth/logout', { method: 'POST' });
+    router.push('/login');
+    router.refresh();
+  };
+
+  return (
+    <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center p-4">
+      <div className="mx-auto max-w-md text-center space-y-6">
+        <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-sky-100 dark:bg-sky-900/30">
+          <Clock className="h-10 w-10 text-sky-500" />
+        </div>
+        <div className="space-y-2">
+          <h1 className="text-2xl font-bold tracking-tight">
+            관리자 승인 대기 중
+          </h1>
+          <p className="text-muted-foreground">
+            온보딩이 완료되었습니다.<br />
+            관리자가 가입을 확인하면 서비스를 이용하실 수 있습니다.
+          </p>
+        </div>
+        <div className="rounded-lg border bg-muted/50 p-4">
+          <p className="text-sm text-muted-foreground">
+            궁금한 점이 있으시면 Discord 채널에서 관리자에게 문의해주세요.
+          </p>
+        </div>
+        <Button variant="outline" onClick={handleLogout} className="gap-2">
+          <LogOut className="h-4 w-4" />
+          로그아웃
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/app/api/admin/members/[id]/route.ts
+++ b/packages/web/src/app/api/admin/members/[id]/route.ts
@@ -88,7 +88,14 @@ export const PUT = withAdminAuth(async (request: NextRequest, _adminAuth) => {
     }
 
     // Validate status
-    const validStatuses = [MemberStatus.ACTIVE, MemberStatus.DORMANT, MemberStatus.WITHDRAWN];
+    const validStatuses = [
+      MemberStatus.PENDING_APPROVAL,
+      MemberStatus.ACTIVE,
+      MemberStatus.INACTIVE,
+      MemberStatus.DORMANT,
+      MemberStatus.OB,
+      MemberStatus.WITHDRAWN,
+    ];
     if (status !== undefined && !validStatuses.includes(status)) {
       errors.push('유효하지 않은 상태입니다.');
     }

--- a/packages/web/src/app/api/admin/members/route.ts
+++ b/packages/web/src/app/api/admin/members/route.ts
@@ -62,13 +62,13 @@ export const GET = withAdminAuth(async (request: NextRequest, _adminAuth) => {
     );
 
     // Group members by status
-    const groupedMembers: Record<string, typeof result> = {
-      pending_approval: [],
-      active: [],
-      inactive: [],
-      dormant: [],
-      ob: [],
-      withdrawn: [],
+    const groupedMembers = {
+      pending_approval: [] as typeof result,
+      active: [] as typeof result,
+      inactive: [] as typeof result,
+      dormant: [] as typeof result,
+      ob: [] as typeof result,
+      withdrawn: [] as typeof result,
     };
 
     const result = membersList.map((member) => {
@@ -105,7 +105,7 @@ export const GET = withAdminAuth(async (request: NextRequest, _adminAuth) => {
 
     // Group by status
     result.forEach((member) => {
-      const status = member.status;
+      const status = member.status as keyof typeof groupedMembers;
       if (groupedMembers[status]) {
         groupedMembers[status].push(member);
       }

--- a/packages/web/src/app/api/admin/members/route.ts
+++ b/packages/web/src/app/api/admin/members/route.ts
@@ -62,10 +62,13 @@ export const GET = withAdminAuth(async (request: NextRequest, _adminAuth) => {
     );
 
     // Group members by status
-    const groupedMembers = {
-      active: [] as typeof result,
-      dormant: [] as typeof result,
-      withdrawn: [] as typeof result,
+    const groupedMembers: Record<string, typeof result> = {
+      pending_approval: [],
+      active: [],
+      inactive: [],
+      dormant: [],
+      ob: [],
+      withdrawn: [],
     };
 
     const result = membersList.map((member) => {
@@ -79,13 +82,17 @@ export const GET = withAdminAuth(async (request: NextRequest, _adminAuth) => {
         discordId: member.discordId,
         discordUsername: member.discordUsername,
         name: member.name,
+        nickname: member.nickname,
         part: member.part,
         blogUrl: member.blogUrl,
         rssUrl: member.rssUrl,
         profileImageUrl: member.profileImageUrl,
         bio: member.bio,
+        interests: member.interests,
+        resolution: member.resolution,
         rssConsent: member.rssConsent ?? true,
         status: member.status,
+        onboardingCompleted: member.onboardingCompleted,
         dormantUsed: member.dormantUsed,
         dormantStartRound: member.dormantStartRound,
         postCount,
@@ -98,12 +105,9 @@ export const GET = withAdminAuth(async (request: NextRequest, _adminAuth) => {
 
     // Group by status
     result.forEach((member) => {
-      if (member.status === MemberStatus.ACTIVE) {
-        groupedMembers.active.push(member);
-      } else if (member.status === MemberStatus.DORMANT) {
-        groupedMembers.dormant.push(member);
-      } else if (member.status === MemberStatus.WITHDRAWN) {
-        groupedMembers.withdrawn.push(member);
+      const status = member.status;
+      if (groupedMembers[status]) {
+        groupedMembers[status].push(member);
       }
     });
 
@@ -111,8 +115,11 @@ export const GET = withAdminAuth(async (request: NextRequest, _adminAuth) => {
       members: result,
       grouped: groupedMembers,
       counts: {
+        pending_approval: groupedMembers.pending_approval.length,
         active: groupedMembers.active.length,
+        inactive: groupedMembers.inactive.length,
         dormant: groupedMembers.dormant.length,
+        ob: groupedMembers.ob.length,
         withdrawn: groupedMembers.withdrawn.length,
         total: result.length,
       },

--- a/packages/web/src/app/api/auth/me/route.ts
+++ b/packages/web/src/app/api/auth/me/route.ts
@@ -58,6 +58,7 @@ export async function GET() {
       discordId,
       hasMemberRecord: !!memberData,
       onboardingCompleted: memberData?.onboardingCompleted ?? false,
+      status: memberData?.status ?? null,
     });
   } catch (error) {
     console.error('Get user error:', error);

--- a/packages/web/src/app/api/profile/onboarding/route.ts
+++ b/packages/web/src/app/api/profile/onboarding/route.ts
@@ -188,7 +188,7 @@ export async function POST(request: NextRequest) {
           instagramUrl: instagramUrl || null,
           rssConsent: rssConsent !== false,
           onboardingCompleted: true,
-          status: 'active',
+          status: 'pending_approval',
         });
     }
 

--- a/packages/web/src/app/auth/callback/route.ts
+++ b/packages/web/src/app/auth/callback/route.ts
@@ -52,19 +52,32 @@ export async function GET(request: Request) {
     if (discordId) {
       const database = db();
       const [memberData] = await database
-        .select({ onboardingCompleted: members.onboardingCompleted })
+        .select({
+          onboardingCompleted: members.onboardingCompleted,
+          status: members.status,
+        })
         .from(members)
         .where(eq(members.discordId, discordId))
         .limit(1);
 
       console.log(
-        `[auth/callback] 멤버 조회: ${memberData ? `onboarding=${memberData.onboardingCompleted}` : '레코드 없음'}`
+        `[auth/callback] 멤버 조회: ${memberData ? `onboarding=${memberData.onboardingCompleted}, status=${memberData.status}` : '레코드 없음'}`
       );
 
       // 멤버 레코드가 없거나 온보딩 미완료 → 온보딩으로
       if (!memberData || !memberData.onboardingCompleted) {
         console.log('[auth/callback] → /profile/onboarding 리다이렉트');
         return NextResponse.redirect(`${origin}/profile/onboarding`);
+      }
+
+      // 상태별 리다이렉트
+      if (memberData.status === 'pending_approval') {
+        console.log('[auth/callback] → /pending 리다이렉트 (승인대기)');
+        return NextResponse.redirect(`${origin}/pending`);
+      }
+      if (memberData.status === 'inactive') {
+        console.log('[auth/callback] → /inactive 리다이렉트 (비활성)');
+        return NextResponse.redirect(`${origin}/inactive`);
       }
     } else {
       // Discord ID가 없는 경우 (일반적이지 않지만) → 온보딩으로

--- a/packages/web/src/lib/member-config.ts
+++ b/packages/web/src/lib/member-config.ts
@@ -1,5 +1,8 @@
-export const MEMBER_STATUS_CONFIG: Record<string, { label: string; variant: 'default' | 'secondary' | 'destructive' }> = {
+export const MEMBER_STATUS_CONFIG: Record<string, { label: string; variant: 'default' | 'secondary' | 'destructive' | 'outline' | 'warning' }> = {
+  pending_approval: { label: '승인대기', variant: 'warning' },
   active: { label: '활성', variant: 'default' },
+  inactive: { label: '비활성', variant: 'destructive' },
   dormant: { label: '휴면', variant: 'secondary' },
+  ob: { label: 'OB', variant: 'outline' },
   withdrawn: { label: '탈퇴', variant: 'destructive' },
 };


### PR DESCRIPTION
## Summary

온보딩 완료 후 관리자 승인이 필요한 멤버 승인 워크플로우와 6단계 상태 관리 시스템을 구축합니다.

- 신규 가입자는 온보딩 후 `pending_approval` 상태로 설정, 관리자 승인 전까지 플랫폼 접근 차단
- 관리자 멤버 관리 페이지를 탭 기반 UI로 전면 개편, 승인/거절/상태변경 기능 추가
- 6개 상태: `pending_approval` · `active` · `inactive` · `dormant` · `ob` · `withdrawn`

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `packages/shared/src/db/schema.ts` | MemberStatus enum에 `pending_approval`, `inactive`, `ob` 추가 |
| `packages/web/src/lib/member-config.ts` | 6개 상태 설정 (label, badge variant) |
| `packages/web/src/app/api/auth/me/route.ts` | 응답에 `status` 필드 추가 |
| `packages/web/src/app/api/profile/onboarding/route.ts` | 신규 유저 INSERT 시 `pending_approval` 설정 |
| `packages/web/src/app/auth/callback/route.ts` | 상태별 리다이렉트 (pending→/pending, inactive→/inactive) |
| `packages/web/src/app/(user)/layout.tsx` | UserLayout에 상태 기반 차단 리다이렉트 추가 |
| `packages/web/src/app/(user)/pending/page.tsx` | **신규** 승인대기 전용 페이지 |
| `packages/web/src/app/(user)/inactive/page.tsx` | **신규** 비활성 전용 페이지 |
| `packages/web/src/app/api/admin/members/route.ts` | GET 그룹핑/카운트 6개 상태 확장 + 프로필 필드 추가 |
| `packages/web/src/app/api/admin/members/[id]/route.ts` | PUT validStatuses 6개로 확장 |
| `packages/web/src/app/(admin)/admin/members/page.tsx` | 탭 기반 필터 UI + 승인/거절 핸들러 + Member 인터페이스 확장 |
| `packages/web/src/app/(admin)/admin/members/pending-member-card.tsx` | **신규** 승인대기 멤버 카드 (2단계 승인: active/ob 선택) |
| `packages/web/src/app/(admin)/admin/members/member-form-dialog.tsx` | 편집 모드에서 상태 변경 select 추가 |

## Design Decisions

| 결정 | 이유 |
|------|------|
| `pending_approval` 상태 시 완전 차단 | 승인 전 데이터 접근 방지, UX 명확성 |
| 2단계 승인 UX (승인 클릭 → active/ob 선택) | OB 유저를 바로 배정할 수 있도록 |
| 탭 기반 필터 (카드 대신 pill 버튼) | 6개 상태를 깔끔하게 표시, 모바일 대응 |
| `inactive`도 완전 차단 | 비활성 유저의 불필요한 접근 방지 |
| `dormant`, `ob`는 모든 기능 허용 | 출석/벌금만 제외, 플랫폼 참여는 유지 |

## Test Plan

- [x] 온보딩 완료 시 `pending_approval` 상태 확인
- [x] pending_approval 유저 로그인 → /pending 페이지 표시 확인
- [x] inactive 유저 로그인 → /inactive 페이지 표시 확인
- [x] 관리자 멤버 페이지에서 탭 필터 동작 확인
- [x] 승인대기 탭에서 카드 UI + 승인(active/ob)/거절 동작 확인
- [x] 멤버 편집 다이얼로그에서 상태 변경 동작 확인
- [x] active/dormant/ob 유저는 정상 접근 확인
- [x] `pnpm build` 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)