### PR TITLE
feat: 큐레이션 페이지 리디자인 + 2차 개선

### DIFF
--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -244,6 +244,8 @@ export const curationItems = pgTable(
     sourceId: uuid('source_id').references(() => curationSources.id),
     title: varchar('title', { length: 500 }).notNull(),
     url: varchar('url', { length: 1000 }).notNull().unique(),
+    description: text('description'),
+    thumbnailUrl: varchar('thumbnail_url', { length: 1000 }),
     publishedAt: timestamp('published_at', { withTimezone: true }),
     category: varchar('category', { length: 50 }).notNull(),
     tags: text('tags').array(),
@@ -254,6 +256,7 @@ export const curationItems = pgTable(
   },
   (table) => ({
     isSharedIdx: index('idx_curation_items_is_shared').on(table.isShared),
+    publishedAtIdx: index('idx_curation_items_published_at').on(table.publishedAt),
   })
 );
 

--- a/packages/web/next-env.d.ts
+++ b/packages/web/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/web/next-env.d.ts
+++ b/packages/web/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts';
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/web/src/app/(user)/curation/page.tsx
+++ b/packages/web/src/app/(user)/curation/page.tsx
@@ -70,12 +70,14 @@ interface ThumbnailProps {
 
 function Thumbnail({ src, title, category, className = '' }: ThumbnailProps) {
   const [failed, setFailed] = useState(false);
+  const [prevSrc, setPrevSrc] = useState(src);
   const gradient = useMemo(() => getArticleGradient(title), [title]);
   const catStyle = CATEGORY_STYLES[category] ?? CATEGORY_STYLES['article']!;
 
-  useEffect(() => {
+  if (src !== prevSrc) {
+    setPrevSrc(src);
     setFailed(false);
-  }, [src]);
+  }
 
   if (!src || failed) {
     return (

--- a/packages/web/src/app/(user)/curation/page.tsx
+++ b/packages/web/src/app/(user)/curation/page.tsx
@@ -1,17 +1,23 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
-import { ExternalLink, Calendar, Sparkles, X, ChevronLeft, ChevronRight } from 'lucide-react';
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { ExternalLink, Sparkles, X } from 'lucide-react';
 import { INTEREST_OPTIONS } from '@blog-study/shared/config';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { PageError } from '@/components/ui/page-state';
-import { TagList } from '@/components/ui/tag-list';
+import { getArticleGradient, formatRelativeDate, CATEGORY_STYLES } from '@/lib/curation-utils';
+
+// ─────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────
 
 interface CurationItem {
   id: string;
   title: string;
   url: string;
+  description: string | null;
+  thumbnailUrl: string | null;
   publishedAt: string | null;
   category: string;
   tags: string[] | null;
@@ -22,44 +28,16 @@ interface CurationItem {
 
 interface CurationData {
   items: CurationItem[];
+  nextCursor: string | null;
+  hasMore: boolean;
   totalCount: number;
-  pagination: {
-    page: number;
-    limit: number;
-    totalPages: number;
-  };
 }
 
 type FilterValue = 'all' | 'conference' | 'article';
 
-const CATEGORY_STYLES: Record<string, { label: string; bg: string; text: string; ring: string }> = {
-  conference: {
-    label: '컨퍼런스',
-    bg: 'bg-violet-100 dark:bg-violet-500/20',
-    text: 'text-violet-700 dark:text-violet-300',
-    ring: 'ring-violet-200 dark:ring-violet-500/30',
-  },
-  article: {
-    label: '아티클',
-    bg: 'bg-sky-100 dark:bg-sky-500/20',
-    text: 'text-sky-700 dark:text-sky-300',
-    ring: 'ring-sky-200 dark:ring-sky-500/30',
-  },
-};
-
-function formatDate(dateStr: string | null) {
-  if (!dateStr) return null;
-  const date = new Date(dateStr);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
-  if (diffDays === 0) return '오늘';
-  if (diffDays === 1) return '어제';
-  if (diffDays < 7) return `${diffDays}일 전`;
-  if (diffDays < 30) return `${Math.floor(diffDays / 7)}주 전`;
-  return date.toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' });
-}
+// ─────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────
 
 const FILTERS: { value: FilterValue; label: string; emoji: string }[] = [
   { value: 'all', label: '전체', emoji: '📚' },
@@ -68,313 +46,554 @@ const FILTERS: { value: FilterValue; label: string; emoji: string }[] = [
 ];
 
 const MAX_TAGS = 4;
+const PAGE_SIZE = 12;
+
+// ─────────────────────────────────────────────
+// Thumbnail — img with gradient fallback
+// ─────────────────────────────────────────────
+
+interface ThumbnailProps {
+  src: string | null;
+  title: string;
+  category: string;
+  className?: string;
+}
+
+function Thumbnail({ src, title, category, className = '' }: ThumbnailProps) {
+  const [failed, setFailed] = useState(false);
+  const gradient = getArticleGradient(title);
+  const catStyle = CATEGORY_STYLES[category] ?? CATEGORY_STYLES['article']!;
+
+  if (!src || failed) {
+    return (
+      <div
+        className={`bg-gradient-to-br ${gradient} flex items-center justify-center ${className}`}
+        aria-hidden="true"
+      >
+        <span className="text-2xl select-none">{catStyle.emoji}</span>
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      alt={title}
+      loading="lazy"
+      onError={() => setFailed(true)}
+      className={`object-cover ${className}`}
+    />
+  );
+}
+
+// ─────────────────────────────────────────────
+// CurationCard — mobile / tablet
+// ─────────────────────────────────────────────
+
+function CurationCard({ item }: { item: CurationItem }) {
+  const catStyle = CATEGORY_STYLES[item.category] ?? CATEGORY_STYLES['article']!;
+  const relativeDate = formatRelativeDate(item.publishedAt);
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group flex flex-col rounded-xl border border-border/60 bg-card overflow-hidden
+        hover:border-primary/30 hover:shadow-md transition-all duration-200"
+    >
+      {/* 16:9 thumbnail */}
+      <div className="aspect-video w-full overflow-hidden bg-muted">
+        <Thumbnail
+          src={item.thumbnailUrl}
+          title={item.title}
+          category={item.category}
+          className="w-full h-full"
+        />
+      </div>
+
+      {/* Body */}
+      <div className="flex flex-col flex-1 gap-2 p-3">
+        {/* Badges */}
+        <div className="flex items-center gap-1.5 flex-wrap">
+          <span
+            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset
+              ${catStyle.bg} ${catStyle.text} ${catStyle.ring}`}
+          >
+            {catStyle.label}
+          </span>
+          {item.sharedAt && (
+            <span className="inline-flex items-center gap-0.5 rounded-full px-2 py-0.5 text-xs font-medium
+              bg-emerald-100 text-emerald-700 ring-1 ring-inset ring-emerald-200
+              dark:bg-emerald-500/20 dark:text-emerald-300 dark:ring-emerald-500/30">
+              <Sparkles className="h-3 w-3" />
+              공유됨
+            </span>
+          )}
+        </div>
+
+        {/* Title */}
+        <h3 className="text-sm font-medium text-foreground line-clamp-2 leading-snug
+          group-hover:text-primary transition-colors">
+          {item.title}
+        </h3>
+
+        {/* Description */}
+        {item.description && (
+          <p className="text-xs text-muted-foreground line-clamp-3 leading-relaxed">
+            {item.description}
+          </p>
+        )}
+
+        {/* Footer */}
+        <div className="flex items-center justify-between mt-auto pt-1">
+          <div className="flex items-center gap-1 text-xs text-muted-foreground min-w-0">
+            {item.sourceName && (
+              <span className="font-medium truncate max-w-[80px]">{item.sourceName}</span>
+            )}
+            {item.sourceName && relativeDate && <span>·</span>}
+            {relativeDate && <span className="shrink-0">{relativeDate}</span>}
+          </div>
+          <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50 group-hover:text-primary transition-colors ml-2" />
+        </div>
+      </div>
+    </a>
+  );
+}
+
+// ─────────────────────────────────────────────
+// CurationListRow — desktop list feed
+// ─────────────────────────────────────────────
+
+function CurationListRow({ item }: { item: CurationItem }) {
+  const catStyle = CATEGORY_STYLES[item.category] ?? CATEGORY_STYLES['article']!;
+  const relativeDate = formatRelativeDate(item.publishedAt);
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group flex items-start gap-4 py-4 px-3 -mx-3 rounded-lg
+        hover:bg-muted/40 transition-colors duration-150"
+    >
+      {/* Thumbnail */}
+      <div className="w-[100px] h-[64px] shrink-0 rounded-md overflow-hidden bg-muted">
+        <Thumbnail
+          src={item.thumbnailUrl}
+          title={item.title}
+          category={item.category}
+          className="w-full h-full"
+        />
+      </div>
+
+      {/* Content */}
+      <div className="flex flex-col flex-1 min-w-0 gap-1.5">
+        {/* Title */}
+        <h3 className="text-sm font-medium text-foreground line-clamp-2 leading-snug
+          group-hover:text-primary transition-colors">
+          {item.title}
+        </h3>
+
+        {/* Description */}
+        {item.description && (
+          <p className="text-xs text-muted-foreground line-clamp-2 leading-relaxed">
+            {item.description}
+          </p>
+        )}
+
+        {/* Footer meta */}
+        <div className="flex items-center gap-2 flex-wrap mt-0.5">
+          <span
+            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset
+              ${catStyle.bg} ${catStyle.text} ${catStyle.ring}`}
+          >
+            {catStyle.label}
+          </span>
+          {item.sharedAt && (
+            <span className="inline-flex items-center gap-0.5 rounded-full px-2 py-0.5 text-xs font-medium
+              bg-emerald-100 text-emerald-700 ring-1 ring-inset ring-emerald-200
+              dark:bg-emerald-500/20 dark:text-emerald-300 dark:ring-emerald-500/30">
+              <Sparkles className="h-3 w-3" />
+              공유됨
+            </span>
+          )}
+          {item.sourceName && (
+            <span className="text-xs text-muted-foreground font-medium">{item.sourceName}</span>
+          )}
+          {relativeDate && (
+            <span className="text-xs text-muted-foreground">{relativeDate}</span>
+          )}
+        </div>
+      </div>
+
+      {/* External link icon */}
+      <ExternalLink className="h-4 w-4 shrink-0 text-muted-foreground/40 group-hover:text-primary transition-colors mt-0.5" />
+    </a>
+  );
+}
+
+// ─────────────────────────────────────────────
+// CardSkeleton
+// ─────────────────────────────────────────────
+
+function CardSkeleton() {
+  return (
+    <div className="rounded-xl border border-border/60 bg-card overflow-hidden animate-pulse">
+      {/* thumbnail placeholder */}
+      <div className="aspect-video w-full bg-muted" />
+      <div className="flex flex-col gap-2 p-3">
+        <div className="h-4 w-16 bg-muted rounded-full" />
+        <div className="space-y-1.5">
+          <div className="h-4 w-full bg-muted rounded" />
+          <div className="h-4 w-3/4 bg-muted rounded" />
+        </div>
+        <div className="space-y-1">
+          <div className="h-3 w-full bg-muted rounded" />
+          <div className="h-3 w-5/6 bg-muted rounded" />
+          <div className="h-3 w-4/6 bg-muted rounded" />
+        </div>
+        <div className="flex items-center justify-between pt-1">
+          <div className="h-3 w-20 bg-muted rounded" />
+          <div className="h-3.5 w-3.5 bg-muted rounded" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
+// ListRowSkeleton
+// ─────────────────────────────────────────────
+
+function ListRowSkeleton() {
+  return (
+    <div className="flex items-start gap-4 py-4 px-3 -mx-3 animate-pulse">
+      <div className="w-[100px] h-[64px] shrink-0 rounded-md bg-muted" />
+      <div className="flex flex-col flex-1 min-w-0 gap-1.5">
+        <div className="h-4 w-3/4 bg-muted rounded" />
+        <div className="h-4 w-full bg-muted rounded" />
+        <div className="flex items-center gap-2 mt-0.5">
+          <div className="h-4 w-14 bg-muted rounded-full" />
+          <div className="h-3 w-16 bg-muted rounded" />
+          <div className="h-3 w-10 bg-muted rounded" />
+        </div>
+      </div>
+      <div className="h-4 w-4 shrink-0 bg-muted rounded" />
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
+// Main: CurationPage
+// ─────────────────────────────────────────────
 
 export default function CurationPage() {
-  const [data, setData] = useState<CurationData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [filter, setFilter] = useState<FilterValue>('all');
-  const [selectedTags, setSelectedTags] = useState<string[]>([]);
-  const [page, setPage] = useState(1);
+  const router = useRouter();
+  const searchParams = useSearchParams();
 
-  const fetchCuration = useCallback(async (cat: FilterValue, tags: string[], p: number) => {
-    setLoading(true);
+  // Derive filter state from URL
+  const categoryParam = searchParams.get('category') as FilterValue | null;
+  const tagsParam = searchParams.get('tags');
+  const category: FilterValue = categoryParam && ['all', 'conference', 'article'].includes(categoryParam)
+    ? categoryParam
+    : 'all';
+  const selectedTags: string[] = tagsParam
+    ? tagsParam.split(',').filter(Boolean)
+    : [];
+
+  // Local state
+  const [items, setItems] = useState<CurationItem[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Sentinel ref for IntersectionObserver
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  // Keep a ref to avoid stale closure in observer callback
+  const hasMoreRef = useRef(hasMore);
+  const loadingMoreRef = useRef(loadingMore);
+  hasMoreRef.current = hasMore;
+  loadingMoreRef.current = loadingMore;
+
+  // ── Fetch ──
+  const fetchItems = useCallback(async (
+    cat: FilterValue,
+    tags: string[],
+    cursorArg: string | null,
+    append: boolean
+  ) => {
+    if (append) {
+      setLoadingMore(true);
+    } else {
+      setLoading(true);
+      setError(null);
+    }
+
     try {
-      const params = new URLSearchParams({ category: cat, page: String(p), limit: '12' });
-      if (tags.length > 0) {
-        params.set('tags', tags.join(','));
-      }
+      const params = new URLSearchParams({
+        category: cat,
+        limit: String(PAGE_SIZE),
+      });
+      if (tags.length > 0) params.set('tags', tags.join(','));
+      if (cursorArg) params.set('cursor', cursorArg);
+
       const response = await fetch(`/api/curation?${params}`);
       if (!response.ok) throw new Error('Failed to fetch curation data');
       const result = await response.json();
-      setData(result.data);
+      const data: CurationData = result.data;
+
+      if (append) {
+        setItems((prev) => [...prev, ...data.items]);
+      } else {
+        setItems(data.items);
+        setTotalCount(data.totalCount);
+      }
+      setHasMore(data.hasMore);
+      setCursor(data.nextCursor);
     } catch (err) {
       setError('큐레이션 데이터를 불러오는데 실패했습니다.');
       console.error(err);
     } finally {
       setLoading(false);
+      setLoadingMore(false);
     }
   }, []);
 
+  // ── Initial / filter-change fetch ──
   useEffect(() => {
-    fetchCuration(filter, selectedTags, page);
-  }, [filter, selectedTags, page, fetchCuration]);
+    setItems([]);
+    setCursor(null);
+    setHasMore(false);
+    fetchItems(category, selectedTags, null, false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [category, tagsParam, fetchItems]);
+
+  // ── IntersectionObserver for infinite scroll ──
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry?.isIntersecting && hasMoreRef.current && !loadingMoreRef.current) {
+          fetchItems(category, selectedTags, cursor, true);
+        }
+      },
+      { rootMargin: '400px' }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+    // cursor changes should re-bind observer so we can load the next page
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cursor, category, tagsParam, fetchItems]);
+
+  // ── URL sync helpers ──
+  const updateFilters = (newCategory: FilterValue, newTags: string[]) => {
+    const params = new URLSearchParams();
+    if (newCategory !== 'all') params.set('category', newCategory);
+    if (newTags.length > 0) params.set('tags', newTags.join(','));
+    const qs = params.toString();
+    router.push(`/curation${qs ? `?${qs}` : ''}`, { scroll: false });
+  };
 
   const handleFilterChange = (value: FilterValue) => {
-    setFilter(value);
-    setPage(1);
+    updateFilters(value, selectedTags);
   };
 
   const handleTagToggle = (tag: string) => {
-    setSelectedTags((prev) => {
-      if (prev.includes(tag)) {
-        return prev.filter((t) => t !== tag);
-      }
-      if (prev.length >= MAX_TAGS) return prev;
-      return [...prev, tag];
-    });
-    setPage(1);
+    const next = selectedTags.includes(tag)
+      ? selectedTags.filter((t) => t !== tag)
+      : selectedTags.length >= MAX_TAGS
+        ? selectedTags
+        : [...selectedTags, tag];
+    updateFilters(category, next);
   };
 
   const clearTags = () => {
-    setSelectedTags([]);
-    setPage(1);
+    updateFilters(category, []);
   };
 
-  if (error) {
+  // ── Error state ──
+  if (error && items.length === 0) {
     return <PageError message={error} />;
   }
 
+  const showInitialSkeletons = loading && items.length === 0;
+
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="space-y-1">
+    <div className="space-y-0">
+      {/* ── Header ── */}
+      <div className="space-y-1 pb-4">
         <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
           Curation
         </p>
         <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-2">
           <h1 className="text-xl font-semibold text-foreground">큐레이션</h1>
-          <span className="text-sm text-muted-foreground">
-            {data?.totalCount ?? 0}개의 콘텐츠
-          </span>
+          {!loading && (
+            <span className="text-sm text-muted-foreground">
+              {totalCount}개의 콘텐츠
+            </span>
+          )}
         </div>
       </div>
 
-      {/* Category Filter Pills */}
-      <div className="flex flex-wrap gap-2">
-        {FILTERS.map(({ value, label, emoji }) => (
-          <button
-            key={value}
-            onClick={() => handleFilterChange(value)}
-            className={`
-              inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-sm font-medium
-              transition-all duration-200
-              ${filter === value
-                ? 'bg-foreground text-background shadow-sm scale-105'
-                : 'bg-muted text-muted-foreground hover:bg-muted/80 hover:scale-[1.02]'
-              }
-            `}
-          >
-            <span>{emoji}</span>
-            {label}
-          </button>
-        ))}
-      </div>
+      {/* ── Sticky filter bar ── */}
+      <div
+        className="sticky top-14 z-20 bg-background/95 backdrop-blur-sm border-b border-border/60
+          -mx-4 sm:-mx-6 lg:-mx-8 px-4 sm:px-6 lg:px-8 py-3 space-y-2.5"
+      >
+        {/* Category pills */}
+        <div className="flex items-center gap-2 flex-wrap">
+          {FILTERS.map(({ value, label, emoji }) => (
+            <button
+              key={value}
+              onClick={() => handleFilterChange(value)}
+              className={`inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-sm font-medium
+                transition-all duration-200
+                ${category === value
+                  ? 'bg-foreground text-background shadow-sm scale-105'
+                  : 'bg-muted text-muted-foreground hover:bg-muted/80 hover:scale-[1.02]'
+                }`}
+            >
+              <span>{emoji}</span>
+              {label}
+            </button>
+          ))}
+        </div>
 
-      {/* Tag Filter — INTEREST_OPTIONS 기반 */}
-      <div className="space-y-2">
+        {/* Tag chips */}
         <div className="flex items-center gap-2">
-          <span className="text-xs font-medium text-muted-foreground">
-            관심 태그 필터
+          {/* Label + clear */}
+          <div className="flex items-center gap-1.5 shrink-0">
+            <span className="text-xs font-medium text-muted-foreground">
+              태그
+              {selectedTags.length > 0 && (
+                <span className="ml-1 text-foreground">({selectedTags.length}/{MAX_TAGS})</span>
+              )}
+            </span>
             {selectedTags.length > 0 && (
-              <span className="ml-1 text-foreground">
-                ({selectedTags.length}/{MAX_TAGS})
-              </span>
+              <button
+                onClick={clearTags}
+                className="inline-flex items-center gap-0.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                aria-label="태그 필터 초기화"
+              >
+                <X className="h-3 w-3" />
+                <span className="hidden sm:inline">초기화</span>
+              </button>
             )}
-          </span>
-          {selectedTags.length > 0 && (
-            <button
-              onClick={clearTags}
-              className="inline-flex items-center gap-0.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
-              <X className="h-3 w-3" />
-              초기화
-            </button>
-          )}
-        </div>
-        <div className="flex flex-wrap gap-1.5">
-          {INTEREST_OPTIONS.map((tag) => (
-            <Badge
-              key={tag}
-              variant={selectedTags.includes(tag) ? 'default' : 'outline'}
-              className={`cursor-pointer transition-colors text-xs ${
-                !selectedTags.includes(tag) && selectedTags.length >= MAX_TAGS
-                  ? 'opacity-50 cursor-not-allowed'
-                  : ''
-              }`}
-              onClick={() => handleTagToggle(tag)}
-            >
-              {tag}
-            </Badge>
-          ))}
+          </div>
+
+          {/* Mobile: horizontal scroll / PC: wrap */}
+          <div className="flex gap-1.5 overflow-x-auto scrollbar-hide lg:flex-wrap">
+            {INTEREST_OPTIONS.map((tag) => {
+              const isSelected = selectedTags.includes(tag);
+              const isDisabled = !isSelected && selectedTags.length >= MAX_TAGS;
+              return (
+                <Badge
+                  key={tag}
+                  variant={isSelected ? 'default' : 'outline'}
+                  className={`cursor-pointer transition-colors text-xs shrink-0
+                    ${isDisabled ? 'opacity-40 cursor-not-allowed' : ''}`}
+                  onClick={() => !isDisabled && handleTagToggle(tag)}
+                >
+                  {tag}
+                </Badge>
+              );
+            })}
+          </div>
         </div>
       </div>
 
-      {/* Loading Skeleton */}
-      {loading ? (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {Array.from({ length: 6 }).map((_, i) => (
-            <div
-              key={i}
-              className="rounded-xl border border-border/60 p-5 space-y-3 animate-pulse"
-            >
-              <div className="h-5 w-16 bg-muted rounded-full" />
-              <div className="space-y-2">
-                <div className="h-4 bg-muted rounded w-full" />
-                <div className="h-4 bg-muted rounded w-3/4" />
-              </div>
-              <div className="flex gap-1.5">
-                <div className="h-5 w-12 bg-muted rounded-full" />
-                <div className="h-5 w-14 bg-muted rounded-full" />
-              </div>
+      {/* ── Content area ── */}
+      <div className="pt-4">
+        {showInitialSkeletons ? (
+          <>
+            {/* Card skeletons — mobile/tablet */}
+            <div className="grid gap-3 sm:grid-cols-2 lg:hidden">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <CardSkeleton key={i} />
+              ))}
             </div>
-          ))}
-        </div>
-      ) : data?.items && data.items.length > 0 ? (
-        /* Card Grid */
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {data.items.map((item) => {
-            const catStyle = CATEGORY_STYLES[item.category] ?? CATEGORY_STYLES['article']!;
-            return (
-              <a
-                key={item.id}
-                href={item.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="group relative rounded-xl border border-border/60 p-5 space-y-3
-                  hover:border-primary/30 hover:shadow-md hover:-translate-y-0.5
-                  transition-all duration-200 bg-card"
+            {/* List skeletons — desktop */}
+            <div className="hidden lg:block divide-y divide-border/40">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <ListRowSkeleton key={i} />
+              ))}
+            </div>
+          </>
+        ) : items.length > 0 ? (
+          <>
+            {/* Card grid — mobile / tablet */}
+            <div className="grid gap-3 sm:grid-cols-2 lg:hidden">
+              {items.map((item) => (
+                <CurationCard key={item.id} item={item} />
+              ))}
+            </div>
+
+            {/* List feed — desktop */}
+            <div className="hidden lg:block divide-y divide-border/40">
+              {items.map((item) => (
+                <CurationListRow key={item.id} item={item} />
+              ))}
+            </div>
+          </>
+        ) : !loading ? (
+          /* Empty state */
+          <div className="flex flex-col items-center justify-center py-16 gap-3">
+            <div className="text-5xl">{selectedTags.length > 0 ? '🔍' : '📭'}</div>
+            <p className="text-sm text-muted-foreground">
+              {selectedTags.length > 0
+                ? '선택한 태그에 맞는 콘텐츠가 없어요'
+                : '아직 큐레이션된 콘텐츠가 없어요'}
+            </p>
+            {selectedTags.length > 0 && (
+              <button
+                onClick={clearTags}
+                className="text-xs text-primary hover:underline"
               >
-                {/* Category Badge + Shared */}
-                <div className="flex items-center gap-1.5">
-                  <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ring-inset ${catStyle.bg} ${catStyle.text} ${catStyle.ring}`}>
-                    {catStyle.label}
-                  </span>
-                  {item.sharedAt && (
-                    <span className="inline-flex items-center gap-0.5 rounded-full px-2 py-0.5 text-xs font-medium bg-emerald-100 text-emerald-700 ring-1 ring-inset ring-emerald-200 dark:bg-emerald-500/20 dark:text-emerald-300 dark:ring-emerald-500/30">
-                      <Sparkles className="h-3 w-3" />
-                      공유됨
-                    </span>
-                  )}
-                </div>
-
-                {/* Title */}
-                <h3 className="text-sm font-medium text-foreground line-clamp-2 group-hover:text-primary transition-colors leading-relaxed">
-                  {item.title}
-                </h3>
-
-                {/* Tags */}
-                {item.tags && item.tags.length > 0 && (
-                  <TagList tags={item.tags} />
-                )}
-
-                {/* Footer: source + date + link icon */}
-                <div className="flex items-center justify-between pt-1">
-                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                    {item.sourceName && (
-                      <span className="font-medium">{item.sourceName}</span>
-                    )}
-                    {item.sourceName && item.publishedAt && (
-                      <span>·</span>
-                    )}
-                    {item.publishedAt && (
-                      <div className="flex items-center gap-1">
-                        <Calendar className="h-3 w-3" />
-                        <span>{formatDate(item.publishedAt)}</span>
-                      </div>
-                    )}
-                  </div>
-                  <ExternalLink className="h-3.5 w-3.5 text-muted-foreground/50 group-hover:text-primary transition-colors" />
-                </div>
-              </a>
-            );
-          })}
-        </div>
-      ) : (
-        /* Empty State */
-        <div className="flex flex-col items-center justify-center py-16 gap-3">
-          <div className="text-5xl">{selectedTags.length > 0 ? '🔍' : '📭'}</div>
-          <p className="text-sm text-muted-foreground">
-            {selectedTags.length > 0
-              ? '선택한 태그에 맞는 콘텐츠가 없어요'
-              : '아직 큐레이션된 콘텐츠가 없어요'}
-          </p>
-          {selectedTags.length > 0 && (
-            <button
-              onClick={clearTags}
-              className="text-xs text-primary hover:underline"
-            >
-              태그 필터 초기화
-            </button>
-          )}
-        </div>
-      )}
-
-      {/* Pagination */}
-      {data && data.pagination.totalPages > 1 && (() => {
-        const total = data.pagination.totalPages;
-        const maxVisible = 10;
-        let start = Math.max(1, page - Math.floor(maxVisible / 2));
-        const end = Math.min(total, start + maxVisible - 1);
-        if (end - start + 1 < maxVisible) {
-          start = Math.max(1, end - maxVisible + 1);
-        }
-        const pages = Array.from({ length: end - start + 1 }, (_, i) => start + i);
-
-        return (
-          <div className="flex flex-wrap items-center justify-center gap-1 pt-2">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              disabled={page <= 1}
-              onClick={() => setPage((p) => p - 1)}
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </Button>
-            {start > 1 && (
-              <>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-8 w-8 p-0"
-                  onClick={() => setPage(1)}
-                >
-                  1
-                </Button>
-                {start > 2 && (
-                  <span className="text-xs text-muted-foreground px-1">...</span>
-                )}
-              </>
+                태그 필터 초기화
+              </button>
             )}
-            {pages.map((p) => (
-              <Button
-                key={p}
-                variant={p === page ? 'default' : 'ghost'}
-                size="sm"
-                className="h-8 w-8 p-0"
-                onClick={() => setPage(p)}
-              >
-                {p}
-              </Button>
-            ))}
-            {end < total && (
-              <>
-                {end < total - 1 && (
-                  <span className="text-xs text-muted-foreground px-1">...</span>
-                )}
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-8 w-8 p-0"
-                  onClick={() => setPage(total)}
-                >
-                  {total}
-                </Button>
-              </>
-            )}
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              disabled={page >= total}
-              onClick={() => setPage((p) => p + 1)}
-            >
-              <ChevronRight className="h-4 w-4" />
-            </Button>
           </div>
-        );
-      })()}
+        ) : null}
+
+        {/* Load-more skeletons */}
+        {loadingMore && (
+          <>
+            <div className="grid gap-3 sm:grid-cols-2 lg:hidden mt-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <CardSkeleton key={i} />
+              ))}
+            </div>
+            <div className="hidden lg:block divide-y divide-border/40">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <ListRowSkeleton key={i} />
+              ))}
+            </div>
+          </>
+        )}
+
+        {/* Sentinel — IntersectionObserver target */}
+        <div ref={sentinelRef} className="h-px" aria-hidden="true" />
+
+        {/* End indicator */}
+        {!hasMore && !loading && items.length > 0 && (
+          <div className="flex flex-col items-center gap-1.5 py-10 text-center">
+            <p className="text-sm font-medium text-foreground">
+              {totalCount}개 모두 확인했어요
+            </p>
+            <p className="text-xs text-muted-foreground">
+              새 콘텐츠는 매일 업데이트됩니다
+            </p>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/web/src/app/(user)/curation/page.tsx
+++ b/packages/web/src/app/(user)/curation/page.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { ExternalLink, Sparkles, X } from 'lucide-react';
+import { ChevronDown, ExternalLink, Search, Sparkles, X } from 'lucide-react';
 import { INTEREST_OPTIONS } from '@blog-study/shared/config';
-import { Badge } from '@/components/ui/badge';
 import { PageError } from '@/components/ui/page-state';
 import { getArticleGradient, formatRelativeDate, CATEGORY_STYLES } from '@/lib/curation-utils';
 
@@ -12,7 +11,7 @@ import { getArticleGradient, formatRelativeDate, CATEGORY_STYLES } from '@/lib/c
 // Types
 // ─────────────────────────────────────────────
 
-interface CurationItem {
+interface CurationItemResponse {
   id: string;
   title: string;
   url: string;
@@ -27,26 +26,36 @@ interface CurationItem {
 }
 
 interface CurationData {
-  items: CurationItem[];
+  items: CurationItemResponse[];
   nextCursor: string | null;
   hasMore: boolean;
   totalCount: number;
 }
 
-type FilterValue = 'all' | 'conference' | 'article';
+type FilterValue = 'recommended' | 'all' | 'conference' | 'article';
 
 // ─────────────────────────────────────────────
 // Constants
 // ─────────────────────────────────────────────
 
 const FILTERS: { value: FilterValue; label: string; emoji: string }[] = [
+  { value: 'recommended', label: '맞춤', emoji: '✨' },
   { value: 'all', label: '전체', emoji: '📚' },
   { value: 'conference', label: '컨퍼런스', emoji: '🎤' },
   { value: 'article', label: '아티클', emoji: '📝' },
 ];
 
-const MAX_TAGS = 4;
+const VALID_CATEGORIES = new Set<string>(['recommended', 'all', 'conference', 'article']);
 const PAGE_SIZE = 12;
+
+function isSafeUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
 
 // ─────────────────────────────────────────────
 // Thumbnail — img with gradient fallback
@@ -61,8 +70,12 @@ interface ThumbnailProps {
 
 function Thumbnail({ src, title, category, className = '' }: ThumbnailProps) {
   const [failed, setFailed] = useState(false);
-  const gradient = getArticleGradient(title);
+  const gradient = useMemo(() => getArticleGradient(title), [title]);
   const catStyle = CATEGORY_STYLES[category] ?? CATEGORY_STYLES['article']!;
+
+  useEffect(() => {
+    setFailed(false);
+  }, [src]);
 
   if (!src || failed) {
     return (
@@ -78,8 +91,11 @@ function Thumbnail({ src, title, category, className = '' }: ThumbnailProps) {
   return (
     <img
       src={src}
-      alt={title}
+      alt=""
+      width={480}
+      height={270}
       loading="lazy"
+      decoding="async"
       onError={() => setFailed(true)}
       className={`object-cover ${className}`}
     />
@@ -87,20 +103,71 @@ function Thumbnail({ src, title, category, className = '' }: ThumbnailProps) {
 }
 
 // ─────────────────────────────────────────────
+// TagFilterList — shared between desktop/mobile
+// ─────────────────────────────────────────────
+
+function TagFilterList({
+  selectedTags,
+  onToggle,
+  onClear,
+}: {
+  selectedTags: string[];
+  onToggle: (tag: string) => void;
+  onClear: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-1.5 flex-wrap">
+      {INTEREST_OPTIONS.map((tag) => {
+        const isSelected = selectedTags.includes(tag);
+        return (
+          <button
+            key={tag}
+            onClick={() => onToggle(tag)}
+            aria-pressed={isSelected}
+            className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold
+              transition-colors cursor-pointer shrink-0
+              focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1
+              ${isSelected
+                ? 'border-transparent bg-primary text-primary-foreground'
+                : 'border-border text-foreground hover:bg-accent hover:text-accent-foreground'
+              }`}
+          >
+            #{tag}
+          </button>
+        );
+      })}
+      {selectedTags.length > 0 && (
+        <button
+          onClick={onClear}
+          className="inline-flex items-center gap-0.5 text-xs text-muted-foreground hover:text-foreground transition-colors ml-1
+            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-sm"
+          aria-label="태그 필터 초기화"
+        >
+          <X className="h-3 w-3" aria-hidden="true" />
+          초기화
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
 // CurationCard — mobile / tablet
 // ─────────────────────────────────────────────
 
-function CurationCard({ item }: { item: CurationItem }) {
+function CurationCard({ item }: { item: CurationItemResponse }) {
   const catStyle = CATEGORY_STYLES[item.category] ?? CATEGORY_STYLES['article']!;
   const relativeDate = formatRelativeDate(item.publishedAt);
+  const href = isSafeUrl(item.url) ? item.url : '#';
 
   return (
     <a
-      href={item.url}
+      href={href}
       target="_blank"
       rel="noopener noreferrer"
       className="group flex flex-col rounded-xl border border-border/60 bg-card overflow-hidden
-        hover:border-primary/30 hover:shadow-md transition-all duration-200"
+        hover:border-primary/30 hover:shadow-md transition-all duration-200
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
     >
       {/* 16:9 thumbnail */}
       <div className="aspect-video w-full overflow-hidden bg-muted">
@@ -114,7 +181,7 @@ function CurationCard({ item }: { item: CurationItem }) {
 
       {/* Body */}
       <div className="flex flex-col flex-1 gap-2 p-3">
-        {/* Badges */}
+        {/* Badges + tags */}
         <div className="flex items-center gap-1.5 flex-wrap">
           <span
             className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset
@@ -126,10 +193,19 @@ function CurationCard({ item }: { item: CurationItem }) {
             <span className="inline-flex items-center gap-0.5 rounded-full px-2 py-0.5 text-xs font-medium
               bg-emerald-100 text-emerald-700 ring-1 ring-inset ring-emerald-200
               dark:bg-emerald-500/20 dark:text-emerald-300 dark:ring-emerald-500/30">
-              <Sparkles className="h-3 w-3" />
+              <Sparkles className="h-3 w-3" aria-hidden="true" />
               공유됨
             </span>
           )}
+          {item.tags?.map((tag) => (
+            <span
+              key={tag}
+              className="inline-flex items-center rounded-full px-2 py-0.5 text-xs text-muted-foreground
+                bg-muted/60 ring-1 ring-inset ring-border/40"
+            >
+              #{tag}
+            </span>
+          ))}
         </div>
 
         {/* Title */}
@@ -147,14 +223,17 @@ function CurationCard({ item }: { item: CurationItem }) {
 
         {/* Footer */}
         <div className="flex items-center justify-between mt-auto pt-1">
-          <div className="flex items-center gap-1 text-xs text-muted-foreground min-w-0">
+          <div className="flex items-center gap-1 text-xs text-muted-foreground min-w-0 flex-1">
             {item.sourceName && (
-              <span className="font-medium truncate max-w-[80px]">{item.sourceName}</span>
+              <span className="font-medium truncate max-w-[120px] sm:max-w-[160px]" title={item.sourceName}>
+                {item.sourceName}
+              </span>
             )}
-            {item.sourceName && relativeDate && <span>·</span>}
-            {relativeDate && <span className="shrink-0">{relativeDate}</span>}
+            {item.sourceName && relativeDate && <span aria-hidden="true">·</span>}
+            {relativeDate && <span className="shrink-0 tabular-nums">{relativeDate}</span>}
           </div>
-          <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50 group-hover:text-primary transition-colors ml-2" />
+          <span className="sr-only">(새 탭에서 열기)</span>
+          <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50 group-hover:text-primary transition-colors ml-2" aria-hidden="true" />
         </div>
       </div>
     </a>
@@ -165,17 +244,19 @@ function CurationCard({ item }: { item: CurationItem }) {
 // CurationListRow — desktop list feed
 // ─────────────────────────────────────────────
 
-function CurationListRow({ item }: { item: CurationItem }) {
+function CurationListRow({ item }: { item: CurationItemResponse }) {
   const catStyle = CATEGORY_STYLES[item.category] ?? CATEGORY_STYLES['article']!;
   const relativeDate = formatRelativeDate(item.publishedAt);
+  const href = isSafeUrl(item.url) ? item.url : '#';
 
   return (
     <a
-      href={item.url}
+      href={href}
       target="_blank"
       rel="noopener noreferrer"
       className="group flex items-start gap-4 py-4 px-3 -mx-3 rounded-lg
-        hover:bg-muted/40 transition-colors duration-150"
+        hover:bg-muted/40 transition-colors duration-150
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
     >
       {/* Thumbnail */}
       <div className="w-[100px] h-[64px] shrink-0 rounded-md overflow-hidden bg-muted">
@@ -214,21 +295,36 @@ function CurationListRow({ item }: { item: CurationItem }) {
             <span className="inline-flex items-center gap-0.5 rounded-full px-2 py-0.5 text-xs font-medium
               bg-emerald-100 text-emerald-700 ring-1 ring-inset ring-emerald-200
               dark:bg-emerald-500/20 dark:text-emerald-300 dark:ring-emerald-500/30">
-              <Sparkles className="h-3 w-3" />
+              <Sparkles className="h-3 w-3" aria-hidden="true" />
               공유됨
             </span>
           )}
+          {item.tags?.map((tag) => (
+            <span
+              key={tag}
+              className="inline-flex items-center rounded-full px-2 py-0.5 text-xs text-muted-foreground
+                bg-muted/60 ring-1 ring-inset ring-border/40"
+            >
+              #{tag}
+            </span>
+          ))}
           {item.sourceName && (
-            <span className="text-xs text-muted-foreground font-medium">{item.sourceName}</span>
+            <span className="text-xs text-muted-foreground font-medium truncate max-w-[160px]" title={item.sourceName}>
+              {item.sourceName}
+            </span>
+          )}
+          {item.sourceName && relativeDate && (
+            <span className="text-xs text-muted-foreground" aria-hidden="true">·</span>
           )}
           {relativeDate && (
-            <span className="text-xs text-muted-foreground">{relativeDate}</span>
+            <span className="text-xs text-muted-foreground tabular-nums shrink-0">{relativeDate}</span>
           )}
         </div>
       </div>
 
       {/* External link icon */}
-      <ExternalLink className="h-4 w-4 shrink-0 text-muted-foreground/40 group-hover:text-primary transition-colors mt-0.5" />
+      <span className="sr-only">(새 탭에서 열기)</span>
+      <ExternalLink className="h-4 w-4 shrink-0 text-muted-foreground/40 group-hover:text-primary transition-colors mt-0.5" aria-hidden="true" />
     </a>
   );
 }
@@ -240,7 +336,6 @@ function CurationListRow({ item }: { item: CurationItem }) {
 function CardSkeleton() {
   return (
     <div className="rounded-xl border border-border/60 bg-card overflow-hidden animate-pulse">
-      {/* thumbnail placeholder */}
       <div className="aspect-video w-full bg-muted" />
       <div className="flex flex-col gap-2 p-3">
         <div className="h-4 w-16 bg-muted rounded-full" />
@@ -293,36 +388,54 @@ export default function CurationPage() {
   const searchParams = useSearchParams();
 
   // Derive filter state from URL
-  const categoryParam = searchParams.get('category') as FilterValue | null;
+  const categoryParam = searchParams.get('category');
   const tagsParam = searchParams.get('tags');
-  const category: FilterValue = categoryParam && ['all', 'conference', 'article'].includes(categoryParam)
-    ? categoryParam
-    : 'all';
+  const searchParam = searchParams.get('search') || '';
+  const category: FilterValue = categoryParam && VALID_CATEGORIES.has(categoryParam)
+    ? (categoryParam as FilterValue)
+    : 'recommended';
   const selectedTags: string[] = tagsParam
     ? tagsParam.split(',').filter(Boolean)
     : [];
 
   // Local state
-  const [items, setItems] = useState<CurationItem[]>([]);
+  const [items, setItems] = useState<CurationItemResponse[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [hasMore, setHasMore] = useState(false);
   const [cursor, setCursor] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [tagsExpanded, setTagsExpanded] = useState(false);
+  const [searchInput, setSearchInput] = useState(searchParam);
 
-  // Sentinel ref for IntersectionObserver
+  // Refs — use refs for values accessed inside IntersectionObserver to avoid stale closures
   const sentinelRef = useRef<HTMLDivElement>(null);
-  // Keep a ref to avoid stale closure in observer callback
   const hasMoreRef = useRef(hasMore);
   const loadingMoreRef = useRef(loadingMore);
+  const cursorRef = useRef<string | null>(cursor);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
   hasMoreRef.current = hasMore;
   loadingMoreRef.current = loadingMore;
+  cursorRef.current = cursor;
+
+  // Sync searchInput with URL on back-navigation
+  useEffect(() => {
+    setSearchInput(searchParam);
+  }, [searchParam]);
+
+  // Cleanup debounce on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
 
   // ── Fetch ──
   const fetchItems = useCallback(async (
     cat: FilterValue,
     tags: string[],
+    search: string,
     cursorArg: string | null,
     append: boolean
   ) => {
@@ -335,10 +448,16 @@ export default function CurationPage() {
 
     try {
       const params = new URLSearchParams({
-        category: cat,
         limit: String(PAGE_SIZE),
       });
+      if (cat === 'recommended') {
+        params.set('sort', 'recommended');
+        params.set('category', 'all');
+      } else {
+        params.set('category', cat);
+      }
       if (tags.length > 0) params.set('tags', tags.join(','));
+      if (search) params.set('search', search);
       if (cursorArg) params.set('cursor', cursorArg);
 
       const response = await fetch(`/api/curation?${params}`);
@@ -350,8 +469,9 @@ export default function CurationPage() {
         setItems((prev) => [...prev, ...data.items]);
       } else {
         setItems(data.items);
-        setTotalCount(data.totalCount);
       }
+      // Always update totalCount (non-zero only on first page)
+      if (data.totalCount > 0) setTotalCount(data.totalCount);
       setHasMore(data.hasMore);
       setCursor(data.nextCursor);
     } catch (err) {
@@ -368,9 +488,9 @@ export default function CurationPage() {
     setItems([]);
     setCursor(null);
     setHasMore(false);
-    fetchItems(category, selectedTags, null, false);
+    fetchItems(category, selectedTags, searchParam, null, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [category, tagsParam, fetchItems]);
+  }, [category, tagsParam, searchParam, fetchItems]);
 
   // ── IntersectionObserver for infinite scroll ──
   useEffect(() => {
@@ -381,7 +501,7 @@ export default function CurationPage() {
       (entries) => {
         const entry = entries[0];
         if (entry?.isIntersecting && hasMoreRef.current && !loadingMoreRef.current) {
-          fetchItems(category, selectedTags, cursor, true);
+          fetchItems(category, selectedTags, searchParam, cursorRef.current, true);
         }
       },
       { rootMargin: '400px' }
@@ -389,15 +509,16 @@ export default function CurationPage() {
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-    // cursor changes should re-bind observer so we can load the next page
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cursor, category, tagsParam, fetchItems]);
+  }, [category, tagsParam, searchParam, fetchItems]);
 
   // ── URL sync helpers ──
-  const updateFilters = (newCategory: FilterValue, newTags: string[]) => {
+  const updateFilters = (newCategory: FilterValue, newTags: string[], newSearch?: string) => {
     const params = new URLSearchParams();
-    if (newCategory !== 'all') params.set('category', newCategory);
+    if (newCategory !== 'recommended') params.set('category', newCategory);
     if (newTags.length > 0) params.set('tags', newTags.join(','));
+    const s = newSearch ?? searchParam;
+    if (s) params.set('search', s);
     const qs = params.toString();
     router.push(`/curation${qs ? `?${qs}` : ''}`, { scroll: false });
   };
@@ -409,14 +530,26 @@ export default function CurationPage() {
   const handleTagToggle = (tag: string) => {
     const next = selectedTags.includes(tag)
       ? selectedTags.filter((t) => t !== tag)
-      : selectedTags.length >= MAX_TAGS
-        ? selectedTags
-        : [...selectedTags, tag];
+      : [...selectedTags, tag];
     updateFilters(category, next);
   };
 
   const clearTags = () => {
     updateFilters(category, []);
+  };
+
+  // ── Search with debounce ──
+  const handleSearchChange = (value: string) => {
+    setSearchInput(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      updateFilters(category, selectedTags, value.trim());
+    }, 300);
+  };
+
+  const clearSearch = () => {
+    setSearchInput('');
+    updateFilters(category, selectedTags, '');
   };
 
   // ── Error state ──
@@ -425,9 +558,16 @@ export default function CurationPage() {
   }
 
   const showInitialSkeletons = loading && items.length === 0;
+  const hasActiveSearch = searchParam.length > 0;
 
   return (
     <div className="space-y-0">
+      {/* Accessible live region for loading state */}
+      <div aria-live="polite" aria-atomic="true" className="sr-only">
+        {loading && '콘텐츠를 불러오는 중입니다.'}
+        {loadingMore && '추가 콘텐츠를 불러오는 중입니다.'}
+      </div>
+
       {/* ── Header ── */}
       <div className="space-y-1 pb-4">
         <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
@@ -448,64 +588,95 @@ export default function CurationPage() {
         className="sticky top-14 z-20 bg-background/95 backdrop-blur-sm border-b border-border/60
           -mx-4 sm:-mx-6 lg:-mx-8 px-4 sm:px-6 lg:px-8 py-3 space-y-2.5"
       >
-        {/* Category pills */}
-        <div className="flex items-center gap-2 flex-wrap">
+        {/* Search bar */}
+        <div role="search" className="relative">
+          <label htmlFor="curation-search" className="sr-only">
+            큐레이션 콘텐츠 검색
+          </label>
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          <input
+            id="curation-search"
+            type="search"
+            value={searchInput}
+            onChange={(e) => handleSearchChange(e.target.value)}
+            placeholder="제목, 설명으로 검색..."
+            className="w-full pl-9 pr-9 py-2 text-sm bg-muted/50 border border-border/60 rounded-lg
+              placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50
+              transition-colors [&::-webkit-search-cancel-button]:hidden"
+          />
+          {searchInput && (
+            <button
+              onClick={clearSearch}
+              className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center justify-center
+                w-8 h-8 text-muted-foreground hover:text-foreground transition-colors rounded-full
+                focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+              aria-label="검색어 지우기"
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+            </button>
+          )}
+        </div>
+
+        {/* Category pills + tags (desktop: same row / mobile: separate rows) */}
+        <div role="group" aria-label="콘텐츠 필터" className="flex items-center gap-2 flex-wrap">
+          {/* Category pills */}
           {FILTERS.map(({ value, label, emoji }) => (
             <button
               key={value}
               onClick={() => handleFilterChange(value)}
+              aria-pressed={category === value}
               className={`inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-sm font-medium
                 transition-all duration-200
+                focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2
                 ${category === value
-                  ? 'bg-foreground text-background shadow-sm scale-105'
-                  : 'bg-muted text-muted-foreground hover:bg-muted/80 hover:scale-[1.02]'
+                  ? 'bg-foreground text-background shadow-sm motion-safe:scale-105'
+                  : 'bg-muted text-muted-foreground hover:bg-muted/80 motion-safe:hover:scale-[1.02]'
                 }`}
             >
-              <span>{emoji}</span>
+              <span aria-hidden="true">{emoji}</span>
               {label}
             </button>
           ))}
+
+          {/* Separator — desktop only */}
+          <div className="hidden lg:block w-px h-5 bg-border/60 mx-1" aria-hidden="true" />
+
+          {/* Desktop tags — inline after categories */}
+          <div className="hidden lg:flex">
+            <TagFilterList selectedTags={selectedTags} onToggle={handleTagToggle} onClear={clearTags} />
+          </div>
         </div>
 
-        {/* Tag chips */}
-        <div className="flex items-center gap-2">
-          {/* Label + clear */}
-          <div className="flex items-center gap-1.5 shrink-0">
-            <span className="text-xs font-medium text-muted-foreground">
-              태그
-              {selectedTags.length > 0 && (
-                <span className="ml-1 text-foreground">({selectedTags.length}/{MAX_TAGS})</span>
-              )}
-            </span>
+        {/* Mobile tag toggle */}
+        <div className="lg:hidden">
+          <button
+            onClick={() => setTagsExpanded((prev) => !prev)}
+            aria-expanded={tagsExpanded}
+            aria-controls="mobile-tag-panel"
+            className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground
+              transition-colors min-h-[44px] px-1 -mx-1 rounded
+              focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+          >
+            태그 필터
             {selectedTags.length > 0 && (
-              <button
-                onClick={clearTags}
-                className="inline-flex items-center gap-0.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
-                aria-label="태그 필터 초기화"
-              >
-                <X className="h-3 w-3" />
-                <span className="hidden sm:inline">초기화</span>
-              </button>
+              <span className="text-foreground">({selectedTags.length})</span>
             )}
-          </div>
+            <ChevronDown
+              aria-hidden="true"
+              className={`h-3.5 w-3.5 motion-safe:transition-transform motion-safe:duration-200 ${tagsExpanded ? 'rotate-180' : ''}`}
+            />
+          </button>
 
-          {/* Mobile: horizontal scroll / PC: wrap */}
-          <div className="flex gap-1.5 overflow-x-auto scrollbar-hide lg:flex-wrap">
-            {INTEREST_OPTIONS.map((tag) => {
-              const isSelected = selectedTags.includes(tag);
-              const isDisabled = !isSelected && selectedTags.length >= MAX_TAGS;
-              return (
-                <Badge
-                  key={tag}
-                  variant={isSelected ? 'default' : 'outline'}
-                  className={`cursor-pointer transition-colors text-xs shrink-0
-                    ${isDisabled ? 'opacity-40 cursor-not-allowed' : ''}`}
-                  onClick={() => !isDisabled && handleTagToggle(tag)}
-                >
-                  {tag}
-                </Badge>
-              );
-            })}
+          <div
+            id="mobile-tag-panel"
+            className={`overflow-hidden motion-safe:transition-[max-height] motion-safe:duration-200 motion-safe:ease-in-out ${
+              tagsExpanded ? 'max-h-60' : 'max-h-0'
+            }`}
+            aria-hidden={!tagsExpanded}
+          >
+            <div className="pt-2">
+              <TagFilterList selectedTags={selectedTags} onToggle={handleTagToggle} onClear={clearTags} />
+            </div>
           </div>
         </div>
       </div>
@@ -514,17 +685,20 @@ export default function CurationPage() {
       <div className="pt-4">
         {showInitialSkeletons ? (
           <>
-            {/* Card skeletons — mobile/tablet */}
-            <div className="grid gap-3 sm:grid-cols-2 lg:hidden">
-              {Array.from({ length: 6 }).map((_, i) => (
-                <CardSkeleton key={i} />
-              ))}
-            </div>
-            {/* List skeletons — desktop */}
-            <div className="hidden lg:block divide-y divide-border/40">
-              {Array.from({ length: 8 }).map((_, i) => (
-                <ListRowSkeleton key={i} />
-              ))}
+            <p className="sr-only">콘텐츠를 불러오는 중입니다.</p>
+            <div aria-hidden="true">
+              {/* Card skeletons — mobile/tablet */}
+              <div className="grid gap-3 sm:grid-cols-2 lg:hidden">
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <CardSkeleton key={i} />
+                ))}
+              </div>
+              {/* List skeletons — desktop */}
+              <div className="hidden lg:block divide-y divide-border/40">
+                {Array.from({ length: 8 }).map((_, i) => (
+                  <ListRowSkeleton key={i} />
+                ))}
+              </div>
             </div>
           </>
         ) : items.length > 0 ? (
@@ -546,18 +720,27 @@ export default function CurationPage() {
         ) : !loading ? (
           /* Empty state */
           <div className="flex flex-col items-center justify-center py-16 gap-3">
-            <div className="text-5xl">{selectedTags.length > 0 ? '🔍' : '📭'}</div>
+            <div className="text-5xl" aria-hidden="true">
+              {hasActiveSearch || selectedTags.length > 0 ? '🔍' : '📭'}
+            </div>
             <p className="text-sm text-muted-foreground">
-              {selectedTags.length > 0
-                ? '선택한 태그에 맞는 콘텐츠가 없어요'
-                : '아직 큐레이션된 콘텐츠가 없어요'}
+              {hasActiveSearch
+                ? '검색 결과가 없어요'
+                : selectedTags.length > 0
+                  ? '선택한 태그에 맞는 콘텐츠가 없어요'
+                  : '아직 큐레이션된 콘텐츠가 없어요'}
             </p>
-            {selectedTags.length > 0 && (
+            {(hasActiveSearch || selectedTags.length > 0) && (
               <button
-                onClick={clearTags}
-                className="text-xs text-primary hover:underline"
+                onClick={() => {
+                  setSearchInput('');
+                  updateFilters(category, [], '');
+                }}
+                className="text-xs text-sky-600 dark:text-primary underline underline-offset-2
+                  hover:text-sky-700 dark:hover:text-primary/80 transition-colors
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-sm"
               >
-                태그 필터 초기화
+                필터 초기화
               </button>
             )}
           </div>
@@ -565,7 +748,7 @@ export default function CurationPage() {
 
         {/* Load-more skeletons */}
         {loadingMore && (
-          <>
+          <div aria-hidden="true">
             <div className="grid gap-3 sm:grid-cols-2 lg:hidden mt-3">
               {Array.from({ length: 3 }).map((_, i) => (
                 <CardSkeleton key={i} />
@@ -576,7 +759,7 @@ export default function CurationPage() {
                 <ListRowSkeleton key={i} />
               ))}
             </div>
-          </>
+          </div>
         )}
 
         {/* Sentinel — IntersectionObserver target */}

--- a/packages/web/src/app/api/admin/curation/crawl/route.ts
+++ b/packages/web/src/app/api/admin/curation/crawl/route.ts
@@ -18,6 +18,7 @@ interface NormalizedFeedItem {
   title?: string;
   link?: string;
   pubDate?: string;
+  description?: string;
   categories?: string[];
 }
 
@@ -32,6 +33,7 @@ function extractFeedItems(result: ReturnType<typeof parseFeed>): NormalizedFeedI
       title: entry.title,
       link: entry.links?.[0]?.href,
       pubDate: entry.published ?? entry.updated,
+      description: entry.summary ?? entry.content,
       categories: entry.categories?.map((c) => c.term).filter(Boolean) as string[],
     }));
   }
@@ -41,6 +43,7 @@ function extractFeedItems(result: ReturnType<typeof parseFeed>): NormalizedFeedI
       title: item.title,
       link: item.link,
       pubDate: item.pubDate ? String(item.pubDate) : undefined,
+      description: item.description,
       categories: item.categories?.map((c) => typeof c === 'string' ? c : c.name).filter(Boolean) as string[],
     }));
   }
@@ -50,6 +53,7 @@ function extractFeedItems(result: ReturnType<typeof parseFeed>): NormalizedFeedI
       title: item.title,
       link: item.url ?? item.external_url,
       pubDate: item.date_published ?? item.date_modified,
+      description: item.summary ?? item.content_text,
       categories: item.tags,
     }));
   }
@@ -59,7 +63,41 @@ function extractFeedItems(result: ReturnType<typeof parseFeed>): NormalizedFeedI
     title: item.title,
     link: item.link,
     pubDate: item.dc?.date,
+    description: item.description,
   }));
+}
+
+/**
+ * HTML 태그 제거 + 300자 truncate
+ */
+function sanitizeDescription(html: string | undefined): string | null {
+  if (!html) return null;
+  const text = html
+    .replace(/<[^>]*>/g, '')
+    .replace(/&[a-zA-Z]+;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!text) return null;
+  return text.length > 300 ? text.slice(0, 300) + '...' : text;
+}
+
+/**
+ * URL에서 og:image 메타태그 추출 (5초 타임아웃)
+ */
+async function extractOgImage(url: string): Promise<string | null> {
+  try {
+    const response = await fetch(url, {
+      headers: { 'User-Agent': 'BlogStudyBot/1.0' },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!response.ok) return null;
+    const html = await response.text();
+    const match = html.match(/<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']/i)
+      || html.match(/<meta[^>]+content=["']([^"']+)["'][^>]+property=["']og:image["']/i);
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -189,10 +227,15 @@ export async function POST(request: NextRequest) {
               publishedAt = new Date(item.pubDate);
             }
 
+            const description = sanitizeDescription(item.description);
+            const thumbnailUrl = await extractOgImage(item.link);
+
             await database.insert(curationItems).values({
               sourceId: source.id,
               title: item.title,
               url: item.link,
+              description,
+              thumbnailUrl,
               publishedAt,
               category: source.category,
               tags: mergedTags.length > 0 ? mergedTags : null,

--- a/packages/web/src/app/api/curation/route.ts
+++ b/packages/web/src/app/api/curation/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { desc, count, eq, and, sql, lt } from 'drizzle-orm';
+import { desc, count, eq, and, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { successResponse, errorResponse } from '@/lib/api-error';
@@ -67,8 +67,9 @@ export async function GET(request: NextRequest) {
       const cursorDate = cursorDateStr ? new Date(cursorDateStr) : null;
       if (cursorDate && !isNaN(cursorDate.getTime()) && cursorId) {
         // (publishedAt < cursorDate) OR (publishedAt = cursorDate AND id < cursorId)
+        const cursorIso = cursorDate.toISOString();
         queryConditions.push(
-          sql`(${curationItems.publishedAt} < ${cursorDate} OR (${curationItems.publishedAt} = ${cursorDate} AND ${curationItems.id} < ${cursorId}))`
+          sql`(${curationItems.publishedAt} < ${cursorIso}::timestamptz OR (${curationItems.publishedAt} = ${cursorIso}::timestamptz AND ${curationItems.id} < ${cursorId}))`
         );
       } else if (cursorId && !cursorDateStr) {
         // publishedAt was null — show items with null publishedAt and id < cursorId
@@ -76,7 +77,9 @@ export async function GET(request: NextRequest) {
           sql`(${curationItems.publishedAt} IS NULL AND ${curationItems.id} < ${cursorId})`
         );
       } else if (cursorDate && !isNaN(cursorDate.getTime())) {
-        queryConditions.push(lt(curationItems.publishedAt, cursorDate));
+        queryConditions.push(
+          sql`${curationItems.publishedAt} < ${cursorDate.toISOString()}::timestamptz`
+        );
       }
     }
     const whereClause = queryConditions.length > 0 ? and(...queryConditions) : undefined;

--- a/packages/web/src/app/api/curation/route.ts
+++ b/packages/web/src/app/api/curation/route.ts
@@ -1,23 +1,78 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { desc, count, eq, and, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
-import { successResponse, errorResponse } from '@/lib/api-error';
+import { successResponse, errorResponse, Errors } from '@/lib/api-error';
 import { createClient } from '@/lib/supabase/server';
 
-const { curationItems, curationSources } = sharedDb;
+const { curationItems, curationSources, members } = sharedDb;
+
+// ── Helpers ──
+
+const VALID_CATEGORIES = new Set(['all', 'conference', 'article']);
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_TAGS = 20;
+const MAX_SEARCH_LENGTH = 100;
+
+function escapeIlike(s: string): string {
+  return s.replace(/[%_\\]/g, '\\$&');
+}
+
+const BASE_SELECT = {
+  id: curationItems.id,
+  title: curationItems.title,
+  url: curationItems.url,
+  description: curationItems.description,
+  thumbnailUrl: curationItems.thumbnailUrl,
+  publishedAt: curationItems.publishedAt,
+  category: curationItems.category,
+  tags: curationItems.tags,
+  relevanceScore: curationItems.relevanceScore,
+  isShared: curationItems.isShared,
+  sharedAt: curationItems.sharedAt,
+  sourceName: curationSources.name,
+};
+
+function serializeItem(item: {
+  id: string;
+  title: string;
+  url: string;
+  description: string | null;
+  thumbnailUrl: string | null;
+  publishedAt: Date | null;
+  category: string;
+  tags: string[] | null;
+  relevanceScore: number | null;
+  isShared: boolean | null;
+  sharedAt: Date | null;
+  sourceName: string | null;
+}) {
+  return {
+    id: item.id,
+    title: item.title,
+    url: item.url,
+    description: item.description ?? null,
+    thumbnailUrl: item.thumbnailUrl ?? null,
+    publishedAt: item.publishedAt?.toISOString() ?? null,
+    category: item.category,
+    tags: item.tags,
+    relevanceScore: item.relevanceScore,
+    sharedAt: item.isShared ? item.sharedAt?.toISOString() ?? null : null,
+    sourceName: item.sourceName ?? null,
+  };
+}
 
 /**
  * GET /api/curation
  * Cursor-based pagination for infinite scroll
- * Supports category filter and tag AND-filter (up to 4 tags)
+ * Supports category filter, tag AND-filter, search, and recommended sort
  */
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
     const { data: { user }, error: authError } = await supabase.auth.getUser();
     if (authError || !user) {
-      return NextResponse.json({ message: '인증이 필요합니다.' }, { status: 401 });
+      return Errors.unauthorized().toResponse();
     }
 
     const { searchParams } = new URL(request.url);
@@ -25,6 +80,13 @@ export async function GET(request: NextRequest) {
     const tagsParam = searchParams.get('tags') || '';
     const cursor = searchParams.get('cursor');
     const limit = Math.min(50, Math.max(1, parseInt(searchParams.get('limit') || '12', 10)));
+    const sortMode = searchParams.get('sort') || 'latest';
+    const searchQuery = (searchParams.get('search')?.trim() || '').slice(0, MAX_SEARCH_LENGTH);
+
+    // ── Input validation ──
+    if (!VALID_CATEGORIES.has(category)) {
+      return Errors.badRequest('유효하지 않은 카테고리입니다.').toResponse();
+    }
 
     const database = db();
 
@@ -38,7 +100,7 @@ export async function GET(request: NextRequest) {
       .split(',')
       .map((t) => t.trim())
       .filter(Boolean)
-      .slice(0, 4);
+      .slice(0, MAX_TAGS);
 
     if (selectedTags.length > 0) {
       filterConditions.push(
@@ -49,30 +111,122 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Total count (filter only, no cursor)
-    const countWhere = filterConditions.length > 0 ? and(...filterConditions) : undefined;
-    const totalCountResult = await database
-      .select({ count: count() })
-      .from(curationItems)
-      .where(countWhere);
-    const totalCount = totalCountResult[0]?.count ?? 0;
+    // Search filter — escape ILIKE wildcards
+    if (searchQuery) {
+      const escaped = escapeIlike(searchQuery);
+      filterConditions.push(
+        sql`(${curationItems.title} ILIKE ${'%' + escaped + '%'} ESCAPE '\\' OR ${curationItems.description} ILIKE ${'%' + escaped + '%'} ESCAPE '\\')`
+      );
+    }
 
-    // Query conditions = filter + cursor
-    // Cursor format: "publishedAt|id" (composite to handle duplicate timestamps)
+    // ── Recommended sort: get user interests ──
+    let userInterests: string[] = [];
+    const isRecommended = sortMode === 'recommended';
+    if (isRecommended) {
+      const discordIdentity = user.identities?.find(i => i.provider === 'discord');
+      const discordId = discordIdentity?.id;
+      if (discordId) {
+        const [member] = await database
+          .select({ interests: members.interests })
+          .from(members)
+          .where(eq(members.discordId, discordId))
+          .limit(1);
+        userInterests = member?.interests ?? [];
+      }
+    }
+
+    // Effective sort: fall back to latest if no interests
+    const useRecommendedSort = isRecommended && userInterests.length > 0;
+
+    // Total count — skip on paginated requests (client already has it)
+    const countWhere = filterConditions.length > 0 ? and(...filterConditions) : undefined;
+    let totalCount = 0;
+    if (!cursor) {
+      const totalCountResult = await database
+        .select({ count: count() })
+        .from(curationItems)
+        .where(countWhere);
+      totalCount = totalCountResult[0]?.count ?? 0;
+    }
+
+    // ── Recommended sort with overlap scoring ──
+    if (useRecommendedSort) {
+      const interestsArray = sql`ARRAY[${sql.join(userInterests.map(i => sql`${i}`), sql`,`)}]::text[]`;
+      const overlapExpr = sql`COALESCE(array_length(ARRAY(SELECT unnest(${curationItems.tags}) INTERSECT SELECT unnest(${interestsArray})), 1), 0)`;
+
+      const queryConditions = [...filterConditions];
+      if (cursor) {
+        const parts = cursor.split('|');
+        if (parts.length === 3) {
+          const cursorOverlap = parseInt(parts[0]!, 10);
+          const cursorDateStr = parts[1]!;
+          const cursorId = parts[2]!;
+
+          if (isNaN(cursorOverlap) || cursorOverlap < 0) {
+            return Errors.badRequest('유효하지 않은 cursor 형식입니다.').toResponse();
+          }
+          if (cursorId && !UUID_RE.test(cursorId)) {
+            return Errors.badRequest('유효하지 않은 cursor 형식입니다.').toResponse();
+          }
+
+          const cursorDate = cursorDateStr ? new Date(cursorDateStr) : null;
+
+          if (cursorDate && !isNaN(cursorDate.getTime()) && cursorId) {
+            const cursorIso = cursorDate.toISOString();
+            queryConditions.push(
+              sql`(${overlapExpr} < ${cursorOverlap} OR (${overlapExpr} = ${cursorOverlap} AND ${curationItems.publishedAt} < ${cursorIso}::timestamptz) OR (${overlapExpr} = ${cursorOverlap} AND ${curationItems.publishedAt} = ${cursorIso}::timestamptz AND ${curationItems.id} < ${cursorId}))`
+            );
+          } else if (cursorId) {
+            queryConditions.push(
+              sql`(${overlapExpr} < ${cursorOverlap} OR (${overlapExpr} = ${cursorOverlap} AND ${curationItems.publishedAt} IS NULL AND ${curationItems.id} < ${cursorId}))`
+            );
+          }
+        }
+      }
+
+      const whereClause = queryConditions.length > 0 ? and(...queryConditions) : undefined;
+
+      const itemsResult = await database
+        .select({ ...BASE_SELECT, overlapCount: overlapExpr.as('overlap_count') })
+        .from(curationItems)
+        .leftJoin(curationSources, eq(curationItems.sourceId, curationSources.id))
+        .where(whereClause)
+        .orderBy(sql`overlap_count DESC`, sql`${curationItems.publishedAt} DESC NULLS LAST`, desc(curationItems.id))
+        .limit(limit + 1);
+
+      const hasMore = itemsResult.length > limit;
+      const items = hasMore ? itemsResult.slice(0, limit) : itemsResult;
+      const lastItem = items[items.length - 1];
+      const nextCursor = hasMore && lastItem
+        ? `${lastItem.overlapCount}|${lastItem.publishedAt?.toISOString() ?? ''}|${lastItem.id}`
+        : null;
+
+      return successResponse({
+        items: items.map(serializeItem),
+        nextCursor,
+        hasMore,
+        totalCount,
+      });
+    }
+
+    // ── Default (latest) sort ──
     const queryConditions = [...filterConditions];
     if (cursor) {
       const separatorIdx = cursor.lastIndexOf('|');
       const cursorDateStr = separatorIdx > 0 ? cursor.slice(0, separatorIdx) : '';
       const cursorId = separatorIdx > 0 ? cursor.slice(separatorIdx + 1) : '';
+
+      if (cursorId && !UUID_RE.test(cursorId)) {
+        return Errors.badRequest('유효하지 않은 cursor 형식입니다.').toResponse();
+      }
+
       const cursorDate = cursorDateStr ? new Date(cursorDateStr) : null;
       if (cursorDate && !isNaN(cursorDate.getTime()) && cursorId) {
-        // (publishedAt < cursorDate) OR (publishedAt = cursorDate AND id < cursorId)
         const cursorIso = cursorDate.toISOString();
         queryConditions.push(
           sql`(${curationItems.publishedAt} < ${cursorIso}::timestamptz OR (${curationItems.publishedAt} = ${cursorIso}::timestamptz AND ${curationItems.id} < ${cursorId}))`
         );
       } else if (cursorId && !cursorDateStr) {
-        // publishedAt was null — show items with null publishedAt and id < cursorId
         queryConditions.push(
           sql`(${curationItems.publishedAt} IS NULL AND ${curationItems.id} < ${cursorId})`
         );
@@ -84,22 +238,8 @@ export async function GET(request: NextRequest) {
     }
     const whereClause = queryConditions.length > 0 ? and(...queryConditions) : undefined;
 
-    // Fetch limit+1 to determine hasMore
     const itemsResult = await database
-      .select({
-        id: curationItems.id,
-        title: curationItems.title,
-        url: curationItems.url,
-        description: curationItems.description,
-        thumbnailUrl: curationItems.thumbnailUrl,
-        publishedAt: curationItems.publishedAt,
-        category: curationItems.category,
-        tags: curationItems.tags,
-        relevanceScore: curationItems.relevanceScore,
-        isShared: curationItems.isShared,
-        sharedAt: curationItems.sharedAt,
-        sourceName: curationSources.name,
-      })
+      .select(BASE_SELECT)
       .from(curationItems)
       .leftJoin(curationSources, eq(curationItems.sourceId, curationSources.id))
       .where(whereClause)
@@ -109,31 +249,18 @@ export async function GET(request: NextRequest) {
     const hasMore = itemsResult.length > limit;
     const items = hasMore ? itemsResult.slice(0, limit) : itemsResult;
     const lastItem = items[items.length - 1];
-    // Composite cursor: "publishedAt|id" to handle duplicate timestamps
     const nextCursor = hasMore && lastItem
       ? `${lastItem.publishedAt?.toISOString() ?? ''}|${lastItem.id}`
       : null;
 
     return successResponse({
-      items: items.map((item) => ({
-        id: item.id,
-        title: item.title,
-        url: item.url,
-        description: item.description ?? null,
-        thumbnailUrl: item.thumbnailUrl ?? null,
-        publishedAt: item.publishedAt?.toISOString() ?? null,
-        category: item.category,
-        tags: item.tags,
-        relevanceScore: item.relevanceScore,
-        sharedAt: item.isShared ? item.sharedAt?.toISOString() : null,
-        sourceName: item.sourceName ?? null,
-      })),
+      items: items.map(serializeItem),
       nextCursor,
       hasMore,
       totalCount,
     });
   } catch (error) {
-    console.error('Curation API error:', error);
+    console.error('Curation API error:', error instanceof Error ? error.message : 'Unknown error');
     return errorResponse(error);
   }
 }

--- a/packages/web/src/app/api/curation/route.ts
+++ b/packages/web/src/app/api/curation/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { desc, count, eq, and, sql } from 'drizzle-orm';
+import { desc, count, eq, and, sql, lt } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { successResponse, errorResponse } from '@/lib/api-error';
@@ -9,9 +9,8 @@ const { curationItems, curationSources } = sharedDb;
 
 /**
  * GET /api/curation
- * Get curated articles and conferences
+ * Cursor-based pagination for infinite scroll
  * Supports category filter and tag AND-filter (up to 4 tags)
- * Tags are predefined in INTEREST_OPTIONS (shared config)
  */
 export async function GET(request: NextRequest) {
   try {
@@ -24,19 +23,17 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const category = searchParams.get('category') || 'all';
     const tagsParam = searchParams.get('tags') || '';
-    const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10));
+    const cursor = searchParams.get('cursor');
     const limit = Math.min(50, Math.max(1, parseInt(searchParams.get('limit') || '12', 10)));
-    const offset = (page - 1) * limit;
 
     const database = db();
 
-    // Build query conditions
-    const conditions = [];
+    // Build filter conditions (without cursor)
+    const filterConditions = [];
     if (category !== 'all') {
-      conditions.push(eq(curationItems.category, category));
+      filterConditions.push(eq(curationItems.category, category));
     }
 
-    // Tag AND-filter: items must contain ALL selected tags
     const selectedTags = tagsParam
       .split(',')
       .map((t) => t.trim())
@@ -44,7 +41,7 @@ export async function GET(request: NextRequest) {
       .slice(0, 4);
 
     if (selectedTags.length > 0) {
-      conditions.push(
+      filterConditions.push(
         sql`${curationItems.tags} @> ARRAY[${sql.join(
           selectedTags.map((t) => sql`${t}`),
           sql`,`
@@ -52,21 +49,32 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
-
-    // Get total count
+    // Total count (filter only, no cursor)
+    const countWhere = filterConditions.length > 0 ? and(...filterConditions) : undefined;
     const totalCountResult = await database
       .select({ count: count() })
       .from(curationItems)
-      .where(whereClause);
+      .where(countWhere);
     const totalCount = totalCountResult[0]?.count ?? 0;
 
-    // Get curation items with source name
+    // Query conditions = filter + cursor
+    const queryConditions = [...filterConditions];
+    if (cursor) {
+      const cursorDate = new Date(cursor);
+      if (!isNaN(cursorDate.getTime())) {
+        queryConditions.push(lt(curationItems.publishedAt, cursorDate));
+      }
+    }
+    const whereClause = queryConditions.length > 0 ? and(...queryConditions) : undefined;
+
+    // Fetch limit+1 to determine hasMore
     const itemsResult = await database
       .select({
         id: curationItems.id,
         title: curationItems.title,
         url: curationItems.url,
+        description: curationItems.description,
+        thumbnailUrl: curationItems.thumbnailUrl,
         publishedAt: curationItems.publishedAt,
         category: curationItems.category,
         tags: curationItems.tags,
@@ -78,15 +86,23 @@ export async function GET(request: NextRequest) {
       .from(curationItems)
       .leftJoin(curationSources, eq(curationItems.sourceId, curationSources.id))
       .where(whereClause)
-      .orderBy(desc(curationItems.relevanceScore), desc(curationItems.collectedAt))
-      .limit(limit)
-      .offset(offset);
+      .orderBy(desc(curationItems.publishedAt), desc(curationItems.collectedAt))
+      .limit(limit + 1);
+
+    const hasMore = itemsResult.length > limit;
+    const items = hasMore ? itemsResult.slice(0, limit) : itemsResult;
+    const lastItem = items[items.length - 1];
+    const nextCursor = hasMore && lastItem?.publishedAt
+      ? lastItem.publishedAt.toISOString()
+      : null;
 
     return successResponse({
-      items: itemsResult.map((item) => ({
+      items: items.map((item) => ({
         id: item.id,
         title: item.title,
         url: item.url,
+        description: item.description ?? null,
+        thumbnailUrl: item.thumbnailUrl ?? null,
         publishedAt: item.publishedAt?.toISOString() ?? null,
         category: item.category,
         tags: item.tags,
@@ -94,12 +110,9 @@ export async function GET(request: NextRequest) {
         sharedAt: item.isShared ? item.sharedAt?.toISOString() : null,
         sourceName: item.sourceName ?? null,
       })),
+      nextCursor,
+      hasMore,
       totalCount,
-      pagination: {
-        page,
-        limit,
-        totalPages: Math.ceil(totalCount / limit),
-      },
     });
   } catch (error) {
     console.error('Curation API error:', error);

--- a/packages/web/src/app/api/curation/route.ts
+++ b/packages/web/src/app/api/curation/route.ts
@@ -58,10 +58,24 @@ export async function GET(request: NextRequest) {
     const totalCount = totalCountResult[0]?.count ?? 0;
 
     // Query conditions = filter + cursor
+    // Cursor format: "publishedAt|id" (composite to handle duplicate timestamps)
     const queryConditions = [...filterConditions];
     if (cursor) {
-      const cursorDate = new Date(cursor);
-      if (!isNaN(cursorDate.getTime())) {
+      const separatorIdx = cursor.lastIndexOf('|');
+      const cursorDateStr = separatorIdx > 0 ? cursor.slice(0, separatorIdx) : '';
+      const cursorId = separatorIdx > 0 ? cursor.slice(separatorIdx + 1) : '';
+      const cursorDate = cursorDateStr ? new Date(cursorDateStr) : null;
+      if (cursorDate && !isNaN(cursorDate.getTime()) && cursorId) {
+        // (publishedAt < cursorDate) OR (publishedAt = cursorDate AND id < cursorId)
+        queryConditions.push(
+          sql`(${curationItems.publishedAt} < ${cursorDate} OR (${curationItems.publishedAt} = ${cursorDate} AND ${curationItems.id} < ${cursorId}))`
+        );
+      } else if (cursorId && !cursorDateStr) {
+        // publishedAt was null — show items with null publishedAt and id < cursorId
+        queryConditions.push(
+          sql`(${curationItems.publishedAt} IS NULL AND ${curationItems.id} < ${cursorId})`
+        );
+      } else if (cursorDate && !isNaN(cursorDate.getTime())) {
         queryConditions.push(lt(curationItems.publishedAt, cursorDate));
       }
     }
@@ -86,14 +100,15 @@ export async function GET(request: NextRequest) {
       .from(curationItems)
       .leftJoin(curationSources, eq(curationItems.sourceId, curationSources.id))
       .where(whereClause)
-      .orderBy(desc(curationItems.publishedAt), desc(curationItems.collectedAt))
+      .orderBy(sql`${curationItems.publishedAt} DESC NULLS LAST`, desc(curationItems.id))
       .limit(limit + 1);
 
     const hasMore = itemsResult.length > limit;
     const items = hasMore ? itemsResult.slice(0, limit) : itemsResult;
     const lastItem = items[items.length - 1];
-    const nextCursor = hasMore && lastItem?.publishedAt
-      ? lastItem.publishedAt.toISOString()
+    // Composite cursor: "publishedAt|id" to handle duplicate timestamps
+    const nextCursor = hasMore && lastItem
+      ? `${lastItem.publishedAt?.toISOString() ?? ''}|${lastItem.id}`
       : null;
 
     return successResponse({

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -291,3 +291,12 @@
 .dark .hljs-selector-class,
 .dark .hljs-selector-id { color: #d2a8ff; }
 .dark .hljs-property { color: #79c0ff; }
+
+/* Scrollbar hide utility for horizontal scroll filters */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}

--- a/packages/web/src/lib/curation-utils.ts
+++ b/packages/web/src/lib/curation-utils.ts
@@ -1,0 +1,63 @@
+/**
+ * 큐레이션 UI 유틸리티
+ */
+
+const GRADIENTS = [
+  'from-sky-100 to-sky-200 dark:from-sky-900/30 dark:to-sky-800/30',
+  'from-violet-100 to-violet-200 dark:from-violet-900/30 dark:to-violet-800/30',
+  'from-emerald-100 to-emerald-200 dark:from-emerald-900/30 dark:to-emerald-800/30',
+  'from-amber-100 to-amber-200 dark:from-amber-900/30 dark:to-amber-800/30',
+  'from-rose-100 to-rose-200 dark:from-rose-900/30 dark:to-rose-800/30',
+  'from-indigo-100 to-indigo-200 dark:from-indigo-900/30 dark:to-indigo-800/30',
+] as const;
+
+/**
+ * 소스명/제목 기반 결정적 그라디언트 반환
+ * 썸네일이 없을 때 플레이스홀더로 사용
+ */
+export function getArticleGradient(seed: string): string {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash << 5) - hash + seed.charCodeAt(i);
+    hash |= 0;
+  }
+  return GRADIENTS[Math.abs(hash) % GRADIENTS.length]!;
+}
+
+/**
+ * 상대 시간 포맷 (한국어)
+ */
+export function formatRelativeDate(dateStr: string | null): string | null {
+  if (!dateStr) return null;
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return '오늘';
+  if (diffDays === 1) return '어제';
+  if (diffDays < 7) return `${diffDays}일 전`;
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)}주 전`;
+  if (diffDays < 365) return `${Math.floor(diffDays / 30)}개월 전`;
+  return date.toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' });
+}
+
+/**
+ * 카테고리별 스타일 상수
+ */
+export const CATEGORY_STYLES: Record<string, { label: string; emoji: string; bg: string; text: string; ring: string }> = {
+  conference: {
+    label: '컨퍼런스',
+    emoji: '🎤',
+    bg: 'bg-violet-100 dark:bg-violet-500/20',
+    text: 'text-violet-700 dark:text-violet-300',
+    ring: 'ring-violet-200 dark:ring-violet-500/30',
+  },
+  article: {
+    label: '아티클',
+    emoji: '📝',
+    bg: 'bg-sky-100 dark:bg-sky-500/20',
+    text: 'text-sky-700 dark:text-sky-300',
+    ring: 'ring-sky-200 dark:ring-sky-500/30',
+  },
+};

--- a/packages/web/src/lib/curation-utils.ts
+++ b/packages/web/src/lib/curation-utils.ts
@@ -30,22 +30,34 @@ export function getArticleGradient(seed: string): string {
 export function formatRelativeDate(dateStr: string | null): string | null {
   if (!dateStr) return null;
   const date = new Date(dateStr);
+  if (isNaN(date.getTime())) return null;
+
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
+  if (diffDays < 0) {
+    return date.toLocaleDateString('ko-KR', { year: 'numeric', month: 'short', day: 'numeric' });
+  }
   if (diffDays === 0) return '오늘';
   if (diffDays === 1) return '어제';
   if (diffDays < 7) return `${diffDays}일 전`;
   if (diffDays < 30) return `${Math.floor(diffDays / 7)}주 전`;
   if (diffDays < 365) return `${Math.floor(diffDays / 30)}개월 전`;
-  return date.toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' });
+  return date.toLocaleDateString('ko-KR', { year: 'numeric', month: 'short', day: 'numeric' });
 }
 
 /**
  * 카테고리별 스타일 상수
  */
 export const CATEGORY_STYLES: Record<string, { label: string; emoji: string; bg: string; text: string; ring: string }> = {
+  recommended: {
+    label: '맞춤',
+    emoji: '✨',
+    bg: 'bg-amber-100 dark:bg-amber-500/20',
+    text: 'text-amber-700 dark:text-amber-300',
+    ring: 'ring-amber-200 dark:ring-amber-500/30',
+  },
   conference: {
     label: '컨퍼런스',
     emoji: '🎤',

--- a/scripts/seed-conference-sources.ts
+++ b/scripts/seed-conference-sources.ts
@@ -1,0 +1,98 @@
+/**
+ * 컨퍼런스 소스 시드 스크립트
+ *
+ * Usage:
+ *   cd packages/shared
+ *   export $(grep DATABASE_URL /Users/hansangho/Desktop/study-admin/.env.local | head -1 | xargs)
+ *   npx tsx ../../scripts/seed-conference-sources.ts
+ */
+import { db } from '../packages/shared/src/db/index.js';
+import { curationSources } from '../packages/shared/src/db/schema.js';
+
+const CONFERENCE_SOURCES = [
+  {
+    name: 'Dev-Event (brave-people)',
+    url: 'https://github.com/brave-people/Dev-Event',
+    rssUrl: 'https://github.com/brave-people/Dev-Event/releases.atom',
+    category: 'conference',
+    tags: ['커리어 성장'],
+    isActive: true,
+  },
+  {
+    name: 'dev.events Korea',
+    url: 'https://dev.events/AS/KR',
+    rssUrl: 'https://dev.events/rss.xml',
+    category: 'conference',
+    tags: ['커리어 성장'],
+    isActive: true,
+  },
+  {
+    name: 'FECONF',
+    url: 'https://feconf.kr',
+    rssUrl: null,
+    category: 'conference',
+    tags: ['프론트엔드'],
+    isActive: true,
+  },
+  {
+    name: 'if(kakao)',
+    url: 'https://if.kakao.com',
+    rssUrl: null,
+    category: 'conference',
+    tags: ['풀스택'],
+    isActive: true,
+  },
+  {
+    name: 'Naver DEVIEW',
+    url: 'https://deview.kr',
+    rssUrl: null,
+    category: 'conference',
+    tags: ['풀스택'],
+    isActive: true,
+  },
+  {
+    name: 'AWS Summit Korea',
+    url: 'https://aws.amazon.com/ko/events/summits/korea/',
+    rssUrl: null,
+    category: 'conference',
+    tags: ['클라우드', 'DevOps'],
+    isActive: true,
+  },
+  {
+    name: 'GDG DevFest Korea',
+    url: 'https://festa.dev',
+    rssUrl: null,
+    category: 'conference',
+    tags: ['풀스택'],
+    isActive: true,
+  },
+  {
+    name: 'Toss SLASH',
+    url: 'https://toss.im/slash',
+    rssUrl: null,
+    category: 'conference',
+    tags: ['프론트엔드', '백엔드'],
+    isActive: true,
+  },
+] as const;
+
+async function main() {
+  const database = db.getDb();
+
+  for (const source of CONFERENCE_SOURCES) {
+    try {
+      await database
+        .insert(curationSources)
+        .values(source)
+        .onConflictDoNothing({ target: curationSources.url });
+      console.log(`✓ ${source.name}`);
+    } catch (err) {
+      console.error(`✗ ${source.name}:`, err);
+    }
+  }
+
+  console.log('\nDone! Conference sources seeded.');
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
## 🎯 Summary
> 큐레이션 페이지를 무한스크롤 기반으로 리디자인하고, 맞춤 탭·검색·접근성·보안을 강화한 2차 개선까지 포함

---

## 🔴 AS-IS
- offset 기반 페이지네이션 (중복/누락 이슈)
- 카테고리 필터만 존재, 검색 없음
- 태그 선택 4개 제한
- 개인화 정렬 없음
- 접근성/보안 미흡

## 🟢 TO-BE
- cursor 기반 무한스크롤 (IntersectionObserver)
- 맞춤(recommended) 탭: 사용자 관심사 기반 태그 겹침 점수 정렬
- 제목/설명 ILIKE 검색 (300ms debounce)
- 태그 제한 제거 + `#` 접두사 + 카드 태그 칩 표시
- 모바일 태그 토글 (접기/펼치기)
- WCAG 2.1 AA 접근성 준수
- ILIKE 와일드카드 이스케이프, 입력 검증, UUID 포맷 체크

---

## 📁 Changes

| 파일 | 변경 |
|------|------|
| `packages/web/src/app/(user)/curation/page.tsx` | 전체 리디자인: 무한스크롤, 맞춤탭, 검색UI, 태그개선, 접근성 |
| `packages/web/src/app/api/curation/route.ts` | cursor 페이지네이션, search/sort 파라미터, 보안 강화 |
| `packages/web/src/lib/curation-utils.ts` | 그라디언트/상대시간 유틸, recommended 카테고리 스타일 |
| `packages/web/src/app/globals.css` | scrollbar-hide 유틸리티 |
| `packages/web/src/app/api/admin/curation/crawl/route.ts` | 관리자 크롤링 API |
| `packages/shared/src/db/schema.ts` | description, thumbnailUrl 컬럼 추가 |
| `scripts/seed-conference-sources.ts` | 컨퍼런스 소스 시드 스크립트 (8개) |
| `packages/web/next-env.d.ts` | Next.js 16 TypeScript 선언 |

## 🏗 Design Decisions

| 결정 | 이유 |
|------|------|
| cursor-based pagination | offset 대비 중복/누락 방지, 무한스크롤에 최적 |
| 3-part cursor (`overlap\|date\|id`) | recommended 정렬의 복합 키 지원 |
| INTERSECT 서브쿼리 | `intarray` 확장 없이 text[] 겹침 계산 |
| `cursorRef` 패턴 | IntersectionObserver stale closure 방지 |
| `escapeIlike()` | ILIKE 와일드카드 인젝션 방지 |
| semantic `<button>` for tags | `<Badge onClick>` 대비 키보드 접근성 보장 |
| `motion-safe:` prefix | 동작 민감 사용자 대응 |

## ✅ Test Plan
- [ ] 맞춤 탭: 관심사 겹침 순 정렬 확인
- [ ] 전체/컨퍼런스/아티클 탭: 최신순 정렬 확인
- [ ] 검색: 제목/설명 검색 + 특수문자(%_\) 입력 테스트
- [ ] 태그: 5개 이상 선택 가능, `#` 접두사 표시, 카드 태그 칩
- [ ] 모바일: 태그 접기/펼치기 + 선택 개수 표시
- [ ] 무한스크롤: 중복 없이 페이지네이션
- [ ] 키보드: Tab으로 모든 인터랙티브 요소 탐색 가능
- [ ] `pnpm typecheck` ✅
- [ ] `pnpm build` ✅

---

## 💬 참고사항
- 컨퍼런스 소스 시드 스크립트(`scripts/seed-conference-sources.ts`)는 수동 실행 필요
- 맞춤 탭은 사용자 관심사 미등록 시 최신순으로 자동 fallback
- 1차 리디자인(무한스크롤) + 2차 개선(맞춤/검색/접근성/보안) 통합 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)