### PR TITLE
feat: 공지 배너 + 풀투리프레시 + UX 개선

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,11 +79,11 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 | `packages/web/src/lib/board-config.ts` | 게시판 카테고리/뱃지 설정 |
 | `packages/web/src/lib/api-error.ts` | API 표준 응답/에러 헬퍼 (`successResponse`, `Errors`) |
 | `packages/web/src/components/ui/member-avatar.tsx` | 재사용 아바타 컴포넌트 (링크+관리자뱃지) |
-| `packages/web/src/components/board/tiptap-editor.tsx` | Tiptap 리치 에디터 (코드블록 언어선택, 링크 다이얼로그) |
-| `packages/web/src/components/layout/bottom-nav.tsx` | 모바일 하단 탭 바 (사용자 5개 / 관리자 6개) |
-| `packages/web/src/components/layout/notice-banner.tsx` | 글로벌 공지 배너 (접기/닫기, localStorage 상태) |
+| `packages/web/src/components/board/tiptap-editor.tsx` | Tiptap 리치 에디터 (H1-H3, 구분선, 코드블록, 링크, 한글 IME 대응) |
+| `packages/web/src/components/layout/bottom-nav.tsx` | 모바일 하단 탭 바 (사용자 5개, 관리자 모드 미표시) |
+| `packages/web/src/components/layout/notice-banner.tsx` | 글로벌 공지 배너 (제목+내용 미리보기, 접기/닫기) |
 | `packages/web/src/components/layout/pull-to-refresh.tsx` | Pull-to-Refresh 컴포넌트 (PWA 터치 제스처) |
-| `packages/web/src/hooks/use-pull-to-refresh.ts` | Pull-to-Refresh 훅 (커스텀 터치 핸들링) |
+| `packages/web/src/hooks/use-pull-to-refresh.ts` | Pull-to-Refresh 훅 (`window.location.reload()` 기반) |
 | `packages/web/src/app/api/notice-banner/route.ts` | 활성 공지 배너 조회 API |
 | `packages/web/src/app/(admin)/admin/rounds/page.tsx` | 회차 관리 페이지 (CRUD + 현재 회차 설정) |
 | `packages/web/src/app/api/profile/withdraw/route.ts` | 유저 자체 탈퇴 API |
@@ -122,9 +122,10 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 - **폰트**: Pretendard Variable
 - **기본 아바타**: DiceBear `fun-emoji` 스타일 (`getDefaultAvatar()` in `utils.ts`)
 - **아바타 리소스**: [DiceBear](https://www.dicebear.com/styles/) - 30+ 스타일, seed 기반 결정적 아바타 생성, API: `https://api.dicebear.com/9.x/{style}/svg?seed={seed}`
-- **레이아웃**: 데스크톱 사이드바 + 모바일 하단 탭 바 (사용자/관리자 분리)
-- **공지 배너**: 글로벌 상단 배너 (관리자가 공지 글에서 활성화, 1개만 노출)
-- **Pull-to-Refresh**: 커스텀 터치 제스처 기반 새로고침 (Safari PWA 최적화)
+- **레이아웃**: 데스크톱 사이드바 + 모바일 하단 탭 바 (사용자 전용, 관리자 모드 미표시)
+- **사이드바**: 모드 전환은 헤더 프로필 드롭다운에서만 가능 (사이드바에 토글 없음)
+- **공지 배너**: 글로벌 상단 배너 (제목+내용 미리보기, 접기→제목만, 닫기→숨김, 관리자 페이지 미표시)
+- **Pull-to-Refresh**: 커스텀 터치 제스처 → `window.location.reload()` (Safari PWA 최적화)
 - **PWA**: 홈 화면 추가 지원 (manifest.json, 서비스 워커 없음)
 - **랜딩 페이지**: 인증 유저 자동 리다이렉트 (`/` → `/dashboard`)
 - **상세 스펙**: `docs/26-03-06-ui-design-system.md` 참조

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,11 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 | `packages/web/src/lib/api-error.ts` | API 표준 응답/에러 헬퍼 (`successResponse`, `Errors`) |
 | `packages/web/src/components/ui/member-avatar.tsx` | 재사용 아바타 컴포넌트 (링크+관리자뱃지) |
 | `packages/web/src/components/board/tiptap-editor.tsx` | Tiptap 리치 에디터 (코드블록 언어선택, 링크 다이얼로그) |
-| `packages/web/src/components/layout/bottom-nav.tsx` | 모바일 하단 탭 바 (5개 메뉴) |
+| `packages/web/src/components/layout/bottom-nav.tsx` | 모바일 하단 탭 바 (사용자 5개 / 관리자 6개) |
+| `packages/web/src/components/layout/notice-banner.tsx` | 글로벌 공지 배너 (접기/닫기, localStorage 상태) |
+| `packages/web/src/components/layout/pull-to-refresh.tsx` | Pull-to-Refresh 컴포넌트 (PWA 터치 제스처) |
+| `packages/web/src/hooks/use-pull-to-refresh.ts` | Pull-to-Refresh 훅 (커스텀 터치 핸들링) |
+| `packages/web/src/app/api/notice-banner/route.ts` | 활성 공지 배너 조회 API |
 | `packages/web/src/app/(admin)/admin/rounds/page.tsx` | 회차 관리 페이지 (CRUD + 현재 회차 설정) |
 | `packages/web/src/app/api/profile/withdraw/route.ts` | 유저 자체 탈퇴 API |
 | `packages/bot/src/scripts/rss-collect.ts` | 수동 RSS 수집 스크립트 (봇 없이 독립 실행) |
@@ -96,6 +100,7 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 - **관리자**: `ADMIN_DISCORD_IDS` 환경변수로 Discord ID 기반 권한 체크
 - **API Route**: `createClient()` → `getUser()` → `identities` 배열에서 Discord ID 추출
 - **상태 리다이렉트**: `auth/callback` + `(user)/layout.tsx`에서 이중 체크 → 상태별 차단 페이지로 리다이렉트
+- **랜딩 페이지**: 서버 사이드 `getUser()` 체크 → 인증 유저는 `/dashboard`로 redirect
 
 ## 멤버 상태 규칙
 
@@ -117,8 +122,11 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 - **폰트**: Pretendard Variable
 - **기본 아바타**: DiceBear `fun-emoji` 스타일 (`getDefaultAvatar()` in `utils.ts`)
 - **아바타 리소스**: [DiceBear](https://www.dicebear.com/styles/) - 30+ 스타일, seed 기반 결정적 아바타 생성, API: `https://api.dicebear.com/9.x/{style}/svg?seed={seed}`
-- **레이아웃**: 데스크톱 사이드바 + 모바일 하단 탭 바 (BottomNav)
+- **레이아웃**: 데스크톱 사이드바 + 모바일 하단 탭 바 (사용자/관리자 분리)
+- **공지 배너**: 글로벌 상단 배너 (관리자가 공지 글에서 활성화, 1개만 노출)
+- **Pull-to-Refresh**: 커스텀 터치 제스처 기반 새로고침 (Safari PWA 최적화)
 - **PWA**: 홈 화면 추가 지원 (manifest.json, 서비스 워커 없음)
+- **랜딩 페이지**: 인증 유저 자동 리다이렉트 (`/` → `/dashboard`)
 - **상세 스펙**: `docs/26-03-06-ui-design-system.md` 참조
 
 ## 에이전트 활용 가이드

--- a/docs/26-03-06-patterns.md
+++ b/docs/26-03-06-patterns.md
@@ -214,7 +214,8 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 ### API: `GET /api/notice-banner`
 - 인증 필수 (`getBoardAuth`)
 - `isNoticeBanner: true` + `isPinned: true` + `deletedAt IS NULL`인 글 1개 반환
-- `Cache-Control: private, max-age=60` 적용
+- `title`, `contentText`, `memberName` 포함
+- `Cache-Control: no-store` (새 공지 즉시 반영)
 
 ### 배너 활성화 로직 (POST/PATCH)
 - `isNoticeBanner` 설정 시 기존 배너 자동 비활성화 (트랜잭션)
@@ -231,8 +232,25 @@ const [result] = await database.transaction(async (tx) => {
 ```
 
 ### 클라이언트 (`NoticeBanner` 컴포넌트)
-- localStorage로 접기/닫기 상태 유지 (공지 ID별, 새 공지 시 자동 리셋)
-- 상태: `open` → `collapsed` → `closed`
+- localStorage로 상태 유지 (공지 ID별, 새 공지 시 자동 리셋)
+- 상태: `open` (제목+내용 미리보기) → `collapsed` (제목만) → `closed` (숨김)
+- 관리자 페이지에서는 미표시 (`{!isAdmin && <NoticeBanner />}`)
+
+### Tiptap 에디터 한글 IME 대응
+
+```ts
+// compositionstart/end로 IME 조합 중 onUpdate 차단
+editorProps: {
+  handleDOMEvents: {
+    compositionstart: () => { composingRef.current = true; return false; },
+    compositionend: (_view) => {
+      composingRef.current = false;
+      requestAnimationFrame(() => onChange(...));
+      return false;
+    },
+  },
+},
+```
 
 ## 카테고리 서버사이드 검증
 

--- a/docs/26-03-06-patterns.md
+++ b/docs/26-03-06-patterns.md
@@ -207,6 +207,42 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 | `Errors.notFound(msg)` | 404 |
 | `Errors.badRequest(msg)` | 400 |
 
+## 공지 배너 패턴
+
+게시판 공지 글 중 1개를 전역 배너로 표시. 관리자만 설정 가능.
+
+### API: `GET /api/notice-banner`
+- 인증 필수 (`getBoardAuth`)
+- `isNoticeBanner: true` + `isPinned: true` + `deletedAt IS NULL`인 글 1개 반환
+- `Cache-Control: private, max-age=60` 적용
+
+### 배너 활성화 로직 (POST/PATCH)
+- `isNoticeBanner` 설정 시 기존 배너 자동 비활성화 (트랜잭션)
+- 관리자 전용: `category === 'notice'` 또는 `isNoticeBanner` 설정 시 `auth.isAdmin` 필수
+
+```ts
+// 트랜잭션 패턴 (배너 clear + set 원자적 처리)
+const [result] = await database.transaction(async (tx) => {
+  if (bannerEnabled) {
+    await tx.update(boardPosts).set({ isNoticeBanner: false }).where(eq(boardPosts.isNoticeBanner, true));
+  }
+  return tx.insert(boardPosts).values({ ... }).returning();
+});
+```
+
+### 클라이언트 (`NoticeBanner` 컴포넌트)
+- localStorage로 접기/닫기 상태 유지 (공지 ID별, 새 공지 시 자동 리셋)
+- 상태: `open` → `collapsed` → `closed`
+
+## 카테고리 서버사이드 검증
+
+```ts
+import { isValidCategory } from '@/lib/board-config';
+if (!isValidCategory(category)) {
+  return Errors.badRequest('유효하지 않은 카테고리입니다.').toResponse();
+}
+```
+
 ## MemberAvatar 재사용 컴포넌트
 
 프로필 아바타 + 이름 + 멤버 상세 링크 + 관리자 뱃지를 통합 제공:

--- a/docs/26-03-06-schema-summary.md
+++ b/docs/26-03-06-schema-summary.md
@@ -112,6 +112,7 @@
 | `content_text` | text | 검색용 평문, not null |
 | `is_secret` | boolean | default false |
 | `is_pinned` | boolean | default false |
+| `is_notice_banner` | boolean | default false, 글로벌 배너 활성화 (1개만) |
 | `comment_count` | integer | default 0 |
 | `created_at`, `updated_at` | timestamptz | defaultNow |
 | `deleted_at` | timestamptz | nullable (soft delete) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,6 +46,8 @@ graph TB
     subgraph Web["Web Dashboard · Vercel"]
         MW["Middleware<br/>세션 검증"]
         PAGES["Pages<br/>Dashboard · Posts · Ranking<br/>Profile · Curation · Board<br/>Admin (Members · Rounds · Attendance<br/>Fines · Scores · Curation · Settings)"]
+        PTR["Pull-to-Refresh<br/>커스텀 터치 제스처"]
+        BANNER["Notice Banner<br/>글로벌 공지 배너"]
         PWA["PWA<br/>manifest.json<br/>홈 화면 추가"]
         API["API Routes<br/>/api/auth · /api/posts<br/>/api/admin · /api/board · ..."]
         SUPA_CLIENT["Supabase SSR Client<br/>@supabase/ssr"]
@@ -210,7 +212,7 @@ flowchart TD
 
 | 그룹 | 경로 | 설명 | 보호 |
 |------|------|------|------|
-| Public | `/` | 랜딩 페이지 | - |
+| Public | `/` | 랜딩 페이지 (인증 시 → `/dashboard` 리다이렉트) | 서버 사이드 세션 체크 |
 | Auth | `/login` | Discord OAuth 로그인 | 인증 시 /dashboard 리다이렉트 |
 | User | `/dashboard` | 대시보드 | 로그인 필수 |
 | User | `/posts` | 글 목록 | 로그인 필수 |
@@ -340,6 +342,7 @@ erDiagram
         varchar category
         varchar title
         jsonb content
+        boolean is_notice_banner
         integer comment_count
     }
 
@@ -377,9 +380,12 @@ erDiagram
 | 뷰포트 | 내비게이션 | 컴포넌트 |
 |--------|-----------|---------|
 | Desktop (md+) | 좌측 고정 사이드바 (접기/펼치기) | `Sidebar` |
-| Mobile (<md) | 하단 고정 탭 바 (5개 메뉴) | `BottomNav` |
+| Mobile 사용자 (<md) | 하단 고정 탭 바 (5개: 글 목록/랭킹/큐레이션/게시판/스터디원) | `BottomNav` |
+| Mobile 관리자 (<md) | 하단 고정 탭 바 (6개: 멤버/회차/출석/벌금/점수/큐레이션) | `BottomNav` |
 
-- **Header**: 로고 + 다크모드 토글 + 프로필 드롭다운 (관리자 링크 포함)
+- **Header**: 로고(사용자→`/dashboard`, 관리자→`/admin`) + 다크모드 토글 + 프로필 드롭다운 (사용자↔관리자 전환)
+- **공지 배너**: 전역 상단 스카이블루 배너 (`NoticeBanner`), 관리자가 공지 글에서 활성화 (1개만), 접기/닫기 localStorage 유지
+- **Pull-to-Refresh**: 커스텀 터치 제스처 기반 새로고침 (`PullToRefresh` + `usePullToRefresh`), Safari PWA 최적화
 - **PWA**: `manifest.json` + 아이콘 (192/512) → 홈 화면 추가 지원, 서비스 워커 없음 (lightweight)
 
 ## 스케줄러 (pg-boss)

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -305,10 +305,7 @@ export const postViews = pgTable(
     viewedAt: timestamp('viewed_at', { withTimezone: true }).defaultNow(),
   },
   (table) => ({
-    memberPostUnique: uniqueIndex('post_views_member_post_unique').on(
-      table.memberId,
-      table.postId
-    ),
+    memberPostUnique: uniqueIndex('post_views_member_post_unique').on(table.memberId, table.postId),
     memberIdIdx: index('idx_post_views_member_id').on(table.memberId),
   })
 );
@@ -349,6 +346,7 @@ export const boardPosts = pgTable(
     contentText: text('content_text').notNull(),
     isSecret: boolean('is_secret').default(false),
     isPinned: boolean('is_pinned').default(false),
+    isNoticeBanner: boolean('is_notice_banner').default(false),
     commentCount: integer('comment_count').default(0),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),

--- a/packages/web/proxy.ts
+++ b/packages/web/proxy.ts
@@ -2,13 +2,7 @@ import { type NextRequest, NextResponse } from 'next/server';
 import { updateSession } from '@/lib/supabase/middleware';
 import { isAdminDiscordId } from '@/lib/admin';
 
-const protectedRoutes = [
-  '/dashboard',
-  '/posts',
-  '/curation',
-  '/ranking',
-  '/profile',
-];
+const protectedRoutes = ['/dashboard', '/posts', '/curation', '/ranking', '/profile'];
 
 const adminRoutes = ['/admin'];
 
@@ -46,12 +40,10 @@ export async function proxy(request: NextRequest) {
       return NextResponse.redirect(loginUrl);
     }
 
-    const discordIdentity = user?.identities?.find(
-      (identity) => identity.provider === 'discord'
-    );
+    const discordIdentity = user?.identities?.find((identity) => identity.provider === 'discord');
     const discordId = discordIdentity?.id;
 
-    if (!discordId || !isAdminDiscordId(discordId)) {
+    if (!discordId || !(await isAdminDiscordId(discordId))) {
       return NextResponse.redirect(new URL('/dashboard', request.url));
     }
 
@@ -62,7 +54,5 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: [
-    '/((?!api|_next/static|_next/image|favicon.ico|.*\\..*|_next).*)',
-  ],
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|.*\\..*|_next).*)'],
 };

--- a/packages/web/src/app/(admin)/admin/members/page.tsx
+++ b/packages/web/src/app/(admin)/admin/members/page.tsx
@@ -200,7 +200,7 @@ export default function AdminMembersPage() {
     <div className="space-y-6">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">참가자 관리</h1>
+          <h1 className="text-3xl font-bold tracking-tight">멤버 관리</h1>
           <p className="text-muted-foreground">
             스터디 참가자를 관리하세요.
           </p>

--- a/packages/web/src/app/(admin)/admin/page.tsx
+++ b/packages/web/src/app/(admin)/admin/page.tsx
@@ -3,9 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import {
-  Calendar,
   FileText,
-  Clock,
   Users,
   CreditCard,
   TrendingUp,
@@ -343,39 +341,6 @@ export default function AdminDashboardPage() {
         </Card>
       </div>
 
-      {/* Quick Actions */}
-      <div className="flex flex-wrap gap-1">
-        <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-foreground" asChild>
-          <Link href="/admin/members">
-            <Users className="h-4 w-4 mr-1.5" />
-            <span className="text-sm">참가자 관리</span>
-          </Link>
-        </Button>
-        <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-foreground" asChild>
-          <Link href="/admin/attendance">
-            <Calendar className="h-4 w-4 mr-1.5" />
-            <span className="text-sm">출석 현황</span>
-          </Link>
-        </Button>
-        <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-foreground" asChild>
-          <Link href="/admin/fines">
-            <CreditCard className="h-4 w-4 mr-1.5" />
-            <span className="text-sm">벌금 관리</span>
-          </Link>
-        </Button>
-        <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-foreground" asChild>
-          <Link href="/admin/settings">
-            <Clock className="h-4 w-4 mr-1.5" />
-            <span className="text-sm">설정</span>
-          </Link>
-        </Button>
-        <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-foreground" asChild>
-          <Link href="/admin/curation">
-            <FileText className="h-4 w-4 mr-1.5" />
-            <span className="text-sm">큐레이션</span>
-          </Link>
-        </Button>
-      </div>
     </div>
   );
 }

--- a/packages/web/src/app/(admin)/admin/scores/page.tsx
+++ b/packages/web/src/app/(admin)/admin/scores/page.tsx
@@ -517,10 +517,7 @@ export default function AdminScoresPage() {
       {/* ── Page header ─────────────────────────────────────────────────── */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <div className="flex items-center gap-2 mb-1">
-            <Star className="h-5 w-5 text-sky-500" />
-            <h1 className="text-3xl font-bold tracking-tight">점수 관리</h1>
-          </div>
+          <h1 className="text-3xl font-bold tracking-tight">점수 관리</h1>
           <p className="text-muted-foreground">멤버에게 활동 점수를 직접 부여하거나 차감하세요.</p>
         </div>
       </div>

--- a/packages/web/src/app/(user)/board/[id]/edit/page.tsx
+++ b/packages/web/src/app/(user)/board/[id]/edit/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { useRouter, useParams } from 'next/navigation';
-import { ArrowLeft, Loader2, Lock } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { ArrowLeft, Loader2, Lock, Megaphone } from 'lucide-react';
 import { TiptapEditor } from '@/components/board/tiptap-editor';
 import { BOARD_CATEGORIES } from '@/lib/board-config';
 import {
@@ -37,6 +37,7 @@ export default function BoardEditPage() {
   const [contentText, setContentText] = useState('');
   const [initialContent, setInitialContent] = useState<object | null>(null);
   const [isSecret, setIsSecret] = useState(false);
+  const [isNoticeBanner, setIsNoticeBanner] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -84,6 +85,7 @@ export default function BoardEditPage() {
         setCategory(post.category);
         setTitle(post.title);
         setIsSecret(post.isSecret);
+        setIsNoticeBanner(post.isNoticeBanner ?? false);
 
         // Set initial content for TiptapEditor (JSON object from DB)
         if (post.content && typeof post.content === 'object') {
@@ -101,9 +103,7 @@ export default function BoardEditPage() {
     loadData();
   }, [id, router]);
 
-  const visibleCategories = BOARD_CATEGORIES.filter(
-    (cat) => cat.value !== 'notice' || isAdmin
-  );
+  const visibleCategories = BOARD_CATEGORIES.filter((cat) => cat.value !== 'notice' || isAdmin);
 
   const handleEditorChange = (json: object, text: string) => {
     setContent(json);
@@ -137,6 +137,7 @@ export default function BoardEditPage() {
           content,
           contentText: contentText.trim(),
           isSecret,
+          isNoticeBanner: category === 'notice' ? isNoticeBanner : false,
         }),
       });
 
@@ -235,9 +236,7 @@ export default function BoardEditPage() {
               </Label>
               <span
                 className={`text-xs tabular-nums ${
-                  titleCharCount >= titleLimit
-                    ? 'text-destructive'
-                    : 'text-muted-foreground'
+                  titleCharCount >= titleLimit ? 'text-destructive' : 'text-muted-foreground'
                 }`}
               >
                 {titleCharCount}/{titleLimit}
@@ -267,6 +266,28 @@ export default function BoardEditPage() {
             )}
           </div>
 
+          {/* Notice Banner Toggle (admin + notice only) */}
+          {isAdmin && category === 'notice' && (
+            <div className="flex items-center justify-between rounded-lg border border-sky-200/60 dark:border-sky-800/40 bg-sky-50/50 dark:bg-sky-950/20 px-4 py-3">
+              <div className="flex items-center gap-2.5">
+                <Megaphone className="h-4 w-4 text-sky-600 dark:text-sky-400 shrink-0" />
+                <div className="space-y-0.5">
+                  <Label htmlFor="isNoticeBanner" className="text-sm font-medium cursor-pointer">
+                    상단 배너에 표시
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    모든 페이지 상단에 공지 배너로 표시됩니다. 기존 배너는 자동 해제됩니다.
+                  </p>
+                </div>
+              </div>
+              <Switch
+                id="isNoticeBanner"
+                checked={isNoticeBanner}
+                onCheckedChange={setIsNoticeBanner}
+              />
+            </div>
+          )}
+
           {/* Divider */}
           <div className="border-t border-border/40" />
 
@@ -283,11 +304,7 @@ export default function BoardEditPage() {
                 </p>
               </div>
             </div>
-            <Switch
-              id="isSecret"
-              checked={isSecret}
-              onCheckedChange={setIsSecret}
-            />
+            <Switch id="isSecret" checked={isSecret} onCheckedChange={setIsSecret} />
           </div>
         </CardContent>
       </Card>

--- a/packages/web/src/app/(user)/board/write/page.tsx
+++ b/packages/web/src/app/(user)/board/write/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { ArrowLeft, Loader2, Lock } from 'lucide-react';
+import { ArrowLeft, Loader2, Lock, Megaphone } from 'lucide-react';
 import { TiptapEditor } from '@/components/board/tiptap-editor';
 import { BOARD_CATEGORIES } from '@/lib/board-config';
 import {
@@ -31,6 +31,7 @@ export default function BoardWritePage() {
   const [content, setContent] = useState<object | null>(null);
   const [contentText, setContentText] = useState('');
   const [isSecret, setIsSecret] = useState(false);
+  const [isNoticeBanner, setIsNoticeBanner] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -42,9 +43,7 @@ export default function BoardWritePage() {
       .catch(() => setIsAdmin(false));
   }, []);
 
-  const visibleCategories = BOARD_CATEGORIES.filter(
-    (cat) => cat.value !== 'notice' || isAdmin
-  );
+  const visibleCategories = BOARD_CATEGORIES.filter((cat) => cat.value !== 'notice' || isAdmin);
 
   const handleEditorChange = (json: object, text: string) => {
     setContent(json);
@@ -79,6 +78,7 @@ export default function BoardWritePage() {
           content,
           contentText: contentText.trim(),
           isSecret,
+          isNoticeBanner: category === 'notice' ? isNoticeBanner : false,
         }),
       });
 
@@ -156,9 +156,7 @@ export default function BoardWritePage() {
               </Label>
               <span
                 className={`text-xs tabular-nums ${
-                  titleCharCount >= titleLimit
-                    ? 'text-destructive'
-                    : 'text-muted-foreground'
+                  titleCharCount >= titleLimit ? 'text-destructive' : 'text-muted-foreground'
                 }`}
               >
                 {titleCharCount}/{titleLimit}
@@ -179,11 +177,30 @@ export default function BoardWritePage() {
             <Label className="text-sm font-medium">
               내용 <span className="text-destructive">*</span>
             </Label>
-            <TiptapEditor
-              onChange={handleEditorChange}
-              placeholder="내용을 입력해주세요..."
-            />
+            <TiptapEditor onChange={handleEditorChange} placeholder="내용을 입력해주세요..." />
           </div>
+
+          {/* Notice Banner Toggle (admin + notice only) */}
+          {isAdmin && category === 'notice' && (
+            <div className="flex items-center justify-between rounded-lg border border-sky-200/60 dark:border-sky-800/40 bg-sky-50/50 dark:bg-sky-950/20 px-4 py-3">
+              <div className="flex items-center gap-2.5">
+                <Megaphone className="h-4 w-4 text-sky-600 dark:text-sky-400 shrink-0" />
+                <div className="space-y-0.5">
+                  <Label htmlFor="isNoticeBanner" className="text-sm font-medium cursor-pointer">
+                    상단 배너에 표시
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    모든 페이지 상단에 공지 배너로 표시됩니다. 기존 배너는 자동 해제됩니다.
+                  </p>
+                </div>
+              </div>
+              <Switch
+                id="isNoticeBanner"
+                checked={isNoticeBanner}
+                onCheckedChange={setIsNoticeBanner}
+              />
+            </div>
+          )}
 
           {/* Divider */}
           <div className="border-t border-border/40" />
@@ -201,11 +218,7 @@ export default function BoardWritePage() {
                 </p>
               </div>
             </div>
-            <Switch
-              id="isSecret"
-              checked={isSecret}
-              onCheckedChange={setIsSecret}
-            />
+            <Switch id="isSecret" checked={isSecret} onCheckedChange={setIsSecret} />
           </div>
         </CardContent>
       </Card>

--- a/packages/web/src/app/api/board/[id]/route.ts
+++ b/packages/web/src/app/api/board/[id]/route.ts
@@ -1,17 +1,15 @@
 import { NextRequest } from 'next/server';
-import { eq, and, isNull, asc } from 'drizzle-orm';
+import { and, asc, eq, isNull } from 'drizzle-orm';
 import { getDb } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { getBoardAuth } from '@/lib/board-auth';
-import { successResponse, errorResponse, Errors } from '@/lib/api-error';
+import { errorResponse, Errors, successResponse } from '@/lib/api-error';
 import { getAdminDiscordIds } from '@/lib/admin';
+import { isValidCategory } from '@/lib/board-config';
 
 const { boardPosts, boardComments, members } = sharedDb;
 
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const auth = await getBoardAuth();
     if (!auth) return Errors.unauthorized().toResponse();
@@ -32,6 +30,7 @@ export async function GET(
         contentText: boardPosts.contentText,
         isSecret: boardPosts.isSecret,
         isPinned: boardPosts.isPinned,
+        isNoticeBanner: boardPosts.isNoticeBanner,
         commentCount: boardPosts.commentCount,
         createdAt: boardPosts.createdAt,
         updatedAt: boardPosts.updatedAt,
@@ -122,10 +121,7 @@ export async function GET(
   }
 }
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const auth = await getBoardAuth();
     if (!auth) return Errors.unauthorized().toResponse();
@@ -145,25 +141,47 @@ export async function PATCH(
     }
 
     const body = await request.json();
-    const { category, title, content, contentText, isSecret } = body;
+    const { category, title, content, contentText, isSecret, isNoticeBanner } = body;
 
-    if (category === 'notice' && !auth.isAdmin) {
-      return Errors.forbidden('공지는 관리자만 작성할 수 있습니다.').toResponse();
+    if (category && !isValidCategory(category)) {
+      return Errors.badRequest('유효하지 않은 카테고리입니다.').toResponse();
     }
 
-    const [updated] = await database
-      .update(boardPosts)
-      .set({
-        ...(category && { category }),
-        ...(title && { title: title.trim() }),
-        ...(content && { content }),
-        ...(contentText && { contentText: contentText.trim() }),
-        ...(isSecret !== undefined && { isSecret }),
-        isPinned: (category || existing.category) === 'notice',
-        updatedAt: new Date(),
-      })
-      .where(eq(boardPosts.id, id))
-      .returning();
+    // Admin-only: notice category or banner toggle
+    if (
+      (category === 'notice' || existing.category === 'notice' || isNoticeBanner) &&
+      !auth.isAdmin
+    ) {
+      return Errors.forbidden('공지 관련 설정은 관리자만 변경할 수 있습니다.').toResponse();
+    }
+
+    const effectiveCategory = category || existing.category;
+    const effectiveBanner = effectiveCategory === 'notice' ? Boolean(isNoticeBanner) : false;
+
+    const [updated] = await database.transaction(async (tx) => {
+      // If enabling banner, disable all existing banners first
+      if (effectiveBanner) {
+        await tx
+          .update(boardPosts)
+          .set({ isNoticeBanner: false })
+          .where(eq(boardPosts.isNoticeBanner, true));
+      }
+
+      return tx
+        .update(boardPosts)
+        .set({
+          ...(category && { category }),
+          ...(title && { title: title.trim() }),
+          ...(content && { content }),
+          ...(contentText && { contentText: contentText.trim() }),
+          ...(isSecret !== undefined && { isSecret }),
+          isPinned: effectiveCategory === 'notice',
+          isNoticeBanner: effectiveBanner,
+          updatedAt: new Date(),
+        })
+        .where(eq(boardPosts.id, id))
+        .returning();
+    });
 
     return successResponse(updated, '게시글이 수정되었습니다.');
   } catch (error) {
@@ -193,10 +211,7 @@ export async function DELETE(
       return Errors.forbidden('삭제 권한이 없습니다.').toResponse();
     }
 
-    await database
-      .update(boardPosts)
-      .set({ deletedAt: new Date() })
-      .where(eq(boardPosts.id, id));
+    await database.update(boardPosts).set({ deletedAt: new Date() }).where(eq(boardPosts.id, id));
 
     return successResponse(null, '게시글이 삭제되었습니다.');
   } catch (error) {

--- a/packages/web/src/app/api/board/route.ts
+++ b/packages/web/src/app/api/board/route.ts
@@ -1,16 +1,17 @@
 import { NextRequest } from 'next/server';
-import { eq, desc, and, isNull, count } from 'drizzle-orm';
+import { and, count, desc, eq, isNull } from 'drizzle-orm';
 import { getDb } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { getBoardAuth } from '@/lib/board-auth';
 import {
-  successResponse,
+  createPaginationMeta,
   errorResponse,
   Errors,
   parsePagination,
-  createPaginationMeta,
+  successResponse,
 } from '@/lib/api-error';
 import { getAdminDiscordIds } from '@/lib/admin';
+import { isValidCategory } from '@/lib/board-config';
 
 const { boardPosts, members } = sharedDb;
 
@@ -47,17 +48,15 @@ export async function GET(request: NextRequest) {
     };
 
     // Pinned notices (when no category filter, or filtering by notice)
-    const pinnedPosts = !category || category === 'notice'
-      ? await database
-          .select(selectFields)
-          .from(boardPosts)
-          .innerJoin(members, eq(boardPosts.memberId, members.id))
-          .where(and(
-            isNull(boardPosts.deletedAt),
-            eq(boardPosts.isPinned, true),
-          ))
-          .orderBy(desc(boardPosts.createdAt))
-      : [];
+    const pinnedPosts =
+      !category || category === 'notice'
+        ? await database
+            .select(selectFields)
+            .from(boardPosts)
+            .innerJoin(members, eq(boardPosts.memberId, members.id))
+            .where(and(isNull(boardPosts.deletedAt), eq(boardPosts.isPinned, true)))
+            .orderBy(desc(boardPosts.createdAt))
+        : [];
 
     // Normal posts (pinned excluded)
     const normalConditions = [...baseConditions, eq(boardPosts.isPinned, false)];
@@ -80,7 +79,7 @@ export async function GET(request: NextRequest) {
     const adminDiscordIds = await getAdminDiscordIds();
 
     // Mask secret posts for non-owner non-admin
-    const maskSecret = (post: typeof normalPosts[number]) => {
+    const maskSecret = (post: (typeof normalPosts)[number]) => {
       if (post.isSecret && post.memberId !== auth.memberId && !auth.isAdmin) {
         return {
           ...post,
@@ -116,32 +115,48 @@ export async function POST(request: NextRequest) {
     if (!auth) return Errors.unauthorized().toResponse();
 
     const body = await request.json();
-    const { category, title, content, contentText, isSecret } = body;
+    const { category, title, content, contentText, isSecret, isNoticeBanner } = body;
 
     // Validation
     if (!category || !title?.trim() || !content || !contentText?.trim()) {
       return Errors.badRequest('필수 항목을 입력해주세요.').toResponse();
     }
 
-    // Only admins can create notices
-    if (category === 'notice' && !auth.isAdmin) {
+    if (!isValidCategory(category)) {
+      return Errors.badRequest('유효하지 않은 카테고리입니다.').toResponse();
+    }
+
+    // Only admins can create notices or set banner
+    if ((category === 'notice' || isNoticeBanner) && !auth.isAdmin) {
       return Errors.forbidden('공지는 관리자만 작성할 수 있습니다.').toResponse();
     }
 
     const database = getDb();
+    const bannerEnabled = category === 'notice' && Boolean(isNoticeBanner);
 
-    const [newPost] = await database
-      .insert(boardPosts)
-      .values({
-        memberId: auth.memberId,
-        category,
-        title: title.trim(),
-        content,
-        contentText: contentText.trim(),
-        isSecret: isSecret || false,
-        isPinned: category === 'notice',
-      })
-      .returning();
+    const [newPost] = await database.transaction(async (tx) => {
+      // If enabling banner, disable all existing banners first
+      if (bannerEnabled) {
+        await tx
+          .update(boardPosts)
+          .set({ isNoticeBanner: false })
+          .where(eq(boardPosts.isNoticeBanner, true));
+      }
+
+      return tx
+        .insert(boardPosts)
+        .values({
+          memberId: auth.memberId,
+          category,
+          title: title.trim(),
+          content,
+          contentText: contentText.trim(),
+          isSecret: isSecret || false,
+          isPinned: category === 'notice',
+          isNoticeBanner: bannerEnabled,
+        })
+        .returning();
+    });
 
     return successResponse(newPost, '게시글이 작성되었습니다.', 201);
   } catch (error) {

--- a/packages/web/src/app/api/notice-banner/route.ts
+++ b/packages/web/src/app/api/notice-banner/route.ts
@@ -17,6 +17,7 @@ export async function GET() {
       .select({
         id: boardPosts.id,
         title: boardPosts.title,
+        contentText: boardPosts.contentText,
         createdAt: boardPosts.createdAt,
         memberName: members.nickname,
       })

--- a/packages/web/src/app/api/notice-banner/route.ts
+++ b/packages/web/src/app/api/notice-banner/route.ts
@@ -1,0 +1,40 @@
+import { and, eq, isNull } from 'drizzle-orm';
+import { getDb } from '@/lib/db';
+import { db as sharedDb } from '@blog-study/shared';
+import { getBoardAuth } from '@/lib/board-auth';
+import { errorResponse, Errors, successResponse } from '@/lib/api-error';
+
+const { boardPosts, members } = sharedDb;
+
+export async function GET() {
+  try {
+    const auth = await getBoardAuth();
+    if (!auth) return Errors.unauthorized().toResponse();
+
+    const database = getDb();
+
+    const [banner] = await database
+      .select({
+        id: boardPosts.id,
+        title: boardPosts.title,
+        createdAt: boardPosts.createdAt,
+        memberName: members.nickname,
+      })
+      .from(boardPosts)
+      .innerJoin(members, eq(boardPosts.memberId, members.id))
+      .where(
+        and(
+          eq(boardPosts.isNoticeBanner, true),
+          eq(boardPosts.isPinned, true),
+          isNull(boardPosts.deletedAt)
+        )
+      )
+      .limit(1);
+
+    const response = successResponse(banner || null);
+    response.headers.set('Cache-Control', 'private, max-age=60, stale-while-revalidate=300');
+    return response;
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/packages/web/src/app/api/notice-banner/route.ts
+++ b/packages/web/src/app/api/notice-banner/route.ts
@@ -33,7 +33,7 @@ export async function GET() {
       .limit(1);
 
     const response = successResponse(banner || null);
-    response.headers.set('Cache-Control', 'private, max-age=60, stale-while-revalidate=300');
+    response.headers.set('Cache-Control', 'no-store');
     return response;
   } catch (error) {
     return errorResponse(error);

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -1,13 +1,8 @@
 import Link from 'next/link';
-import {
-  Rss,
-  Activity,
-  CalendarCheck,
-  Banknote,
-  Trophy,
-  Newspaper,
-} from 'lucide-react';
+import { redirect } from 'next/navigation';
+import { Activity, Banknote, CalendarCheck, Newspaper, Rss, Trophy } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { createClient } from '@/lib/supabase/server';
 
 // ---------------------------------------------------------------------------
 // Data
@@ -50,7 +45,17 @@ const features = [
 // Page
 // ---------------------------------------------------------------------------
 
-export default function Home() {
+export default async function Home() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (!error && user) {
+    redirect('/dashboard');
+  }
+
   return (
     <div className="flex min-h-screen flex-col bg-background text-foreground">
       {/* ------------------------------------------------------------------ */}
@@ -60,12 +65,8 @@ export default function Home() {
         <nav className="mx-auto flex h-14 max-w-6xl items-center justify-between px-6">
           {/* Logo */}
           <Link href="/" className="flex items-center gap-2.5">
-            <span className="text-lg font-bold tracking-tight text-primary">
-              BS
-            </span>
-            <span className="text-sm font-medium text-foreground/80">
-              블로그 스터디
-            </span>
+            <span className="text-lg font-bold tracking-tight text-primary">BS</span>
+            <span className="text-sm font-medium text-foreground/80">블로그 스터디</span>
           </Link>
 
           {/* Right actions */}
@@ -96,8 +97,7 @@ export default function Home() {
 
         {/* Subtext */}
         <p className="mt-6 max-w-xl text-base leading-relaxed text-muted-foreground sm:text-lg">
-          봇이 글을 수집하고, 출석을 관리하고, 대시보드에서 한눈에
-          확인하세요.
+          봇이 글을 수집하고, 출석을 관리하고, 대시보드에서 한눈에 확인하세요.
         </p>
 
         {/* CTA */}
@@ -105,9 +105,7 @@ export default function Home() {
           <Button size="lg" asChild className="h-11 px-8 text-sm font-semibold">
             <Link href="/login">Discord로 시작하기</Link>
           </Button>
-          <p className="text-xs text-muted-foreground">
-            무료로 시작 · 설정 5분
-          </p>
+          <p className="text-xs text-muted-foreground">무료로 시작 · 설정 5분</p>
         </div>
       </section>
 
@@ -134,12 +132,8 @@ export default function Home() {
                 className="group rounded-lg border border-border bg-card p-6 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md"
               >
                 <Icon className="mb-4 h-10 w-10 text-primary" strokeWidth={1.5} />
-                <h3 className="mb-1.5 text-sm font-semibold text-foreground">
-                  {title}
-                </h3>
-                <p className="text-sm leading-relaxed text-muted-foreground">
-                  {description}
-                </p>
+                <h3 className="mb-1.5 text-sm font-semibold text-foreground">{title}</h3>
+                <p className="text-sm leading-relaxed text-muted-foreground">{description}</p>
               </div>
             ))}
           </div>
@@ -152,10 +146,7 @@ export default function Home() {
       <footer className="mt-auto border-t border-border px-6 py-6">
         <div className="mx-auto flex max-w-6xl items-center justify-between text-xs text-muted-foreground">
           <span>© 2026 블로그 스터디</span>
-          <Link
-            href="#"
-            className="transition-colors hover:text-foreground"
-          >
+          <Link href="#" className="transition-colors hover:text-foreground">
             GitHub
           </Link>
         </div>

--- a/packages/web/src/components/board/tiptap-editor.tsx
+++ b/packages/web/src/components/board/tiptap-editor.tsx
@@ -17,10 +17,14 @@ import { common, createLowlight } from 'lowlight';
 import {
   Bold,
   Code,
+  Heading1,
+  Heading2,
+  Heading3,
   Italic,
   Link as LinkIcon,
   List,
   ListOrdered,
+  Minus,
   Quote,
   Redo,
   Strikethrough,
@@ -202,6 +206,35 @@ export function TiptapEditor({
         {editable && (
           <div className="flex flex-wrap items-center gap-0.5 border-b border-zinc-200 dark:border-zinc-800 p-1.5">
             <ToolbarButton
+              onClick={() => editor.chain().focus().setParagraph().run()}
+              active={editor.isActive('paragraph') && !editor.isActive('heading')}
+              title="본문"
+            >
+              <span className="text-xs font-semibold w-4 h-4 flex items-center justify-center">T</span>
+            </ToolbarButton>
+            <ToolbarButton
+              onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
+              active={editor.isActive('heading', { level: 1 })}
+              title="제목 1"
+            >
+              <Heading1 className="h-4 w-4" />
+            </ToolbarButton>
+            <ToolbarButton
+              onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+              active={editor.isActive('heading', { level: 2 })}
+              title="제목 2"
+            >
+              <Heading2 className="h-4 w-4" />
+            </ToolbarButton>
+            <ToolbarButton
+              onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
+              active={editor.isActive('heading', { level: 3 })}
+              title="제목 3"
+            >
+              <Heading3 className="h-4 w-4" />
+            </ToolbarButton>
+            <div className="mx-1 h-5 w-px bg-zinc-200 dark:bg-zinc-700" />
+            <ToolbarButton
               onClick={() => editor.chain().focus().toggleBold().run()}
               active={editor.isActive('bold')}
               title="굵게"
@@ -250,6 +283,12 @@ export function TiptapEditor({
               title="코드 블록"
             >
               <Code className="h-4 w-4" />
+            </ToolbarButton>
+            <ToolbarButton
+              onClick={() => editor.chain().focus().setHorizontalRule().run()}
+              title="구분선"
+            >
+              <Minus className="h-4 w-4" />
             </ToolbarButton>
             <div className="mx-1 h-5 w-px bg-zinc-200 dark:bg-zinc-700" />
             {isLinkActive ? (

--- a/packages/web/src/components/board/tiptap-editor.tsx
+++ b/packages/web/src/components/board/tiptap-editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type { NodeViewProps } from '@tiptap/react';
 import {
   EditorContent,
@@ -163,6 +163,7 @@ export function TiptapEditor({
 }: TiptapEditorProps) {
   const [linkDialogOpen, setLinkDialogOpen] = useState(false);
   const [linkUrl, setLinkUrl] = useState('');
+  const composingRef = useRef(false);
 
   const editor = useEditor({
     immediatelyRender: false,
@@ -179,7 +180,27 @@ export function TiptapEditor({
     content: content || '',
     editable,
     onUpdate: ({ editor: e }) => {
+      if (composingRef.current) return;
       onChange(e.getJSON(), e.getText());
+    },
+    editorProps: {
+      handleDOMEvents: {
+        compositionstart: () => { composingRef.current = true; return false; },
+        compositionend: (_view, event) => {
+          composingRef.current = false;
+          // event.target is the editor element; trigger deferred update
+          const target = event.target as HTMLElement;
+          requestAnimationFrame(() => {
+            if (target.closest('.ProseMirror')) {
+              const e = _view;
+              const json = e.state.doc.toJSON();
+              const text = e.state.doc.textContent;
+              onChange({ type: 'doc', content: json.content }, text);
+            }
+          });
+          return false;
+        },
+      },
     },
   });
 

--- a/packages/web/src/components/layout/bottom-nav.tsx
+++ b/packages/web/src/components/layout/bottom-nav.tsx
@@ -2,18 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import {
-  Banknote,
-  CalendarCheck,
-  CalendarRange,
-  FileText,
-  MessageSquare,
-  Newspaper,
-  Star,
-  Trophy,
-  Users,
-  UsersRound,
-} from 'lucide-react';
+import { FileText, MessageSquare, Newspaper, Trophy, UsersRound } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface NavItem {
@@ -22,21 +11,12 @@ interface NavItem {
   icon: React.ComponentType<{ className?: string }>;
 }
 
-const userNavItems: NavItem[] = [
+const navItems: NavItem[] = [
   { title: '글 목록', href: '/posts', icon: FileText },
   { title: '랭킹', href: '/ranking', icon: Trophy },
   { title: '큐레이션', href: '/curation', icon: Newspaper },
   { title: '게시판', href: '/board', icon: MessageSquare },
   { title: '스터디원', href: '/members', icon: UsersRound },
-];
-
-const adminNavItems: NavItem[] = [
-  { title: '멤버', href: '/admin/members', icon: Users },
-  { title: '회차', href: '/admin/rounds', icon: CalendarRange },
-  { title: '출석', href: '/admin/attendance', icon: CalendarCheck },
-  { title: '벌금', href: '/admin/fines', icon: Banknote },
-  { title: '점수', href: '/admin/scores', icon: Star },
-  { title: '큐레이션', href: '/admin/curation', icon: Newspaper },
 ];
 
 interface BottomNavProps {
@@ -45,7 +25,9 @@ interface BottomNavProps {
 
 export function BottomNav({ isAdmin = false }: BottomNavProps) {
   const pathname = usePathname();
-  const navItems = isAdmin ? adminNavItems : userNavItems;
+
+  // 관리자 모드에서는 하단 탭 바 미표시
+  if (isAdmin) return null;
 
   return (
     <nav

--- a/packages/web/src/components/layout/bottom-nav.tsx
+++ b/packages/web/src/components/layout/bottom-nav.tsx
@@ -23,7 +23,7 @@ interface NavItem {
 }
 
 const userNavItems: NavItem[] = [
-  { title: '글 목록', href: '/posts', icon: FileText },
+  { title: '포스트', href: '/posts', icon: FileText },
   { title: '랭킹', href: '/ranking', icon: Trophy },
   { title: '큐레이션', href: '/curation', icon: Newspaper },
   { title: '게시판', href: '/board', icon: MessageSquare },

--- a/packages/web/src/components/layout/bottom-nav.tsx
+++ b/packages/web/src/components/layout/bottom-nav.tsx
@@ -2,7 +2,18 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { FileText, MessageSquare, Newspaper, Trophy, UsersRound } from 'lucide-react';
+import {
+  Banknote,
+  CalendarCheck,
+  CalendarRange,
+  FileText,
+  MessageSquare,
+  Newspaper,
+  Star,
+  Trophy,
+  Users,
+  UsersRound,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface NavItem {
@@ -11,12 +22,21 @@ interface NavItem {
   icon: React.ComponentType<{ className?: string }>;
 }
 
-const navItems: NavItem[] = [
+const userNavItems: NavItem[] = [
   { title: '글 목록', href: '/posts', icon: FileText },
   { title: '랭킹', href: '/ranking', icon: Trophy },
   { title: '큐레이션', href: '/curation', icon: Newspaper },
   { title: '게시판', href: '/board', icon: MessageSquare },
   { title: '스터디원', href: '/members', icon: UsersRound },
+];
+
+const adminNavItems: NavItem[] = [
+  { title: '멤버', href: '/admin/members', icon: Users },
+  { title: '회차', href: '/admin/rounds', icon: CalendarRange },
+  { title: '출석', href: '/admin/attendance', icon: CalendarCheck },
+  { title: '벌금', href: '/admin/fines', icon: Banknote },
+  { title: '점수', href: '/admin/scores', icon: Star },
+  { title: '큐레이션', href: '/admin/curation', icon: Newspaper },
 ];
 
 interface BottomNavProps {
@@ -25,9 +45,7 @@ interface BottomNavProps {
 
 export function BottomNav({ isAdmin = false }: BottomNavProps) {
   const pathname = usePathname();
-
-  // 관리자 모드에서는 하단 탭 바 미표시
-  if (isAdmin) return null;
+  const navItems = isAdmin ? adminNavItems : userNavItems;
 
   return (
     <nav

--- a/packages/web/src/components/layout/bottom-nav.tsx
+++ b/packages/web/src/components/layout/bottom-nav.tsx
@@ -2,7 +2,18 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { FileText, LayoutDashboard, MessageSquare, Newspaper, Trophy } from 'lucide-react';
+import {
+  Banknote,
+  CalendarCheck,
+  CalendarRange,
+  FileText,
+  MessageSquare,
+  Newspaper,
+  Star,
+  Trophy,
+  Users,
+  UsersRound,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface NavItem {
@@ -11,16 +22,30 @@ interface NavItem {
   icon: React.ComponentType<{ className?: string }>;
 }
 
-const navItems: NavItem[] = [
-  { title: '대시보드', href: '/dashboard', icon: LayoutDashboard },
+const userNavItems: NavItem[] = [
   { title: '글 목록', href: '/posts', icon: FileText },
   { title: '랭킹', href: '/ranking', icon: Trophy },
   { title: '큐레이션', href: '/curation', icon: Newspaper },
   { title: '게시판', href: '/board', icon: MessageSquare },
+  { title: '스터디원', href: '/members', icon: UsersRound },
 ];
 
-export function BottomNav() {
+const adminNavItems: NavItem[] = [
+  { title: '멤버', href: '/admin/members', icon: Users },
+  { title: '회차', href: '/admin/rounds', icon: CalendarRange },
+  { title: '출석', href: '/admin/attendance', icon: CalendarCheck },
+  { title: '벌금', href: '/admin/fines', icon: Banknote },
+  { title: '점수', href: '/admin/scores', icon: Star },
+  { title: '큐레이션', href: '/admin/curation', icon: Newspaper },
+];
+
+interface BottomNavProps {
+  isAdmin?: boolean;
+}
+
+export function BottomNav({ isAdmin = false }: BottomNavProps) {
   const pathname = usePathname();
+  const navItems = isAdmin ? adminNavItems : userNavItems;
 
   return (
     <nav

--- a/packages/web/src/components/layout/header.tsx
+++ b/packages/web/src/components/layout/header.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useTheme } from 'next-themes';
-import { LogOut, Moon, Shield, Sun, UserCircle } from 'lucide-react';
+import { LayoutDashboard, LogOut, Moon, Shield, Sun, UserCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -15,6 +15,7 @@ interface HeaderProps {
     email: string;
     imageUrl?: string;
   } | null;
+  isAdmin?: boolean;
   onLogout?: () => void;
 }
 
@@ -58,7 +59,7 @@ function DarkModeToggle() {
   );
 }
 
-export function Header({ user, onLogout }: HeaderProps) {
+export function Header({ user, isAdmin = false, onLogout }: HeaderProps) {
   const router = useRouter();
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -87,7 +88,7 @@ export function Header({ user, onLogout }: HeaderProps) {
       <div className="flex h-14 items-center px-4 lg:px-6">
         {/* Logo */}
         <Link
-          href="/dashboard"
+          href={isAdmin ? '/admin' : '/dashboard'}
           className="flex items-center gap-2 select-none hover:opacity-80 transition-opacity"
         >
           <span className="text-lg font-black tracking-tight text-foreground">BS</span>
@@ -141,17 +142,21 @@ export function Header({ user, onLogout }: HeaderProps) {
                     프로필
                   </button>
 
-                  {/* Admin */}
+                  {/* Admin / User toggle */}
                   <button
                     type="button"
                     className="flex w-full items-center gap-2.5 px-4 py-2.5 text-sm text-foreground hover:bg-accent transition-colors"
                     onClick={() => {
                       setMenuOpen(false);
-                      router.push('/admin');
+                      router.push(isAdmin ? '/dashboard' : '/admin');
                     }}
                   >
-                    <Shield className="h-4 w-4 text-muted-foreground" />
-                    관리자
+                    {isAdmin ? (
+                      <LayoutDashboard className="h-4 w-4 text-muted-foreground" />
+                    ) : (
+                      <Shield className="h-4 w-4 text-muted-foreground" />
+                    )}
+                    {isAdmin ? '사용자' : '관리자'}
                   </button>
 
                   {/* Logout */}

--- a/packages/web/src/components/layout/main-layout.tsx
+++ b/packages/web/src/components/layout/main-layout.tsx
@@ -81,7 +81,7 @@ export function MainLayout({
   return (
     <div className="min-h-screen flex flex-col overflow-x-hidden">
       <Header user={user} isAdmin={isAdmin} onLogout={handleLogout} />
-      <NoticeBanner />
+      {!isAdmin && <NoticeBanner />}
       <PullToRefresh>
         <div className="flex flex-1">
           {showSidebar && (

--- a/packages/web/src/components/layout/main-layout.tsx
+++ b/packages/web/src/components/layout/main-layout.tsx
@@ -5,6 +5,8 @@ import { useRouter } from 'next/navigation';
 import { Header } from './header';
 import { Sidebar } from './sidebar';
 import { BottomNav } from './bottom-nav';
+import { NoticeBanner } from './notice-banner';
+import { PullToRefresh } from './pull-to-refresh';
 import { cn } from '@/lib/utils';
 
 const STORAGE_KEY = 'study-sidebar-collapsed';
@@ -78,20 +80,23 @@ export function MainLayout({
 
   return (
     <div className="min-h-screen flex flex-col overflow-x-hidden">
-      <Header user={user} onLogout={handleLogout} />
-      <div className="flex flex-1">
-        {showSidebar && (
-          <Sidebar
-            isAdmin={isAdmin}
-            collapsed={collapsed}
-            onToggleCollapsed={handleToggleCollapsed}
-          />
-        )}
-        <MainContent showSidebar={showSidebar} collapsed={collapsed}>
-          {children}
-        </MainContent>
-      </div>
-      {showSidebar && <BottomNav />}
+      <Header user={user} isAdmin={isAdmin} onLogout={handleLogout} />
+      <NoticeBanner />
+      <PullToRefresh>
+        <div className="flex flex-1">
+          {showSidebar && (
+            <Sidebar
+              isAdmin={isAdmin}
+              collapsed={collapsed}
+              onToggleCollapsed={handleToggleCollapsed}
+            />
+          )}
+          <MainContent showSidebar={showSidebar} collapsed={collapsed}>
+            {children}
+          </MainContent>
+        </div>
+      </PullToRefresh>
+      {showSidebar && <BottomNav isAdmin={isAdmin} />}
     </div>
   );
 }

--- a/packages/web/src/components/layout/notice-banner.tsx
+++ b/packages/web/src/components/layout/notice-banner.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { Megaphone, X } from 'lucide-react';
+import { ChevronDown, ChevronUp, Megaphone, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface NoticeBannerData {
@@ -15,23 +15,24 @@ interface NoticeBannerData {
 
 const STORAGE_KEY = 'notice-banner-state';
 
-function isClosed(noticeId: string): boolean {
-  if (typeof window === 'undefined') return false;
+type BannerState = 'open' | 'collapsed' | 'closed';
+
+function getSavedState(noticeId: string): BannerState {
+  if (typeof window === 'undefined') return 'open';
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return false;
-    const data = JSON.parse(raw) as { id: string; closed: boolean };
-    // Different notice → show again
-    if (data.id !== noticeId) return false;
-    return data.closed;
+    if (!raw) return 'open';
+    const data = JSON.parse(raw) as { id: string; state: BannerState };
+    if (data.id !== noticeId) return 'open';
+    return data.state;
   } catch {
-    return false;
+    return 'open';
   }
 }
 
-function setClosed(noticeId: string) {
+function saveState(noticeId: string, state: BannerState) {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ id: noticeId, closed: true }));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ id: noticeId, state }));
   } catch {
     // ignore
   }
@@ -39,7 +40,7 @@ function setClosed(noticeId: string) {
 
 export function NoticeBanner() {
   const [notice, setNotice] = useState<NoticeBannerData | null>(null);
-  const [visible, setVisible] = useState(true);
+  const [bannerState, setBannerState] = useState<BannerState>('open');
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
@@ -48,21 +49,28 @@ export function NoticeBanner() {
       .then((result) => {
         if (result.data) {
           setNotice(result.data);
-          setVisible(!isClosed(result.data.id));
+          setBannerState(getSavedState(result.data.id));
         }
         setLoaded(true);
       })
       .catch(() => setLoaded(true));
   }, []);
 
-  if (!loaded || !notice || !visible) return null;
+  if (!loaded || !notice || bannerState === 'closed') return null;
 
-  const handleClose = () => {
-    setVisible(false);
-    setClosed(notice.id);
+  const handleToggle = () => {
+    const next = bannerState === 'open' ? 'collapsed' : 'open';
+    setBannerState(next);
+    saveState(notice.id, next);
   };
 
-  // Truncate content preview
+  const handleClose = () => {
+    setBannerState('closed');
+    saveState(notice.id, 'closed');
+  };
+
+  const isOpen = bannerState === 'open';
+
   const preview =
     notice.contentText.length > 80
       ? notice.contentText.slice(0, 80) + '…'
@@ -76,31 +84,49 @@ export function NoticeBanner() {
       )}
     >
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="flex items-start gap-2.5 py-2.5">
+        <div className={cn('flex items-start gap-2.5', isOpen ? 'py-2.5' : 'py-2')}>
           {/* Icon */}
-          <Megaphone className="h-4 w-4 mt-0.5 shrink-0 text-sky-600 dark:text-sky-400" />
+          <Megaphone className={cn('shrink-0 text-sky-600 dark:text-sky-400', isOpen ? 'h-4 w-4 mt-0.5' : 'h-3.5 w-3.5 mt-[3px]')} />
 
           {/* Content */}
           <Link
             href={`/board/${notice.id}`}
             className="group flex-1 min-w-0"
           >
-            <p className="truncate text-sm font-semibold text-sky-900 dark:text-sky-100 group-hover:underline">
+            <p className={cn(
+              'truncate font-semibold text-sky-900 dark:text-sky-100 group-hover:underline',
+              isOpen ? 'text-sm' : 'text-xs'
+            )}>
               {notice.title}
             </p>
-            <p className="mt-0.5 text-xs text-sky-700/70 dark:text-sky-300/60 line-clamp-1">
-              {preview}
-            </p>
+            {isOpen && (
+              <p className="mt-0.5 text-xs text-sky-700/70 dark:text-sky-300/60 line-clamp-1">
+                {preview}
+              </p>
+            )}
           </Link>
 
-          {/* Close */}
-          <button
-            onClick={handleClose}
-            className="p-1 mt-0.5 shrink-0 rounded-md text-sky-500/70 hover:text-sky-700 dark:hover:text-sky-300 hover:bg-sky-100/60 dark:hover:bg-sky-900/40 transition-colors"
-            aria-label="공지 닫기"
-          >
-            <X className="h-3.5 w-3.5" />
-          </button>
+          {/* Actions */}
+          <div className={cn('flex items-center gap-0.5 shrink-0', isOpen ? 'mt-0.5' : 'mt-[1px]')}>
+            <button
+              onClick={handleToggle}
+              className="p-1 rounded-md text-sky-500/70 hover:text-sky-700 dark:hover:text-sky-300 hover:bg-sky-100/60 dark:hover:bg-sky-900/40 transition-colors"
+              aria-label={isOpen ? '공지 접기' : '공지 펼치기'}
+            >
+              {isOpen ? (
+                <ChevronUp className="h-3.5 w-3.5" />
+              ) : (
+                <ChevronDown className="h-3.5 w-3.5" />
+              )}
+            </button>
+            <button
+              onClick={handleClose}
+              className="p-1 rounded-md text-sky-500/70 hover:text-sky-700 dark:hover:text-sky-300 hover:bg-sky-100/60 dark:hover:bg-sky-900/40 transition-colors"
+              aria-label="공지 닫기"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/web/src/components/layout/notice-banner.tsx
+++ b/packages/web/src/components/layout/notice-banner.tsx
@@ -93,10 +93,7 @@ export function NoticeBanner() {
             href={`/board/${notice.id}`}
             className="group flex-1 min-w-0"
           >
-            <p className={cn(
-              'truncate font-semibold text-sky-900 dark:text-sky-100 group-hover:underline',
-              isOpen ? 'text-sm' : 'text-xs'
-            )}>
+            <p className="truncate text-sm font-semibold text-sky-900 dark:text-sky-100 group-hover:underline">
               {notice.title}
             </p>
             {isOpen && (

--- a/packages/web/src/components/layout/notice-banner.tsx
+++ b/packages/web/src/components/layout/notice-banner.tsx
@@ -2,37 +2,36 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { ChevronDown, ChevronUp, Megaphone, X } from 'lucide-react';
+import { Megaphone, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface NoticeBannerData {
   id: string;
   title: string;
+  contentText: string;
   createdAt: string;
   memberName: string;
 }
 
 const STORAGE_KEY = 'notice-banner-state';
 
-type BannerState = 'open' | 'collapsed' | 'closed';
-
-function getSavedState(noticeId: string): BannerState {
-  if (typeof window === 'undefined') return 'open';
+function isClosed(noticeId: string): boolean {
+  if (typeof window === 'undefined') return false;
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return 'open';
-    const data = JSON.parse(raw) as { id: string; state: BannerState };
-    // Different notice → reset to open
-    if (data.id !== noticeId) return 'open';
-    return data.state;
+    if (!raw) return false;
+    const data = JSON.parse(raw) as { id: string; closed: boolean };
+    // Different notice → show again
+    if (data.id !== noticeId) return false;
+    return data.closed;
   } catch {
-    return 'open';
+    return false;
   }
 }
 
-function saveState(noticeId: string, state: BannerState) {
+function setClosed(noticeId: string) {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ id: noticeId, state }));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ id: noticeId, closed: true }));
   } catch {
     // ignore
   }
@@ -40,7 +39,7 @@ function saveState(noticeId: string, state: BannerState) {
 
 export function NoticeBanner() {
   const [notice, setNotice] = useState<NoticeBannerData | null>(null);
-  const [bannerState, setBannerState] = useState<BannerState>('open');
+  const [visible, setVisible] = useState(true);
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
@@ -49,84 +48,59 @@ export function NoticeBanner() {
       .then((result) => {
         if (result.data) {
           setNotice(result.data);
-          setBannerState(getSavedState(result.data.id));
+          setVisible(!isClosed(result.data.id));
         }
         setLoaded(true);
       })
       .catch(() => setLoaded(true));
   }, []);
 
-  if (!loaded || !notice || bannerState === 'closed') return null;
-
-  const handleToggle = () => {
-    const next = bannerState === 'open' ? 'collapsed' : 'open';
-    setBannerState(next);
-    saveState(notice.id, next);
-  };
+  if (!loaded || !notice || !visible) return null;
 
   const handleClose = () => {
-    setBannerState('closed');
-    saveState(notice.id, 'closed');
+    setVisible(false);
+    setClosed(notice.id);
   };
+
+  // Truncate content preview
+  const preview =
+    notice.contentText.length > 80
+      ? notice.contentText.slice(0, 80) + '…'
+      : notice.contentText;
 
   return (
     <div
       className={cn(
         'w-full border-b border-sky-200/60 dark:border-sky-800/40',
-        'bg-sky-50/80 dark:bg-sky-950/30',
-        'transition-all duration-200'
+        'bg-sky-50/80 dark:bg-sky-950/30'
       )}
     >
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center gap-2 py-2">
+        <div className="flex items-start gap-2.5 py-2.5">
           {/* Icon */}
-          <Megaphone className="h-3.5 w-3.5 shrink-0 text-sky-600 dark:text-sky-400" />
+          <Megaphone className="h-4 w-4 mt-0.5 shrink-0 text-sky-600 dark:text-sky-400" />
 
           {/* Content */}
-          <div className="flex-1 min-w-0">
-            {bannerState === 'open' ? (
-              <Link
-                href={`/board/${notice.id}`}
-                className="group flex items-baseline gap-2 min-w-0"
-              >
-                <span className="truncate text-sm font-medium text-sky-900 dark:text-sky-100 group-hover:underline">
-                  {notice.title}
-                </span>
-                <span className="shrink-0 text-[11px] text-sky-600/70 dark:text-sky-400/60">
-                  {notice.memberName}
-                </span>
-              </Link>
-            ) : (
-              <button
-                onClick={handleToggle}
-                className="text-xs text-sky-600/80 dark:text-sky-400/70 hover:text-sky-700 dark:hover:text-sky-300 transition-colors"
-              >
-                공지사항 보기
-              </button>
-            )}
-          </div>
+          <Link
+            href={`/board/${notice.id}`}
+            className="group flex-1 min-w-0"
+          >
+            <p className="truncate text-sm font-semibold text-sky-900 dark:text-sky-100 group-hover:underline">
+              {notice.title}
+            </p>
+            <p className="mt-0.5 text-xs text-sky-700/70 dark:text-sky-300/60 line-clamp-1">
+              {preview}
+            </p>
+          </Link>
 
-          {/* Actions */}
-          <div className="flex items-center gap-0.5 shrink-0">
-            <button
-              onClick={handleToggle}
-              className="p-1 rounded-md text-sky-500/70 hover:text-sky-700 dark:hover:text-sky-300 hover:bg-sky-100/60 dark:hover:bg-sky-900/40 transition-colors"
-              aria-label={bannerState === 'open' ? '공지 접기' : '공지 펼치기'}
-            >
-              {bannerState === 'open' ? (
-                <ChevronUp className="h-3.5 w-3.5" />
-              ) : (
-                <ChevronDown className="h-3.5 w-3.5" />
-              )}
-            </button>
-            <button
-              onClick={handleClose}
-              className="p-1 rounded-md text-sky-500/70 hover:text-sky-700 dark:hover:text-sky-300 hover:bg-sky-100/60 dark:hover:bg-sky-900/40 transition-colors"
-              aria-label="공지 닫기"
-            >
-              <X className="h-3.5 w-3.5" />
-            </button>
-          </div>
+          {/* Close */}
+          <button
+            onClick={handleClose}
+            className="p-1 mt-0.5 shrink-0 rounded-md text-sky-500/70 hover:text-sky-700 dark:hover:text-sky-300 hover:bg-sky-100/60 dark:hover:bg-sky-900/40 transition-colors"
+            aria-label="공지 닫기"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
         </div>
       </div>
     </div>

--- a/packages/web/src/components/layout/notice-banner.tsx
+++ b/packages/web/src/components/layout/notice-banner.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ChevronDown, ChevronUp, Megaphone, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface NoticeBannerData {
+  id: string;
+  title: string;
+  createdAt: string;
+  memberName: string;
+}
+
+const STORAGE_KEY = 'notice-banner-state';
+
+type BannerState = 'open' | 'collapsed' | 'closed';
+
+function getSavedState(noticeId: string): BannerState {
+  if (typeof window === 'undefined') return 'open';
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return 'open';
+    const data = JSON.parse(raw) as { id: string; state: BannerState };
+    // Different notice → reset to open
+    if (data.id !== noticeId) return 'open';
+    return data.state;
+  } catch {
+    return 'open';
+  }
+}
+
+function saveState(noticeId: string, state: BannerState) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ id: noticeId, state }));
+  } catch {
+    // ignore
+  }
+}
+
+export function NoticeBanner() {
+  const [notice, setNotice] = useState<NoticeBannerData | null>(null);
+  const [bannerState, setBannerState] = useState<BannerState>('open');
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/notice-banner')
+      .then((res) => res.json())
+      .then((result) => {
+        if (result.data) {
+          setNotice(result.data);
+          setBannerState(getSavedState(result.data.id));
+        }
+        setLoaded(true);
+      })
+      .catch(() => setLoaded(true));
+  }, []);
+
+  if (!loaded || !notice || bannerState === 'closed') return null;
+
+  const handleToggle = () => {
+    const next = bannerState === 'open' ? 'collapsed' : 'open';
+    setBannerState(next);
+    saveState(notice.id, next);
+  };
+
+  const handleClose = () => {
+    setBannerState('closed');
+    saveState(notice.id, 'closed');
+  };
+
+  return (
+    <div
+      className={cn(
+        'w-full border-b border-sky-200/60 dark:border-sky-800/40',
+        'bg-sky-50/80 dark:bg-sky-950/30',
+        'transition-all duration-200'
+      )}
+    >
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center gap-2 py-2">
+          {/* Icon */}
+          <Megaphone className="h-3.5 w-3.5 shrink-0 text-sky-600 dark:text-sky-400" />
+
+          {/* Content */}
+          <div className="flex-1 min-w-0">
+            {bannerState === 'open' ? (
+              <Link
+                href={`/board/${notice.id}`}
+                className="group flex items-baseline gap-2 min-w-0"
+              >
+                <span className="truncate text-sm font-medium text-sky-900 dark:text-sky-100 group-hover:underline">
+                  {notice.title}
+                </span>
+                <span className="shrink-0 text-[11px] text-sky-600/70 dark:text-sky-400/60">
+                  {notice.memberName}
+                </span>
+              </Link>
+            ) : (
+              <button
+                onClick={handleToggle}
+                className="text-xs text-sky-600/80 dark:text-sky-400/70 hover:text-sky-700 dark:hover:text-sky-300 transition-colors"
+              >
+                공지사항 보기
+              </button>
+            )}
+          </div>
+
+          {/* Actions */}
+          <div className="flex items-center gap-0.5 shrink-0">
+            <button
+              onClick={handleToggle}
+              className="p-1 rounded-md text-sky-500/70 hover:text-sky-700 dark:hover:text-sky-300 hover:bg-sky-100/60 dark:hover:bg-sky-900/40 transition-colors"
+              aria-label={bannerState === 'open' ? '공지 접기' : '공지 펼치기'}
+            >
+              {bannerState === 'open' ? (
+                <ChevronUp className="h-3.5 w-3.5" />
+              ) : (
+                <ChevronDown className="h-3.5 w-3.5" />
+              )}
+            </button>
+            <button
+              onClick={handleClose}
+              className="p-1 rounded-md text-sky-500/70 hover:text-sky-700 dark:hover:text-sky-300 hover:bg-sky-100/60 dark:hover:bg-sky-900/40 transition-colors"
+              aria-label="공지 닫기"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/layout/pull-to-refresh.tsx
+++ b/packages/web/src/components/layout/pull-to-refresh.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useRef } from 'react';
+import { usePullToRefresh } from '@/hooks/use-pull-to-refresh';
+import { RefreshCw } from 'lucide-react';
+
+export function PullToRefresh({ children }: { children: React.ReactNode }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { setIndicatorRef, setIconRef } = usePullToRefresh(containerRef);
+
+  return (
+    <>
+      {/* Indicator - positioned above the content, revealed by translateY */}
+      <div
+        ref={setIndicatorRef}
+        className="fixed left-0 right-0 z-50 flex justify-center pointer-events-none"
+        style={{
+          top: `calc(env(safe-area-inset-top) + 3.5rem - 48px)`,
+          opacity: 0,
+        }}
+      >
+        <div
+          data-circle
+          className="flex items-center justify-center h-9 w-9 rounded-full bg-background shadow-md border border-border"
+        >
+          <div ref={setIconRef} className="h-4 w-4 text-muted-foreground">
+            <RefreshCw className="h-4 w-4" />
+          </div>
+        </div>
+      </div>
+
+      {/* Content wrapper that translates down */}
+      <div ref={containerRef} className="will-change-transform">
+        {children}
+      </div>
+    </>
+  );
+}

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -160,47 +160,27 @@ function SidebarContent({
 
         {/* User / Admin page toggle link */}
         <div className="mb-2">
-          {isAdmin ? (
-            <Link
-              href="/dashboard"
-              title={collapsed ? '사용자 페이지' : undefined}
-              className={cn(
-                'group flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium',
-                collapsed && 'justify-center px-0',
-                'text-zinc-500 dark:text-zinc-400',
-                'hover:bg-zinc-100 dark:hover:bg-zinc-800/60',
-                'hover:text-zinc-900 dark:hover:text-zinc-100',
-                'transition-colors duration-200'
-              )}
-            >
-              <LayoutDashboard
-                className={cn(
-                  'h-4 w-4 shrink-0 text-zinc-400 group-hover:text-zinc-700 dark:group-hover:text-zinc-300 transition-colors duration-200'
-                )}
-              />
-              {!collapsed && <span className="truncate leading-none">사용자 페이지</span>}
-            </Link>
-          ) : (
-            <Link
-              href="/admin"
-              title={collapsed ? '관리자' : undefined}
-              className={cn(
-                'group flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium',
-                collapsed && 'justify-center px-0',
-                'text-zinc-500 dark:text-zinc-400',
-                'hover:bg-zinc-100 dark:hover:bg-zinc-800/60',
-                'hover:text-zinc-900 dark:hover:text-zinc-100',
-                'transition-colors duration-200'
-              )}
-            >
-              <Shield
-                className={cn(
-                  'h-4 w-4 shrink-0 text-zinc-400 group-hover:text-zinc-700 dark:group-hover:text-zinc-300 transition-colors duration-200'
-                )}
-              />
-              {!collapsed && <span className="truncate leading-none">관리자</span>}
-            </Link>
-          )}
+          <Link
+            href={isAdmin ? '/dashboard' : '/admin'}
+            title={collapsed ? (isAdmin ? '사용자' : '관리자') : undefined}
+            className={cn(
+              'group flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium',
+              collapsed && 'justify-center px-0',
+              'text-zinc-500 dark:text-zinc-400',
+              'hover:bg-zinc-100 dark:hover:bg-zinc-800/60',
+              'hover:text-zinc-900 dark:hover:text-zinc-100',
+              'transition-colors duration-200'
+            )}
+          >
+            {isAdmin ? (
+              <LayoutDashboard className="h-4 w-4 shrink-0 text-zinc-400 group-hover:text-zinc-700 dark:group-hover:text-zinc-300 transition-colors duration-200" />
+            ) : (
+              <Shield className="h-4 w-4 shrink-0 text-zinc-400 group-hover:text-zinc-700 dark:group-hover:text-zinc-300 transition-colors duration-200" />
+            )}
+            {!collapsed && (
+              <span className="truncate leading-none">{isAdmin ? '사용자' : '관리자'}</span>
+            )}
+          </Link>
         </div>
 
         {/* Collapse toggle */}

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -38,7 +38,7 @@ interface NavItem {
 
 const userNavItems: NavItem[] = [
   { title: '대시보드', href: '/dashboard', icon: LayoutDashboard },
-  { title: '글 목록', href: '/posts', icon: FileText },
+  { title: '포스트', href: '/posts', icon: FileText },
   { title: '랭킹', href: '/ranking', icon: Trophy },
   { title: '큐레이션', href: '/curation', icon: Newspaper },
   { title: '게시판', href: '/board', icon: MessageSquare },

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -13,14 +13,12 @@ import {
   PanelLeftClose,
   PanelLeftOpen,
   Settings,
-  Shield,
   Star,
   Trophy,
   Users,
   UsersRound,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { Separator } from '@/components/ui/separator';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -155,59 +153,30 @@ function SidebarContent({
       </nav>
 
       {/* ── Bottom section ───────────────────────────────────────────── */}
-      <div className={cn('shrink-0', collapsed ? 'px-2' : 'px-3')}>
-        <Separator className="mb-3" />
-
-        {/* User / Admin page toggle link */}
-        <div className="mb-2">
-          <Link
-            href={isAdmin ? '/dashboard' : '/admin'}
-            title={collapsed ? (isAdmin ? '사용자' : '관리자') : undefined}
-            className={cn(
-              'group flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium',
-              collapsed && 'justify-center px-0',
-              'text-zinc-500 dark:text-zinc-400',
-              'hover:bg-zinc-100 dark:hover:bg-zinc-800/60',
-              'hover:text-zinc-900 dark:hover:text-zinc-100',
-              'transition-colors duration-200'
-            )}
-          >
-            {isAdmin ? (
-              <LayoutDashboard className="h-4 w-4 shrink-0 text-zinc-400 group-hover:text-zinc-700 dark:group-hover:text-zinc-300 transition-colors duration-200" />
-            ) : (
-              <Shield className="h-4 w-4 shrink-0 text-zinc-400 group-hover:text-zinc-700 dark:group-hover:text-zinc-300 transition-colors duration-200" />
-            )}
-            {!collapsed && (
-              <span className="truncate leading-none">{isAdmin ? '사용자' : '관리자'}</span>
-            )}
-          </Link>
-        </div>
-
+      <div className={cn('shrink-0 pb-3', collapsed ? 'px-2' : 'px-3')}>
         {/* Collapse toggle */}
-        <div className="mb-3">
-          <button
-            onClick={toggleCollapsed}
-            title={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
-            aria-label={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
-            className={cn(
-              'flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium',
-              collapsed && 'justify-center px-0',
-              'text-zinc-400 dark:text-zinc-500',
-              'hover:bg-zinc-100 dark:hover:bg-zinc-800/60',
-              'hover:text-zinc-700 dark:hover:text-zinc-300',
-              'transition-colors duration-200'
-            )}
-          >
-            {collapsed ? (
-              <PanelLeftOpen className="h-4 w-4 shrink-0" />
-            ) : (
-              <>
-                <PanelLeftClose className="h-4 w-4 shrink-0" />
-                <span className="truncate leading-none">접기</span>
-              </>
-            )}
-          </button>
-        </div>
+        <button
+          onClick={toggleCollapsed}
+          title={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
+          aria-label={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
+          className={cn(
+            'flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium',
+            collapsed && 'justify-center px-0',
+            'text-zinc-400 dark:text-zinc-500',
+            'hover:bg-zinc-100 dark:hover:bg-zinc-800/60',
+            'hover:text-zinc-700 dark:hover:text-zinc-300',
+            'transition-colors duration-200'
+          )}
+        >
+          {collapsed ? (
+            <PanelLeftOpen className="h-4 w-4 shrink-0" />
+          ) : (
+            <>
+              <PanelLeftClose className="h-4 w-4 shrink-0" />
+              <span className="truncate leading-none">접기</span>
+            </>
+          )}
+        </button>
       </div>
     </div>
   );

--- a/packages/web/src/hooks/use-pull-to-refresh.ts
+++ b/packages/web/src/hooks/use-pull-to-refresh.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import { useCallback, useEffect, useRef } from 'react';
-import { useRouter } from 'next/navigation';
 
 const THRESHOLD = 70;
 const MAX_PULL = 120;
@@ -10,7 +9,6 @@ const RESISTANCE = 0.45;
 type PullState = 'idle' | 'pulling' | 'ready' | 'refreshing';
 
 export function usePullToRefresh(containerRef: React.RefObject<HTMLDivElement | null>) {
-  const router = useRouter();
   const startY = useRef(0);
   const pullDistance = useRef(0);
   const state = useRef<PullState>('idle');
@@ -169,7 +167,7 @@ export function usePullToRefresh(containerRef: React.RefObject<HTMLDivElement | 
         updateIconState('refreshing');
         applyTransform(THRESHOLD * 0.6, true);
 
-        router.refresh();
+        window.location.reload();
 
         resetTimer.current = setTimeout(() => {
           applyTransform(0, true);
@@ -196,7 +194,7 @@ export function usePullToRefresh(containerRef: React.RefObject<HTMLDivElement | 
       if (resetTimer.current) clearTimeout(resetTimer.current);
       if (innerTimer.current) clearTimeout(innerTimer.current);
     };
-  }, [applyTransform, updateIconState, clearAllStyles, router]);
+  }, [applyTransform, updateIconState, clearAllStyles]);
 
   return { setIndicatorRef, setIconRef };
 }

--- a/packages/web/src/hooks/use-pull-to-refresh.ts
+++ b/packages/web/src/hooks/use-pull-to-refresh.ts
@@ -1,0 +1,202 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+
+const THRESHOLD = 70;
+const MAX_PULL = 120;
+const RESISTANCE = 0.45;
+
+type PullState = 'idle' | 'pulling' | 'ready' | 'refreshing';
+
+export function usePullToRefresh(containerRef: React.RefObject<HTMLDivElement | null>) {
+  const router = useRouter();
+  const startY = useRef(0);
+  const pullDistance = useRef(0);
+  const state = useRef<PullState>('idle');
+  const indicatorRef = useRef<HTMLDivElement | null>(null);
+  const iconRef = useRef<HTMLDivElement | null>(null);
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const innerTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const setIndicatorRef = useCallback((el: HTMLDivElement | null) => {
+    indicatorRef.current = el;
+  }, []);
+
+  const setIconRef = useCallback((el: HTMLDivElement | null) => {
+    iconRef.current = el;
+  }, []);
+
+  const clearAllStyles = useCallback(() => {
+    const container = containerRef.current;
+    const indicator = indicatorRef.current;
+    const icon = iconRef.current;
+
+    if (container) {
+      container.style.transition = '';
+      container.style.transform = '';
+    }
+    if (indicator) {
+      indicator.style.transition = '';
+      indicator.style.transform = '';
+      indicator.style.opacity = '0';
+    }
+    if (icon) {
+      icon.style.transform = '';
+      icon.classList.remove('animate-spin');
+    }
+
+    const circle = indicator?.querySelector('[data-circle]') as HTMLElement | null;
+    circle?.classList.remove('border-primary');
+  }, [containerRef]);
+
+  const applyTransform = useCallback(
+    (distance: number, animated: boolean) => {
+      const container = containerRef.current;
+      const indicator = indicatorRef.current;
+      const icon = iconRef.current;
+      if (!container) return;
+
+      const transition = animated ? 'transform 0.3s cubic-bezier(0.2, 0, 0, 1)' : 'none';
+      container.style.transition = transition;
+      container.style.transform = distance > 0 ? `translateY(${distance}px)` : '';
+
+      if (indicator) {
+        indicator.style.transition = transition;
+        indicator.style.transform = distance > 0 ? `translateY(${distance}px)` : '';
+        indicator.style.opacity = distance > 10 ? '1' : '0';
+      }
+
+      if (icon && state.current !== 'refreshing') {
+        const progress = Math.min(distance / THRESHOLD, 1);
+        icon.style.transform = `rotate(${progress * 180}deg)`;
+      }
+    },
+    [containerRef]
+  );
+
+  const updateIconState = useCallback((newState: PullState) => {
+    const icon = iconRef.current;
+    const indicator = indicatorRef.current;
+    if (!icon || !indicator) return;
+
+    const circle = indicator.querySelector('[data-circle]') as HTMLElement | null;
+
+    if (newState === 'refreshing') {
+      icon.classList.add('animate-spin');
+      icon.style.transform = '';
+      circle?.classList.add('border-primary');
+    } else {
+      icon.classList.remove('animate-spin');
+      if (newState === 'ready') {
+        circle?.classList.add('border-primary');
+      } else {
+        circle?.classList.remove('border-primary');
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    let isTouching = false;
+
+    function findScrollableParent(el: HTMLElement | null): HTMLElement | null {
+      while (el && el !== document.body) {
+        const style = window.getComputedStyle(el);
+        const overflowY = style.overflowY;
+        if ((overflowY === 'auto' || overflowY === 'scroll') && el.scrollTop > 0) {
+          return el;
+        }
+        el = el.parentElement;
+      }
+      return null;
+    }
+
+    function onTouchStart(e: TouchEvent) {
+      if (state.current === 'refreshing') return;
+      if (window.scrollY > 5) return;
+
+      const target = e.target as HTMLElement;
+      if (findScrollableParent(target)) return;
+
+      startY.current = e.touches[0]!.clientY;
+      pullDistance.current = 0;
+      isTouching = true;
+    }
+
+    function onTouchMove(e: TouchEvent) {
+      if (!isTouching || state.current === 'refreshing') return;
+
+      const diff = e.touches[0]!.clientY - startY.current;
+
+      if (diff <= 0) {
+        if (pullDistance.current > 0) {
+          pullDistance.current = 0;
+          state.current = 'idle';
+          applyTransform(0, false);
+          updateIconState('idle');
+        }
+        return;
+      }
+
+      if (window.scrollY <= 0) {
+        e.preventDefault();
+      }
+
+      const distance = Math.min(diff * RESISTANCE, MAX_PULL);
+      pullDistance.current = distance;
+
+      const newState = distance >= THRESHOLD ? 'ready' : 'pulling';
+      if (state.current !== newState) {
+        state.current = newState;
+        updateIconState(newState);
+      }
+
+      applyTransform(distance, false);
+    }
+
+    function resetToIdle() {
+      state.current = 'idle';
+      pullDistance.current = 0;
+      clearAllStyles();
+    }
+
+    function onTouchEnd() {
+      if (!isTouching) return;
+      isTouching = false;
+
+      if (state.current === 'ready') {
+        state.current = 'refreshing';
+        updateIconState('refreshing');
+        applyTransform(THRESHOLD * 0.6, true);
+
+        router.refresh();
+
+        resetTimer.current = setTimeout(() => {
+          applyTransform(0, true);
+          innerTimer.current = setTimeout(() => {
+            resetToIdle();
+          }, 350);
+        }, 800);
+      } else {
+        applyTransform(0, true);
+        innerTimer.current = setTimeout(() => {
+          resetToIdle();
+        }, 350);
+      }
+    }
+
+    document.addEventListener('touchstart', onTouchStart, { passive: true });
+    document.addEventListener('touchmove', onTouchMove, { passive: false });
+    document.addEventListener('touchend', onTouchEnd);
+
+    return () => {
+      document.removeEventListener('touchstart', onTouchStart);
+      document.removeEventListener('touchmove', onTouchMove);
+      document.removeEventListener('touchend', onTouchEnd);
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+      if (innerTimer.current) clearTimeout(innerTimer.current);
+    };
+  }, [applyTransform, updateIconState, clearAllStyles, router]);
+
+  return { setIndicatorRef, setIconRef };
+}

--- a/packages/web/src/lib/board-config.ts
+++ b/packages/web/src/lib/board-config.ts
@@ -16,6 +16,12 @@ export const categoryBadgeConfig: Record<string, { label: string; className: str
   etc: { label: '기타', className: 'bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-400' },
 };
 
+export const VALID_CATEGORY_VALUES = BOARD_CATEGORIES.map((c) => c.value) as readonly string[];
+
+export function isValidCategory(value: string): boolean {
+  return VALID_CATEGORY_VALUES.includes(value);
+}
+
 export function getCategoryLabel(value: string): string {
   return categoryBadgeConfig[value]?.label || value;
 }


### PR DESCRIPTION
## Summary
- 랜딩 페이지 인증 리다이렉트, 글로벌 공지 배너, Pull-to-refresh, 하단 탭 바/사이드바/헤더 UX 통일
- 게시판 API 보안 강화 + Tiptap 에디터 확장 + 한글 IME 자소분리 수정

## Changes

| 파일 | 변경 내용 |
|------|-----------|
| `packages/shared/src/db/schema.ts` | `isNoticeBanner` boolean 컬럼 추가 |
| `packages/web/src/app/page.tsx` | 인증 사용자 → `/dashboard` 리다이렉트 |
| `packages/web/src/app/api/notice-banner/route.ts` | **NEW** 공지 배너 조회 API (no-store 캐시) |
| `packages/web/src/components/layout/notice-banner.tsx` | **NEW** 글로벌 공지 배너 (제목+내용 미리보기, 접기/닫기) |
| `packages/web/src/components/layout/pull-to-refresh.tsx` | **NEW** Pull-to-refresh 래퍼 컴포넌트 |
| `packages/web/src/hooks/use-pull-to-refresh.ts` | **NEW** 터치 제스처 훅 (`window.location.reload()`) |
| `packages/web/src/components/layout/bottom-nav.tsx` | 사용자 5개 메뉴, 관리자 모드 미표시 |
| `packages/web/src/components/layout/header.tsx` | 관리자 모드 로고 라우팅 + 모드 전환 드롭다운 |
| `packages/web/src/components/layout/sidebar.tsx` | 하단 모드 전환 링크 제거 (프로필 드롭다운 전용) |
| `packages/web/src/components/layout/main-layout.tsx` | NoticeBanner(관리자 미표시) + PullToRefresh 통합 |
| `packages/web/src/components/board/tiptap-editor.tsx` | H1-H3, 구분선, 본문 버튼 + 한글 IME 자소분리 수정 |
| `packages/web/src/app/api/board/route.ts` | 트랜잭션, 카테고리 검증, 배너 토글 |
| `packages/web/src/app/api/board/[id]/route.ts` | 트랜잭션, 카테고리 검증, 관리자 권한 강화 |
| `packages/web/src/app/(user)/board/write/page.tsx` | 배너 설정 UI 추가 |
| `packages/web/src/app/(user)/board/[id]/edit/page.tsx` | 배너 설정 UI 추가 |
| `packages/web/proxy.ts` | `isAdminDiscordId()` await 누락 수정 |
| `packages/web/src/lib/board-config.ts` | `isValidCategory()` 서버사이드 검증 함수 |
| `packages/web/src/app/(admin)/admin/page.tsx` | Quick Actions 링크 섹션 제거 |
| `packages/web/src/app/(admin)/admin/members/page.tsx` | 참가자 관리 → 멤버 관리 워딩 변경 |
| `packages/web/src/app/(admin)/admin/scores/page.tsx` | 점수 관리 Star 아이콘 제거 |
| `CLAUDE.md`, `docs/*` | 문서 최신화 |

## Design Decisions

| 결정 | 이유 |
|------|------|
| 배너 `no-store` 캐시 | 새 공지 등록 시 즉시 반영 (max-age=60은 지연 발생) |
| 배너 3단계 상태 (open/collapsed/closed) | 접기 시 제목만 표시, 닫기 시 완전 숨김 |
| PTR `window.location.reload()` | `router.refresh()`는 클라이언트 데이터 갱신 불가 |
| 관리자 모드 하단 탭 바 미표시 | 사이드바로 충분, 중복 제거 |
| 사이드바 모드 전환 제거 | 프로필 드롭다운으로 통일 |
| Tiptap `compositionstart/end` | 한글 IME 조합 중 onUpdate 차단으로 자소분리 방지 |
| 배너 clear+set 트랜잭션 | TOCTOU 레이스 컨디션 방지 |
| 카테고리 allowlist 서버 검증 | 임의 문자열 injection 방지 |

## Test Plan
- [x] 비로그인 → `/` 랜딩 페이지 표시
- [x] 로그인 → `/` 접근 시 `/dashboard`로 리다이렉트
- [x] 관리자: 공지글 작성 시 "상단 배너에 표시" 토글 동작
- [x] 공지 배너 접기 → 제목만 표시, 닫기 → 완전 숨김
- [x] 새 공지 배너 설정 시 기존 배너 자동 해제 + 즉시 반영
- [x] 관리자 페이지에서 공지 배너 미표시
- [x] 모바일: Pull-to-refresh 제스처 → 페이지 새로고침 (location.reload)
- [x] 모바일: 사용자 모드 하단 탭 5개, 관리자 모드 탭 바 미표시
- [x] 사이드바 모드 전환 링크 없음, 프로필 드롭다운에서만 전환
- [x] Tiptap: H1-H3 토글, 구분선 삽입, 본문 변환 동작
- [x] Tiptap: 한글 입력 시 자소분리 없이 정상 조합
- [x] 비관리자: 공지 카테고리/배너 설정 시 403
- [x] 네비게이션: "포스트" 워딩, "멤버 관리" 타이틀

🤖 Generated with [Claude Code](https://claude.com/claude-code)