### PR TITLE
feat: 모바일 하단 탭 바 + 레이아웃 개선 + 문서 최신화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ packages/
 ```bash
 # 개발
 pnpm dev:bot          # 봇 로컬 실행
-pnpm dev:web          # 웹 로컬 실행 (localhost:3000)
+pnpm dev:web          # 웹 로컬 실행 (localhost:3300)
 
 # 빌드/테스트
 pnpm build            # 전체 빌드 (shared → bot/web)
@@ -43,6 +43,7 @@ pnpm --filter @blog-study/shared build   # 반드시 리빌드
 # 봇 전용
 pnpm --filter @blog-study/bot deploy-commands  # 슬래시 커맨드 등록
 pnpm --filter @blog-study/bot init-rounds      # 회차 초기화
+pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 ```
 
 ## 코딩 컨벤션
@@ -83,6 +84,8 @@ pnpm --filter @blog-study/bot init-rounds      # 회차 초기화
 | `packages/web/src/lib/api-error.ts` | API 표준 응답/에러 헬퍼 (`successResponse`, `Errors`) |
 | `packages/web/src/components/ui/member-avatar.tsx` | 재사용 아바타 컴포넌트 (링크+관리자뱃지) |
 | `packages/web/src/components/board/tiptap-editor.tsx` | Tiptap 리치 에디터 (코드블록 언어선택, 링크 다이얼로그) |
+| `packages/web/src/components/layout/bottom-nav.tsx` | 모바일 하단 탭 바 (5개 메뉴) |
+| `packages/bot/src/scripts/rss-collect.ts` | 수동 RSS 수집 스크립트 (봇 없이 독립 실행) |
 
 ## 인증 구조
 
@@ -113,6 +116,8 @@ pnpm --filter @blog-study/bot init-rounds      # 회차 초기화
 - **폰트**: Pretendard Variable
 - **기본 아바타**: DiceBear `fun-emoji` 스타일 (`getDefaultAvatar()` in `utils.ts`)
 - **아바타 리소스**: [DiceBear](https://www.dicebear.com/styles/) - 30+ 스타일, seed 기반 결정적 아바타 생성, API: `https://api.dicebear.com/9.x/{style}/svg?seed={seed}`
+- **레이아웃**: 데스크톱 사이드바 + 모바일 하단 탭 바 (BottomNav)
+- **PWA**: 홈 화면 추가 지원 (manifest.json, 서비스 워커 없음)
 - **상세 스펙**: `docs/26-03-06-ui-design-system.md` 참조
 
 ## 에이전트 활용 가이드

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,6 +30,7 @@ graph TB
     subgraph Web["Web Dashboard · Vercel"]
         MW["Middleware<br/>세션 검증"]
         PAGES["Pages<br/>Dashboard · Posts · Ranking<br/>Profile · Curation · Board · Admin"]
+        PWA["PWA<br/>manifest.json<br/>홈 화면 추가"]
         API["API Routes<br/>/api/auth · /api/posts<br/>/api/admin · /api/board · ..."]
         SUPA_CLIENT["Supabase SSR Client<br/>@supabase/ssr"]
     end
@@ -62,6 +63,7 @@ mindmap
       Tailwind CSS v4
       shadcn/ui + Radix UI
       Tiptap Rich Editor
+      PWA 홈 화면 추가
       Supabase Auth
         Discord OAuth
         @supabase/ssr
@@ -352,6 +354,16 @@ erDiagram
 ```
 
 상세 스키마: [`docs/26-03-06-schema-summary.md`](./26-03-06-schema-summary.md)
+
+## 레이아웃 구조
+
+| 뷰포트 | 내비게이션 | 컴포넌트 |
+|--------|-----------|---------|
+| Desktop (md+) | 좌측 고정 사이드바 (접기/펼치기) | `Sidebar` |
+| Mobile (<md) | 하단 고정 탭 바 (5개 메뉴) | `BottomNav` |
+
+- **Header**: 로고 + 다크모드 토글 + 프로필 드롭다운 (관리자 링크 포함)
+- **PWA**: `manifest.json` + 아이콘 (192/512) → 홈 화면 추가 지원, 서비스 워커 없음 (lightweight)
 
 ## 스케줄러 (pg-boss)
 

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -13,7 +13,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "deploy-commands": "tsx src/deploy-commands.ts",
-    "init-rounds": "tsx src/scripts/init-rounds.ts"
+    "init-rounds": "tsx src/scripts/init-rounds.ts",
+    "rss-collect": "tsx src/scripts/rss-collect.ts"
   },
   "dependencies": {
     "@blog-study/shared": "workspace:*",

--- a/packages/web/next-env.d.ts
+++ b/packages/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import './.next/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -1,6 +1,11 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { ThemeProvider } from 'next-themes';
 import './globals.css';
+
+export const viewport: Viewport = {
+  viewportFit: 'cover',
+  themeColor: '#0ea5e9',
+};
 
 export const metadata: Metadata = {
   title: {
@@ -31,7 +36,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         />
         <link rel="icon" href="/icon.svg" type="image/svg+xml" />
         <link rel="apple-touch-icon" href="/icon-192.png" />
-        <meta name="theme-color" content="#0ea5e9" />
       </head>
       <body
         className="font-sans antialiased"

--- a/packages/web/src/components/layout/bottom-nav.tsx
+++ b/packages/web/src/components/layout/bottom-nav.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { FileText, LayoutDashboard, MessageSquare, Newspaper, Trophy } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface NavItem {
+  title: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+}
+
+const navItems: NavItem[] = [
+  { title: '대시보드', href: '/dashboard', icon: LayoutDashboard },
+  { title: '글 목록', href: '/posts', icon: FileText },
+  { title: '랭킹', href: '/ranking', icon: Trophy },
+  { title: '큐레이션', href: '/curation', icon: Newspaper },
+  { title: '게시판', href: '/board', icon: MessageSquare },
+];
+
+export function BottomNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      aria-label="모바일 내비게이션"
+      className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-background/95 backdrop-blur-sm md:hidden"
+    >
+      <div className="flex h-14 items-center justify-around px-1">
+        {navItems.map((item) => {
+          const Icon = item.icon;
+          const isActive = pathname === item.href || pathname.startsWith(item.href + '/');
+
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                'flex flex-1 flex-col items-center justify-center gap-0.5 py-1 text-[10px] font-medium transition-colors',
+                isActive ? 'text-primary' : 'text-muted-foreground active:text-foreground'
+              )}
+            >
+              <Icon className={cn('h-5 w-5', isActive && 'text-primary')} />
+              <span>{item.title}</span>
+            </Link>
+          );
+        })}
+      </div>
+      {/* Safe area for iOS home indicator */}
+      <div className="h-[env(safe-area-inset-bottom)]" />
+    </nav>
+  );
+}

--- a/packages/web/src/components/layout/header.tsx
+++ b/packages/web/src/components/layout/header.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useState, useEffect, useRef, useSyncExternalStore } from 'react';
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useTheme } from 'next-themes';
-import { Menu, LogOut, Moon, Sun, UserCircle } from 'lucide-react';
+import { LogOut, Moon, Shield, Sun, UserCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -15,7 +15,6 @@ interface HeaderProps {
     email: string;
     imageUrl?: string;
   } | null;
-  onMenuClick?: () => void;
   onLogout?: () => void;
 }
 
@@ -23,7 +22,11 @@ const emptySubscribe = () => () => {};
 
 function DarkModeToggle() {
   const { theme, setTheme } = useTheme();
-  const mounted = useSyncExternalStore(emptySubscribe, () => true, () => false);
+  const mounted = useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false
+  );
 
   if (!mounted) {
     // Render a placeholder with the same dimensions to prevent layout shift
@@ -50,16 +53,12 @@ function DarkModeToggle() {
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
       aria-label={isDark ? '라이트 모드로 전환' : '다크 모드로 전환'}
     >
-      {isDark ? (
-        <Sun className="h-4 w-4" />
-      ) : (
-        <Moon className="h-4 w-4" />
-      )}
+      {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
     </Button>
   );
 }
 
-export function Header({ user, onMenuClick, onLogout }: HeaderProps) {
+export function Header({ user, onLogout }: HeaderProps) {
   const router = useRouter();
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -86,20 +85,6 @@ export function Header({ user, onMenuClick, onLogout }: HeaderProps) {
       )}
     >
       <div className="flex h-14 items-center px-4 lg:px-6">
-
-        {/* Left: hamburger (mobile only) */}
-        <div className="flex items-center lg:hidden">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-9 w-9 text-muted-foreground hover:text-foreground"
-            onClick={onMenuClick}
-            aria-label="메뉴 열기"
-          >
-            <Menu className="h-5 w-5" />
-          </Button>
-        </div>
-
         {/* Logo */}
         <Link
           href="/dashboard"
@@ -111,13 +96,11 @@ export function Header({ user, onMenuClick, onLogout }: HeaderProps) {
           </span>
         </Link>
 
-
         {/* Spacer */}
         <div className="flex-1" />
 
         {/* Right: dark mode toggle + user menu */}
         <div className="flex items-center gap-1">
-
           {/* Dark mode toggle */}
           <DarkModeToggle />
 
@@ -156,6 +139,19 @@ export function Header({ user, onMenuClick, onLogout }: HeaderProps) {
                   >
                     <UserCircle className="h-4 w-4 text-muted-foreground" />
                     프로필
+                  </button>
+
+                  {/* Admin */}
+                  <button
+                    type="button"
+                    className="flex w-full items-center gap-2.5 px-4 py-2.5 text-sm text-foreground hover:bg-accent transition-colors"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      router.push('/admin');
+                    }}
+                  >
+                    <Shield className="h-4 w-4 text-muted-foreground" />
+                    관리자
                   </button>
 
                   {/* Logout */}

--- a/packages/web/src/components/layout/index.ts
+++ b/packages/web/src/components/layout/index.ts
@@ -1,4 +1,4 @@
 export { Header } from './header';
 export { Sidebar } from './sidebar';
-export { Footer } from './footer';
+export { BottomNav } from './bottom-nav';
 export { MainLayout } from './main-layout';

--- a/packages/web/src/components/layout/main-layout.tsx
+++ b/packages/web/src/components/layout/main-layout.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Header } from './header';
 import { Sidebar } from './sidebar';
-import { Footer } from './footer';
+import { BottomNav } from './bottom-nav';
 import { cn } from '@/lib/utils';
 
 const STORAGE_KEY = 'study-sidebar-collapsed';
@@ -35,7 +35,8 @@ function MainContent({
     <main
       className={cn(
         'flex-1 min-w-0 transition-[margin-left] duration-200',
-        showSidebar && (collapsed ? 'md:ml-16' : 'md:ml-60')
+        showSidebar && (collapsed ? 'md:ml-16' : 'md:ml-60'),
+        'pb-20 md:pb-0' // bottom nav spacing on mobile
       )}
     >
       <div className="w-full px-4 sm:px-6 lg:px-8 py-6 max-w-7xl mx-auto">{children}</div>
@@ -51,7 +52,6 @@ export function MainLayout({
   onLogout,
 }: MainLayoutProps) {
   const router = useRouter();
-  const [sidebarOpen, setSidebarOpen] = useState(false);
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     if (typeof window === 'undefined') return false;
     return localStorage.getItem(STORAGE_KEY) === 'true';
@@ -78,24 +78,20 @@ export function MainLayout({
 
   return (
     <div className="min-h-screen flex flex-col overflow-x-hidden">
-      <Header
-        user={user}
-        onMenuClick={() => setSidebarOpen(true)}
-        onLogout={handleLogout}
-      />
+      <Header user={user} onLogout={handleLogout} />
       <div className="flex flex-1">
         {showSidebar && (
           <Sidebar
-            isOpen={sidebarOpen}
-            onClose={() => setSidebarOpen(false)}
             isAdmin={isAdmin}
             collapsed={collapsed}
             onToggleCollapsed={handleToggleCollapsed}
           />
         )}
-        <MainContent showSidebar={showSidebar} collapsed={collapsed}>{children}</MainContent>
+        <MainContent showSidebar={showSidebar} collapsed={collapsed}>
+          {children}
+        </MainContent>
       </div>
-      <Footer />
+      {showSidebar && <BottomNav />}
     </div>
   );
 }

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -17,7 +17,6 @@ import {
   Trophy,
   Users,
   UsersRound,
-  X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Separator } from '@/components/ui/separator';
@@ -25,11 +24,9 @@ import { Separator } from '@/components/ui/separator';
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 interface SidebarProps {
-  isOpen?: boolean; // mobile drawer open state
-  onClose?: () => void; // mobile close handler
-  isAdmin?: boolean; // show admin nav
-  collapsed: boolean; // controlled collapsed state
-  onToggleCollapsed: (value: boolean) => void; // callback to toggle collapsed
+  isAdmin?: boolean;
+  collapsed: boolean;
+  onToggleCollapsed: (value: boolean) => void;
 }
 
 interface NavItem {
@@ -65,16 +62,14 @@ interface NavLinkProps {
   item: NavItem;
   isActive: boolean;
   collapsed: boolean;
-  onClick?: () => void;
 }
 
-function NavLink({ item, isActive, collapsed, onClick }: NavLinkProps) {
+function NavLink({ item, isActive, collapsed }: NavLinkProps) {
   const Icon = item.icon;
 
   return (
     <Link
       href={item.href}
-      onClick={onClick}
       title={collapsed ? item.title : undefined}
       className={cn(
         // Base layout
@@ -116,8 +111,6 @@ function NavLink({ item, isActive, collapsed, onClick }: NavLinkProps) {
 // ─── SidebarContent sub-component ────────────────────────────────────────────
 
 interface SidebarContentProps {
-  mobile?: boolean;
-  onClose?: () => void;
   collapsed: boolean;
   navItems: NavItem[];
   pathname: string;
@@ -126,8 +119,6 @@ interface SidebarContentProps {
 }
 
 function SidebarContent({
-  mobile = false,
-  onClose,
   collapsed,
   navItems,
   pathname,
@@ -136,34 +127,13 @@ function SidebarContent({
 }: SidebarContentProps) {
   return (
     <div className="flex h-full flex-col">
-      {/* ── Mobile header: logo + close ────────────────────────────── */}
-      {mobile && (
-        <div className="flex h-14 shrink-0 items-center border-b border-zinc-200 dark:border-zinc-800 px-5">
-          <Link href="/dashboard" onClick={onClose} className="flex items-center gap-2 select-none">
-            <span className="text-lg font-black tracking-tight text-zinc-900 dark:text-zinc-50">
-              BS
-            </span>
-            <span className="text-xs font-medium text-zinc-400 dark:text-zinc-500 tracking-wide uppercase">
-              Blog Study
-            </span>
-          </Link>
-          <button
-            onClick={onClose}
-            aria-label="사이드바 닫기"
-            className="ml-auto rounded-md p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-300 transition-colors duration-200"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
-      )}
-
-      {/* Desktop: spacer to match header height */}
-      {!mobile && <div className="h-14 shrink-0" />}
+      {/* Spacer to match header height */}
+      <div className="h-14 shrink-0" />
 
       {/* ── Primary navigation ───────────────────────────────────────── */}
       <nav
         aria-label={isAdmin ? '관리자 메뉴' : '사용자 메뉴'}
-        className={cn('flex-1 overflow-y-auto py-3', collapsed && !mobile ? 'px-2' : 'px-3')}
+        className={cn('flex-1 overflow-y-auto py-3', collapsed ? 'px-2' : 'px-3')}
       >
         <ul role="list" className="space-y-1">
           {navItems.map((item) => {
@@ -175,12 +145,7 @@ function SidebarContent({
 
             return (
               <li key={item.href}>
-                <NavLink
-                  item={item}
-                  isActive={isActive}
-                  collapsed={collapsed && !mobile}
-                  onClick={mobile ? onClose : undefined}
-                />
+                <NavLink item={item} isActive={isActive} collapsed={collapsed} />
               </li>
             );
           })}
@@ -188,7 +153,7 @@ function SidebarContent({
       </nav>
 
       {/* ── Bottom section ───────────────────────────────────────────── */}
-      <div className={cn('shrink-0', collapsed && !mobile ? 'px-2' : 'px-3')}>
+      <div className={cn('shrink-0', collapsed ? 'px-2' : 'px-3')}>
         <Separator className="mb-3" />
 
         {/* User / Admin page toggle link */}
@@ -196,11 +161,10 @@ function SidebarContent({
           {isAdmin ? (
             <Link
               href="/dashboard"
-              onClick={mobile ? onClose : undefined}
-              title={collapsed && !mobile ? '사용자 페이지' : undefined}
+              title={collapsed ? '사용자 페이지' : undefined}
               className={cn(
                 'group flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium',
-                collapsed && !mobile && 'justify-center px-0',
+                collapsed && 'justify-center px-0',
                 'text-zinc-500 dark:text-zinc-400',
                 'hover:bg-zinc-100 dark:hover:bg-zinc-800/60',
                 'hover:text-zinc-900 dark:hover:text-zinc-100',
@@ -212,18 +176,15 @@ function SidebarContent({
                   'h-4 w-4 shrink-0 text-zinc-400 group-hover:text-zinc-700 dark:group-hover:text-zinc-300 transition-colors duration-200'
                 )}
               />
-              {(!collapsed || mobile) && (
-                <span className="truncate leading-none">사용자 페이지</span>
-              )}
+              {!collapsed && <span className="truncate leading-none">사용자 페이지</span>}
             </Link>
           ) : (
             <Link
               href="/admin"
-              onClick={mobile ? onClose : undefined}
-              title={collapsed && !mobile ? '관리자' : undefined}
+              title={collapsed ? '관리자' : undefined}
               className={cn(
                 'group flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium',
-                collapsed && !mobile && 'justify-center px-0',
+                collapsed && 'justify-center px-0',
                 'text-zinc-500 dark:text-zinc-400',
                 'hover:bg-zinc-100 dark:hover:bg-zinc-800/60',
                 'hover:text-zinc-900 dark:hover:text-zinc-100',
@@ -235,38 +196,36 @@ function SidebarContent({
                   'h-4 w-4 shrink-0 text-zinc-400 group-hover:text-zinc-700 dark:group-hover:text-zinc-300 transition-colors duration-200'
                 )}
               />
-              {(!collapsed || mobile) && <span className="truncate leading-none">관리자</span>}
+              {!collapsed && <span className="truncate leading-none">관리자</span>}
             </Link>
           )}
         </div>
 
-        {/* Collapse toggle — desktop only (hidden inside mobile drawer) */}
-        {!mobile && (
-          <div className="mb-3">
-            <button
-              onClick={toggleCollapsed}
-              title={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
-              aria-label={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
-              className={cn(
-                'flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium',
-                collapsed && 'justify-center px-0',
-                'text-zinc-400 dark:text-zinc-500',
-                'hover:bg-zinc-100 dark:hover:bg-zinc-800/60',
-                'hover:text-zinc-700 dark:hover:text-zinc-300',
-                'transition-colors duration-200'
-              )}
-            >
-              {collapsed ? (
-                <PanelLeftOpen className="h-4 w-4 shrink-0" />
-              ) : (
-                <>
-                  <PanelLeftClose className="h-4 w-4 shrink-0" />
-                  <span className="truncate leading-none">접기</span>
-                </>
-              )}
-            </button>
-          </div>
-        )}
+        {/* Collapse toggle */}
+        <div className="mb-3">
+          <button
+            onClick={toggleCollapsed}
+            title={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
+            aria-label={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
+            className={cn(
+              'flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium',
+              collapsed && 'justify-center px-0',
+              'text-zinc-400 dark:text-zinc-500',
+              'hover:bg-zinc-100 dark:hover:bg-zinc-800/60',
+              'hover:text-zinc-700 dark:hover:text-zinc-300',
+              'transition-colors duration-200'
+            )}
+          >
+            {collapsed ? (
+              <PanelLeftOpen className="h-4 w-4 shrink-0" />
+            ) : (
+              <>
+                <PanelLeftClose className="h-4 w-4 shrink-0" />
+                <span className="truncate leading-none">접기</span>
+              </>
+            )}
+          </button>
+        </div>
       </div>
     </div>
   );
@@ -274,13 +233,7 @@ function SidebarContent({
 
 // ─── Sidebar component ────────────────────────────────────────────────────────
 
-export function Sidebar({
-  isOpen = false,
-  onClose,
-  isAdmin = false,
-  collapsed,
-  onToggleCollapsed,
-}: SidebarProps) {
+export function Sidebar({ isAdmin = false, collapsed, onToggleCollapsed }: SidebarProps) {
   const pathname = usePathname();
 
   const toggleCollapsed = () => onToggleCollapsed(!collapsed);
@@ -288,63 +241,23 @@ export function Sidebar({
   const navItems = isAdmin ? adminNavItems : userNavItems;
 
   return (
-    <>
-      {/* ── Mobile: overlay backdrop + drawer ──────────────────────── */}
-      {/* Backdrop */}
-      <div
-        aria-hidden="true"
-        onClick={onClose}
-        className={cn(
-          'fixed inset-0 z-40 bg-black/30 backdrop-blur-xs md:hidden',
-          'transition-opacity duration-200',
-          isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
-        )}
+    <aside
+      aria-label="데스크톱 내비게이션"
+      className={cn(
+        'fixed left-0 top-0 z-30 hidden h-full md:flex md:flex-col',
+        'border-r border-zinc-200 dark:border-zinc-800',
+        'bg-white dark:bg-zinc-950',
+        'transition-[width] duration-200 ease-in-out',
+        collapsed ? 'w-16' : 'w-60'
+      )}
+    >
+      <SidebarContent
+        collapsed={collapsed}
+        navItems={navItems}
+        pathname={pathname}
+        isAdmin={isAdmin}
+        toggleCollapsed={toggleCollapsed}
       />
-
-      {/* Mobile drawer */}
-      <aside
-        aria-label="모바일 내비게이션"
-        className={cn(
-          'fixed left-0 top-0 z-50 h-full w-60 md:hidden',
-          'border-r border-zinc-200 dark:border-zinc-800',
-          'bg-white dark:bg-zinc-950',
-          'shadow-xl',
-          'transition-transform duration-200 ease-in-out',
-          isOpen ? 'translate-x-0' : '-translate-x-full'
-        )}
-      >
-        <SidebarContent
-          mobile
-          onClose={onClose}
-          collapsed={collapsed}
-          navItems={navItems}
-          pathname={pathname}
-          isAdmin={isAdmin}
-          toggleCollapsed={toggleCollapsed}
-        />
-      </aside>
-
-      {/* ── Desktop: fixed sidebar ──────────────────────────────────── */}
-      <aside
-        aria-label="데스크톱 내비게이션"
-        className={cn(
-          'fixed left-0 top-0 z-30 hidden h-full md:flex md:flex-col',
-          'border-r border-zinc-200 dark:border-zinc-800',
-          'bg-white dark:bg-zinc-950',
-          // Width transitions between expanded (240px) and collapsed (64px)
-          'transition-[width] duration-200 ease-in-out',
-          collapsed ? 'w-16' : 'w-60'
-        )}
-      >
-        <SidebarContent
-          onClose={onClose}
-          collapsed={collapsed}
-          navItems={navItems}
-          pathname={pathname}
-          isAdmin={isAdmin}
-          toggleCollapsed={toggleCollapsed}
-        />
-      </aside>
-    </>
+    </aside>
   );
 }


### PR DESCRIPTION
## Summary
- 모바일 사이드바 드로어 → **하단 고정 탭 바(BottomNav)** 로 교체 (iOS safe area 지원)
- 헤더 프로필 드롭다운에 **관리자 페이지 링크** 추가
- 사이드바 모바일 코드 제거 (데스크톱 전용으로 정리)
- 봇 `rss-collect` 수동 실행 스크립트 커맨드 추가
- CLAUDE.md / ARCHITECTURE.md 최신화 (PWA, BottomNav, 포트 3300 등 반영)

## Changes
| 파일 | 변경 |
|------|------|
| `bottom-nav.tsx` | 새 모바일 하단 탭 바 컴포넌트 |
| `main-layout.tsx` | Footer → BottomNav, 하단 패딩 추가 |
| `header.tsx` | 프로필 드롭다운에 관리자 링크 |
| `sidebar.tsx` | 모바일 드로어 코드 제거 |
| `layout.tsx` | viewport-fit: cover (iOS safe area) |
| `CLAUDE.md` | 포트, PWA, 핵심 파일 업데이트 |
| `ARCHITECTURE.md` | PWA, 레이아웃 구조 섹션 추가 |

## Test plan
- [x] 모바일 뷰에서 하단 탭 바 정상 표시 확인
- [x] 데스크톱에서 사이드바 정상 동작 확인
- [x] 프로필 드롭다운 → 관리자 링크 클릭 시 /admin 이동 확인
- [x] iOS PWA에서 safe area 하단 여백 확인
- [x] `pnpm typecheck` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)