### PR TITLE
feat: 웹 API 표준화 + 보안 강화 + 에러 처리 개선

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ packages/
 |------|------|
 | Runtime | Node.js 22, TypeScript 5.x |
 | Bot | discord.js v14, feedsmith (RSS 파서), pg-boss (PostgreSQL 잡 큐) |
-| Web | Next.js 16 App Router, React 19, shadcn/ui, Tailwind CSS v4, Tiptap (리치 에디터) |
+| Web | Next.js 16 App Router, React 19, shadcn/ui, Tailwind CSS v4, Tiptap (리치 에디터), sonner (토스트) |
 | DB | Supabase PostgreSQL + Drizzle ORM (Transaction Pooler, `prepare: false`) |
 | Auth | Supabase Auth (Discord OAuth) + `@supabase/ssr` |
 | 배포 | AWS EC2 (bot), Vercel (web), Supabase (DB + Auth) |
@@ -54,6 +54,10 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 - **커밋**: 기존 git log 스타일 따름, Co-Authored-By 포함
 - **Drizzle SQL**: `packages/shared/drizzle/*.sql` 마이그레이션 파일은 로컬 전용 (`.gitignore`에 등록됨, 커밋 금지)
 - **다이얼로그**: `window.confirm()`, `window.alert()`, `window.prompt()` 사용 금지 → 커스텀 다이얼로그 컴포넌트 사용 (기존 `DeletePostDialog` 패턴 참고)
+- **토스트**: `sonner` 라이브러리 사용 (`toast.success()`, `toast.error()`) — inline 상태 관리 토스트 금지
+- **API 응답**: 모든 API 라우트는 `Errors.*()` + `successResponse()` + `errorResponse()` 패턴 사용 (직접 `NextResponse.json` 금지)
+- **캐시**: 읽기 전용 API에 `withCache(response, maxAge)` 적용 (members: 60s, ranking: 30s)
+- **보안**: Tiptap content는 저장 전 `sanitizeTiptapContent()` 적용, 외부 URL fetch 시 `isSafeUrl()` SSRF 체크
 
 ## 핵심 파일 위치
 
@@ -77,7 +81,11 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 | `packages/bot/src/services/score.service.ts` | 활동 점수 계산/부여 |
 | `packages/web/src/lib/board-auth.ts` | 게시판 인증 헬퍼 (`getBoardAuth`) |
 | `packages/web/src/lib/board-config.ts` | 게시판 카테고리/뱃지 설정 |
-| `packages/web/src/lib/api-error.ts` | API 표준 응답/에러 헬퍼 (`successResponse`, `Errors`) |
+| `packages/web/src/lib/api-error.ts` | API 표준 응답/에러 헬퍼 (`successResponse`, `Errors`, `withCache`) |
+| `packages/web/src/lib/sanitize.ts` | 입력 새니타이즈 (`sanitizeDescription`, `sanitizeTiptapContent`, `getTodayKST`) |
+| `packages/web/src/app/not-found.tsx` | 커스텀 404 페이지 |
+| `packages/web/src/app/(user)/error.tsx` | 사용자 에러 바운더리 |
+| `packages/web/src/app/(admin)/error.tsx` | 관리자 에러 바운더리 |
 | `packages/web/src/components/ui/member-avatar.tsx` | 재사용 아바타 컴포넌트 (링크+관리자뱃지) |
 | `packages/web/src/components/board/tiptap-editor.tsx` | Tiptap 리치 에디터 (H1-H3, 구분선, 코드블록, 링크, 한글 IME 대응) |
 | `packages/web/src/components/layout/bottom-nav.tsx` | 모바일 하단 탭 바 (사용자 5개, 관리자 모드 미표시) |
@@ -129,6 +137,10 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 - **Pull-to-Refresh**: 커스텀 터치 제스처 → `window.location.reload()` (Safari PWA 최적화, 다이얼로그 열림 시 비활성화)
 - **PWA**: 홈 화면 추가 지원 (manifest.json, 서비스 워커 없음)
 - **랜딩 페이지**: 인증 유저 자동 리다이렉트 (`/` → `/dashboard`)
+- **토스트**: sonner (`<Toaster />` in root layout, `position="bottom-center"`, `richColors`)
+- **에러 바운더리**: `(user)/error.tsx`, `(admin)/error.tsx` — 리셋 버튼 포함
+- **404 페이지**: `not-found.tsx` — 대시보드 링크 포함
+- **CSP**: `next.config.js`에 Content-Security-Policy 헤더 설정
 - **상세 스펙**: `docs/26-03-06-ui-design-system.md` 참조
 
 ## 에이전트 활용 가이드

--- a/docs/26-03-06-patterns.md
+++ b/docs/26-03-06-patterns.md
@@ -50,24 +50,23 @@ const database = db();
 
 ```ts
 // packages/web/src/app/api/admin/{resource}/route.ts
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { eq } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { withAdminAuth } from '@/lib/admin';
+import { errorResponse, successResponse } from '@/lib/api-error';
 
-const { members, MemberStatus } = sharedDb;
+const { members } = sharedDb;
 
 // GET — 목록 조회
 export const GET = withAdminAuth(async (request: NextRequest, _adminAuth) => {
   try {
-    const { searchParams } = new URL(request.url);
     const database = db();
     const result = await database.select().from(members);
-    return NextResponse.json({ data: result });
+    return successResponse({ data: result });
   } catch (error) {
-    console.error('API error:', error);
-    return NextResponse.json({ message: '서버 오류' }, { status: 500 });
+    return errorResponse(error);
   }
 });
 
@@ -76,9 +75,9 @@ export const POST = withAdminAuth(async (request: NextRequest, _adminAuth) => {
   try {
     const body = await request.json();
     // validation → insert → returning
-    return NextResponse.json({ message: '성공', data: newItem });
+    return successResponse(newItem, '생성되었습니다.', 201);
   } catch (error) {
-    return NextResponse.json({ message: '서버 오류' }, { status: 500 });
+    return errorResponse(error);
   }
 });
 ```
@@ -104,14 +103,20 @@ export const DELETE = withAdminAuth(async (request: NextRequest, _adminAuth) => 
 ```ts
 // 인증만 필요, 관리자 권한 불필요
 import { createClient } from '@/lib/supabase/server';
+import { errorResponse, Errors, successResponse, withCache } from '@/lib/api-error';
 
 export async function GET() {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: '인증 필요' }, { status: 401 });
+  try {
+    const supabase = await createClient();
+    const { data: { user }, error } = await supabase.auth.getUser();
+    if (error || !user) return Errors.unauthorized().toResponse();
 
-  const discordId = user.identities?.find(i => i.provider === 'discord')?.id;
-  // discordId로 members 테이블 조회
+    const discordId = user.identities?.find(i => i.provider === 'discord')?.id;
+    // discordId로 members 테이블 조회
+    return withCache(successResponse(data), 60); // 읽기 전용은 캐시 적용
+  } catch (error) {
+    return errorResponse(error);
+  }
 }
 ```
 
@@ -206,6 +211,62 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 | `Errors.forbidden(msg)` | 403 |
 | `Errors.notFound(msg)` | 404 |
 | `Errors.badRequest(msg)` | 400 |
+| `withCache(response, maxAge, scope?)` | Cache-Control 헤더 설정 (`private` 기본) |
+
+## Cache-Control 패턴
+
+```ts
+import { withCache, successResponse } from '@/lib/api-error';
+
+// 읽기 전용 API에 캐시 적용
+return withCache(successResponse(data), 60);           // private, 60s, swr 120s
+return withCache(successResponse(data), 30, 'public'); // public, 30s, swr 60s
+```
+
+| API | maxAge | scope |
+|-----|--------|-------|
+| `GET /api/members` | 60s | private |
+| `GET /api/members/[id]` | 60s | private |
+| `GET /api/ranking` | 30s | private |
+
+## 입력 새니타이즈 패턴
+
+```ts
+import { sanitizeDescription, sanitizeTiptapContent } from '@/lib/sanitize';
+
+// description 필드: 제어 문자 + 제로 너비 유니코드 제거, 300자 제한
+const desc = sanitizeDescription(input);
+
+// Tiptap JSON content: javascript:/data:/vbscript: 프로토콜 링크 제거
+const safeContent = sanitizeTiptapContent(content);
+```
+
+**적용 위치**: `api/board/route.ts` (POST), `api/board/[id]/route.ts` (PATCH)
+
+## SSRF 방어 패턴
+
+```ts
+import { isSafeUrl } from '@/lib/rss-detect';
+
+// 외부 URL fetch 전 반드시 체크
+if (!isSafeUrl(url)) {
+  return Errors.badRequest('허용되지 않은 URL입니다.').toResponse();
+}
+```
+
+**적용 위치**: `api/posts/manual/route.ts`, `api/admin/curation/crawl/route.ts`
+
+## 토스트 패턴
+
+```tsx
+import { toast } from 'sonner';
+
+// 성공/에러 피드백 (inline 상태 관리 금지)
+toast.success('저장되었습니다.');
+toast.error('오류가 발생했습니다.');
+```
+
+`<Toaster />` 는 root `layout.tsx`에 설정됨 (`position="bottom-center"`, `richColors`)
 
 ## 공지 배너 패턴
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Blog Study Admin - 시스템 아키텍처
 
-> 최종 업데이트: 2026-03-08
+> 최종 업데이트: 2026-03-08 (v2)
 
 블로그 글쓰기 스터디 운영 자동화 플랫폼. 웹 대시보드에서 모든 관리/유저 기능을 제공하고, Discord 봇은 스케줄러(RSS 수집/출석/벌금/큐레이션)와 이벤트 핸들러만 담당한다.
 
@@ -81,6 +81,7 @@ mindmap
       Tailwind CSS v4
       shadcn/ui + Radix UI
       Tiptap Rich Editor
+      sonner Toast
       PWA 홈 화면 추가
       Supabase Auth
         Discord OAuth
@@ -400,6 +401,30 @@ erDiagram
 | Daily Content | 매일 10:00 | 큐레이션 컨텐츠 공유 |
 | Round Reporter | 회차 종료 시 | 회차 리포트 자동 생성 → #공지사항 |
 | Round Start | 매주 월 00:00 | 회차 시작 안내 + active 멤버 멘션 → #공지사항 |
+
+## 보안
+
+| 레이어 | 방어 | 구현 위치 |
+|--------|------|----------|
+| **인증** | Supabase Auth (Discord OAuth PKCE) + 미들웨어 세션 검증 | `middleware.ts`, `lib/supabase/` |
+| **인가** | Discord ID 기반 관리자 체크 (`ADMIN_DISCORD_IDS`) | `lib/admin.ts` |
+| **XSS** | Tiptap JSON content 새니타이즈 (`javascript:`, `data:`, `vbscript:` 프로토콜 차단) | `lib/sanitize.ts` → `api/board/` |
+| **SSRF** | 외부 URL fetch 전 `isSafeUrl()` 체크 (private IP, localhost 차단) | `lib/rss-detect.ts` → `api/posts/manual/`, `api/admin/curation/crawl/` |
+| **CSP** | Content-Security-Policy 헤더 (`frame-ancestors 'none'`, 허용 도메인 화이트리스트) | `next.config.js` |
+| **SQL Injection** | Drizzle ORM 파라미터화 쿼리 (raw SQL 사용 안 함) | 전체 API Routes |
+| **CSRF** | Supabase Auth 쿠키 `SameSite=Lax` | Supabase 기본 설정 |
+| **입력 검증** | description 새니타이즈 (제어 문자/제로 너비 유니코드 제거, 300자 제한) | `lib/sanitize.ts` |
+
+### 에러 처리
+
+| 레이어 | 처리 | 구현 |
+|--------|------|------|
+| **API 에러** | 표준 `ApiError` 클래스 + `Errors` 팩토리 (`401`/`403`/`404`/`400`) | `lib/api-error.ts` |
+| **API 성공** | `successResponse(data, message?, status?)` 통일 | `lib/api-error.ts` |
+| **캐시** | `withCache(response, maxAge, scope?)` — 읽기 API에 Cache-Control 적용 | `lib/api-error.ts` |
+| **클라이언트 에러** | Error Boundary (`error.tsx`) — 사용자/관리자 그룹별 | `(user)/error.tsx`, `(admin)/error.tsx` |
+| **404** | 커스텀 Not Found 페이지 | `not-found.tsx` |
+| **사용자 피드백** | sonner 토스트 (`toast.success()`, `toast.error()`) | `layout.tsx` (`<Toaster />`) |
 
 ## 배포 구조
 

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -35,6 +35,18 @@ const nextConfig = {
           { key: 'X-Content-Type-Options', value: 'nosniff' },
           { key: 'X-Frame-Options', value: 'DENY' },
           { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          {
+            key: 'Content-Security-Policy',
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+              "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
+              "img-src 'self' https://cdn.discordapp.com https://*.supabase.co https://api.dicebear.com data: blob:",
+              "font-src 'self' https://cdn.jsdelivr.net",
+              "connect-src 'self' https://*.supabase.co",
+              "frame-ancestors 'none'",
+            ].join('; '),
+          },
         ],
       },
     ];

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -45,7 +45,8 @@
     "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-"tailwind-merge": "^2.3.0",
+    "sonner": "^2.0.7",
+    "tailwind-merge": "^2.3.0",
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {

--- a/packages/web/src/app/(admin)/admin/fines/page.tsx
+++ b/packages/web/src/app/(admin)/admin/fines/page.tsx
@@ -1,14 +1,8 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
-import {
-  CreditCard,
-  CheckCircle,
-  XCircle,
-  AlertCircle,
-  Search,
-  Ban,
-} from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { AlertCircle, Ban, CheckCircle, CreditCard, Search, XCircle } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -95,13 +89,7 @@ export default function AdminFinesPage() {
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [updatingId, setUpdatingId] = useState<string | null>(null);
-  const [toast, setToast] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
   const [waiveTarget, setWaiveTarget] = useState<string | null>(null);
-
-  const showToast = (type: 'success' | 'error', message: string) => {
-    setToast({ type, message });
-    setTimeout(() => setToast(null), 3000);
-  };
 
   const fetchFines = useCallback(async () => {
     try {
@@ -138,10 +126,10 @@ export default function AdminFinesPage() {
       }
 
       await fetchFines();
-      showToast('success', '납부 처리되었습니다.');
+      toast.success('납부 처리되었습니다.');
     } catch (err) {
       console.error('Error marking fine as paid:', err);
-      showToast('error', '납부 처리에 실패했습니다.');
+      toast.error('납부 처리에 실패했습니다.');
     } finally {
       setUpdatingId(null);
     }
@@ -162,10 +150,10 @@ export default function AdminFinesPage() {
       }
 
       await fetchFines();
-      showToast('success', '면제 처리되었습니다.');
+      toast.success('면제 처리되었습니다.');
     } catch (err) {
       console.error('Error waiving fine:', err);
-      showToast('error', '면제 처리에 실패했습니다.');
+      toast.error('면제 처리에 실패했습니다.');
     } finally {
       setUpdatingId(null);
     }
@@ -175,31 +163,30 @@ export default function AdminFinesPage() {
   if (error) return <PageError message={error} />;
 
   // Filter fines
-  const filteredFines = data?.fines.filter((fine) => {
-    // Status filter
-    if (statusFilter !== 'all' && fine.status !== statusFilter) {
-      return false;
-    }
-    // Search filter
-    if (searchQuery) {
-      const query = searchQuery.toLowerCase();
-      return (
-        fine.memberName.toLowerCase().includes(query) ||
-        fine.memberDiscordUsername.toLowerCase().includes(query) ||
-        fine.memberPart.toLowerCase().includes(query)
-      );
-    }
-    return true;
-  }) || [];
+  const filteredFines =
+    data?.fines.filter((fine) => {
+      // Status filter
+      if (statusFilter !== 'all' && fine.status !== statusFilter) {
+        return false;
+      }
+      // Search filter
+      if (searchQuery) {
+        const query = searchQuery.toLowerCase();
+        return (
+          fine.memberName.toLowerCase().includes(query) ||
+          fine.memberDiscordUsername.toLowerCase().includes(query) ||
+          fine.memberPart.toLowerCase().includes(query)
+        );
+      }
+      return true;
+    }) || [];
 
   return (
     <div className="space-y-6">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">벌금 관리</h1>
-          <p className="text-muted-foreground">
-            벌금 현황을 확인하고 납부/면제 처리를 하세요.
-          </p>
+          <p className="text-muted-foreground">벌금 현황을 확인하고 납부/면제 처리를 하세요.</p>
         </div>
       </div>
 
@@ -217,9 +204,7 @@ export default function AdminFinesPage() {
             <div className="text-2xl font-bold">
               {(data?.summary.total.amount ?? 0).toLocaleString()}원
             </div>
-            <p className="text-xs text-muted-foreground">
-              {data?.summary.total.count ?? 0}건
-            </p>
+            <p className="text-xs text-muted-foreground">{data?.summary.total.count ?? 0}건</p>
           </CardContent>
         </Card>
         <Card
@@ -234,9 +219,7 @@ export default function AdminFinesPage() {
             <div className="text-2xl font-bold text-destructive">
               {(data?.summary.unpaid.amount ?? 0).toLocaleString()}원
             </div>
-            <p className="text-xs text-muted-foreground">
-              {data?.summary.unpaid.count ?? 0}건
-            </p>
+            <p className="text-xs text-muted-foreground">{data?.summary.unpaid.count ?? 0}건</p>
           </CardContent>
         </Card>
         <Card
@@ -251,9 +234,7 @@ export default function AdminFinesPage() {
             <div className="text-2xl font-bold text-success">
               {(data?.summary.paid.amount ?? 0).toLocaleString()}원
             </div>
-            <p className="text-xs text-muted-foreground">
-              {data?.summary.paid.count ?? 0}건
-            </p>
+            <p className="text-xs text-muted-foreground">{data?.summary.paid.count ?? 0}건</p>
           </CardContent>
         </Card>
         <Card
@@ -268,9 +249,7 @@ export default function AdminFinesPage() {
             <div className="text-2xl font-bold text-muted-foreground">
               {(data?.summary.waived.amount ?? 0).toLocaleString()}원
             </div>
-            <p className="text-xs text-muted-foreground">
-              {data?.summary.waived.count ?? 0}건
-            </p>
+            <p className="text-xs text-muted-foreground">{data?.summary.waived.count ?? 0}건</p>
           </CardContent>
         </Card>
       </div>
@@ -316,7 +295,8 @@ export default function AdminFinesPage() {
             <div>
               <CardTitle>벌금 목록</CardTitle>
               <CardDescription>
-                {statusFilter === 'all' ? '전체' : statusConfig[statusFilter]?.label} 벌금 {filteredFines.length}건
+                {statusFilter === 'all' ? '전체' : statusConfig[statusFilter]?.label} 벌금{' '}
+                {filteredFines.length}건
               </CardDescription>
             </div>
             <div className="flex items-center gap-2">
@@ -343,7 +323,10 @@ export default function AdminFinesPage() {
                       <p className="font-medium truncate">{fine.memberName}</p>
                       <p className="text-xs text-muted-foreground">{fine.memberPart}</p>
                     </div>
-                    <Badge variant={statusConfig[fine.status]?.variant || 'secondary'} className="shrink-0">
+                    <Badge
+                      variant={statusConfig[fine.status]?.variant || 'secondary'}
+                      className="shrink-0"
+                    >
                       {statusConfig[fine.status]?.label || fine.status}
                     </Badge>
                   </div>
@@ -354,7 +337,9 @@ export default function AdminFinesPage() {
                       {typeConfig[fine.type]?.label || fine.type}
                     </span>
                     <span>·</span>
-                    <span className="font-medium text-foreground">{fine.amount.toLocaleString()}원</span>
+                    <span className="font-medium text-foreground">
+                      {fine.amount.toLocaleString()}원
+                    </span>
                     <span>·</span>
                     <span>{new Date(fine.createdAt).toLocaleDateString('ko-KR')}</span>
                   </div>
@@ -418,9 +403,7 @@ export default function AdminFinesPage() {
                       <TableCell>
                         <div>
                           <div className="font-medium whitespace-nowrap">{fine.memberName}</div>
-                          <div className="text-xs text-muted-foreground">
-                            {fine.memberPart}
-                          </div>
+                          <div className="text-xs text-muted-foreground">{fine.memberPart}</div>
                         </div>
                       </TableCell>
                       <TableCell className="whitespace-nowrap">{fine.roundNumber}회차</TableCell>
@@ -506,24 +489,6 @@ export default function AdminFinesPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-
-      {/* Toast */}
-      {toast && (
-        <div
-          className={`fixed bottom-6 right-6 z-50 flex items-center gap-2 rounded-lg border px-4 py-3 text-sm shadow-lg transition-all ${
-            toast.type === 'success'
-              ? 'border-success/30 bg-success/10 text-success'
-              : 'border-destructive/30 bg-destructive/10 text-destructive'
-          }`}
-        >
-          {toast.type === 'success' ? (
-            <CheckCircle className="h-4 w-4" />
-          ) : (
-            <AlertCircle className="h-4 w-4" />
-          )}
-          {toast.message}
-        </div>
-      )}
     </div>
   );
 }

--- a/packages/web/src/app/(admin)/error.tsx
+++ b/packages/web/src/app/(admin)/error.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+import { AlertCircle } from 'lucide-react';
+
+export default function AdminError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('Admin page error:', error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[400px] flex-col items-center justify-center gap-4 p-4">
+      <AlertCircle className="h-10 w-10 text-destructive/60" />
+      <div className="text-center space-y-1">
+        <h2 className="text-base font-semibold">관리자 페이지 오류</h2>
+        <p className="text-sm text-muted-foreground">잠시 후 다시 시도해주세요.</p>
+      </div>
+      <button
+        onClick={reset}
+        className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+      >
+        다시 시도
+      </button>
+    </div>
+  );
+}

--- a/packages/web/src/app/(user)/board/[id]/edit/page.tsx
+++ b/packages/web/src/app/(user)/board/[id]/edit/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 import { ArrowLeft, Loader2, Lock, Megaphone } from 'lucide-react';
 import { TiptapEditor } from '@/components/board/tiptap-editor';
 import { BOARD_CATEGORIES } from '@/lib/board-config';
@@ -144,10 +145,11 @@ export default function BoardEditPage() {
       const result = await res.json();
 
       if (!res.ok) {
-        setError(result.message || '게시글 수정에 실패했습니다.');
+        setError(result.message || result.error?.message || '게시글 수정에 실패했습니다.');
         return;
       }
 
+      toast.success('게시글이 수정되었습니다.');
       router.push(`/board/${id}`);
     } catch {
       setError('서버 오류가 발생했습니다. 다시 시도해주세요.');

--- a/packages/web/src/app/(user)/board/write/page.tsx
+++ b/packages/web/src/app/(user)/board/write/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 import { ArrowLeft, Loader2, Lock, Megaphone } from 'lucide-react';
 import { TiptapEditor } from '@/components/board/tiptap-editor';
 import { BOARD_CATEGORIES } from '@/lib/board-config';
@@ -85,10 +86,11 @@ export default function BoardWritePage() {
       const result = await res.json();
 
       if (!res.ok) {
-        setError(result.message || '게시글 작성에 실패했습니다.');
+        setError(result.message || result.error?.message || '게시글 작성에 실패했습니다.');
         return;
       }
 
+      toast.success('게시글이 작성되었습니다.');
       router.push(`/board/${result.data.id}`);
     } catch {
       setError('서버 오류가 발생했습니다. 다시 시도해주세요.');

--- a/packages/web/src/app/(user)/error.tsx
+++ b/packages/web/src/app/(user)/error.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+import { AlertCircle } from 'lucide-react';
+
+export default function UserError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('User page error:', error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[400px] flex-col items-center justify-center gap-4 p-4">
+      <AlertCircle className="h-10 w-10 text-destructive/60" />
+      <div className="text-center space-y-1">
+        <h2 className="text-base font-semibold">문제가 발생했습니다</h2>
+        <p className="text-sm text-muted-foreground">잠시 후 다시 시도해주세요.</p>
+      </div>
+      <button
+        onClick={reset}
+        className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+      >
+        다시 시도
+      </button>
+    </div>
+  );
+}

--- a/packages/web/src/app/(user)/posts/page.tsx
+++ b/packages/web/src/app/(user)/posts/page.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { Suspense, useEffect, useState } from 'react';
-import { useSearchParams, useRouter } from 'next/navigation';
-import { FileText, ExternalLink, ChevronLeft, ChevronRight, Plus, Loader2 } from 'lucide-react';
+import { Suspense, useCallback, useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { toast } from 'sonner';
+import { ChevronLeft, ChevronRight, ExternalLink, FileText, Loader2, Plus } from 'lucide-react';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { PostsListSkeleton, PageError } from '@/components/ui/page-state';
+import { PageError, PostsListSkeleton } from '@/components/ui/page-state';
 import { PartBadge } from '@/components/ui/part-badge';
 import {
   Dialog,
@@ -65,44 +66,26 @@ function PostsContent() {
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const fetchPosts = async () => {
-      setLoading(true);
-      try {
-        const response = await fetch(`/api/posts?page=${currentPage}&pageSize=10`);
-        if (!response.ok) {
-          throw new Error('Failed to fetch posts');
-        }
-        const result = await response.json();
-        setData(result.data);
-      } catch (err) {
-        setError('포스트 목록을 불러오는데 실패했습니다.');
-        console.error(err);
-      } finally {
-        setLoading(false);
+  const fetchPosts = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(`/api/posts?page=${currentPage}&pageSize=10`);
+      if (!response.ok) {
+        throw new Error('Failed to fetch posts');
       }
-    };
-
-    fetchPosts();
+      const result = await response.json();
+      setData(result.data);
+    } catch (err) {
+      setError('포스트 목록을 불러오는데 실패했습니다.');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
   }, [currentPage]);
 
-  const refetchPosts = () => {
-    const fetchPosts = async () => {
-      setLoading(true);
-      try {
-        const response = await fetch(`/api/posts?page=${currentPage}&pageSize=10`);
-        if (!response.ok) throw new Error('Failed to fetch posts');
-        const result = await response.json();
-        setData(result.data);
-      } catch (err) {
-        setError('포스트 목록을 불러오는데 실패했습니다.');
-        console.error(err);
-      } finally {
-        setLoading(false);
-      }
-    };
+  useEffect(() => {
     fetchPosts();
-  };
+  }, [fetchPosts]);
 
   const handlePageChange = (page: number) => {
     router.push(`/posts?page=${page}`);
@@ -150,9 +133,10 @@ function PostsContent() {
       }
 
       // 성공 → 모달 닫기 + 목록 새로고침
+      toast.success('글이 등록되었습니다.');
       setDialogOpen(false);
       resetDialog();
-      refetchPosts();
+      fetchPosts();
     } catch {
       setSubmitError('서버 오류가 발생했습니다.');
     } finally {
@@ -180,11 +164,16 @@ function PostsContent() {
             <span className="text-xs text-muted-foreground">
               총 {data?.pagination.totalCount ?? 0}개
             </span>
-            <Dialog open={dialogOpen} onOpenChange={(open) => { setDialogOpen(open); if (!open) resetDialog(); }}>
+            <Dialog
+              open={dialogOpen}
+              onOpenChange={(open) => {
+                setDialogOpen(open);
+                if (!open) resetDialog();
+              }}
+            >
               <DialogTrigger asChild>
                 <Button variant="outline" size="sm" className="h-7 text-xs gap-1">
-                  <Plus className="h-3.5 w-3.5" />
-                  글 등록
+                  <Plus className="h-3.5 w-3.5" />글 등록
                 </Button>
               </DialogTrigger>
               <DialogContent>
@@ -220,9 +209,7 @@ function PostsContent() {
                       </p>
                     </div>
                   )}
-                  {submitError && (
-                    <p className="text-sm text-destructive">{submitError}</p>
-                  )}
+                  {submitError && <p className="text-sm text-destructive">{submitError}</p>}
                 </div>
                 <DialogFooter>
                   <Button
@@ -281,69 +268,86 @@ function PostsContent() {
 
             {/* Desktop: table */}
             <div className="hidden md:block overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow className="border-border/60">
-                  <TableHead className="w-[40%] text-xs font-medium text-muted-foreground h-9">제목</TableHead>
-                  <TableHead className="text-xs font-medium text-muted-foreground h-9 whitespace-nowrap">작성자</TableHead>
-                  <TableHead className="text-center text-xs font-medium text-muted-foreground h-9 whitespace-nowrap">파트</TableHead>
-                  <TableHead className="text-xs font-medium text-muted-foreground h-9 whitespace-nowrap">회차</TableHead>
-                  <TableHead className="text-xs font-medium text-muted-foreground h-9 whitespace-nowrap">작성일</TableHead>
-                  <TableHead className="text-right text-xs font-medium text-muted-foreground h-9 whitespace-nowrap">링크</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {data.posts.map((post) => (
-                  <TableRow key={post.id} className="border-border/40 hover:bg-muted/30">
-                    <TableCell className="py-2.5">
-                      <a
-                        href={post.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-sm text-primary hover:underline underline-offset-4 line-clamp-1 font-medium"
-                        onClick={() => trackPostView(post.id)}
-                      >
-                        {post.title}
-                      </a>
-                    </TableCell>
-                    <TableCell className="text-sm text-foreground/80 py-2.5 whitespace-nowrap">
-                      {post.memberNickname || post.memberDiscordUsername}
-                    </TableCell>
-                    <TableCell className="text-center py-2.5 whitespace-nowrap">
-                      {post.memberPart ? (
-                        <PartBadge part={post.memberPart} />
-                      ) : (
-                        <span className="text-xs text-muted-foreground">—</span>
-                      )}
-                    </TableCell>
-                    <TableCell className="py-2.5 whitespace-nowrap">
-                      {post.roundNumber ? (
-                        <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                          {post.roundNumber}회차
-                        </span>
-                      ) : (
-                        <span className="text-xs text-muted-foreground">—</span>
-                      )}
-                    </TableCell>
-                    <TableCell className="text-sm text-muted-foreground py-2.5 whitespace-nowrap">
-                      {new Date(post.publishedAt).toLocaleDateString('ko-KR')}
-                    </TableCell>
-                    <TableCell className="text-right py-2.5 whitespace-nowrap">
-                      <Button variant="ghost" size="sm" asChild className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground">
+              <Table>
+                <TableHeader>
+                  <TableRow className="border-border/60">
+                    <TableHead className="w-[40%] text-xs font-medium text-muted-foreground h-9">
+                      제목
+                    </TableHead>
+                    <TableHead className="text-xs font-medium text-muted-foreground h-9 whitespace-nowrap">
+                      작성자
+                    </TableHead>
+                    <TableHead className="text-center text-xs font-medium text-muted-foreground h-9 whitespace-nowrap">
+                      파트
+                    </TableHead>
+                    <TableHead className="text-xs font-medium text-muted-foreground h-9 whitespace-nowrap">
+                      회차
+                    </TableHead>
+                    <TableHead className="text-xs font-medium text-muted-foreground h-9 whitespace-nowrap">
+                      작성일
+                    </TableHead>
+                    <TableHead className="text-right text-xs font-medium text-muted-foreground h-9 whitespace-nowrap">
+                      링크
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data.posts.map((post) => (
+                    <TableRow key={post.id} className="border-border/40 hover:bg-muted/30">
+                      <TableCell className="py-2.5">
                         <a
                           href={post.url}
                           target="_blank"
                           rel="noopener noreferrer"
+                          className="text-sm text-primary hover:underline underline-offset-4 line-clamp-1 font-medium"
                           onClick={() => trackPostView(post.id)}
                         >
-                          <ExternalLink className="h-3.5 w-3.5" />
+                          {post.title}
                         </a>
-                      </Button>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                      </TableCell>
+                      <TableCell className="text-sm text-foreground/80 py-2.5 whitespace-nowrap">
+                        {post.memberNickname || post.memberDiscordUsername}
+                      </TableCell>
+                      <TableCell className="text-center py-2.5 whitespace-nowrap">
+                        {post.memberPart ? (
+                          <PartBadge part={post.memberPart} />
+                        ) : (
+                          <span className="text-xs text-muted-foreground">—</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="py-2.5 whitespace-nowrap">
+                        {post.roundNumber ? (
+                          <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                            {post.roundNumber}회차
+                          </span>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">—</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground py-2.5 whitespace-nowrap">
+                        {new Date(post.publishedAt).toLocaleDateString('ko-KR')}
+                      </TableCell>
+                      <TableCell className="text-right py-2.5 whitespace-nowrap">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          asChild
+                          className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
+                        >
+                          <a
+                            href={post.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            onClick={() => trackPostView(post.id)}
+                          >
+                            <ExternalLink className="h-3.5 w-3.5" />
+                          </a>
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
             </div>
 
             {/* Pagination */}
@@ -415,9 +419,7 @@ export default function PostsPage() {
       <div className="space-y-0.5">
         <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Posts</p>
         <h1 className="text-xl font-semibold tracking-tight">포스트</h1>
-        <p className="text-sm text-muted-foreground">
-          스터디원들이 작성한 블로그 글 목록입니다.
-        </p>
+        <p className="text-sm text-muted-foreground">스터디원들이 작성한 블로그 글 목록입니다.</p>
       </div>
 
       <Suspense fallback={<PostsListSkeleton />}>

--- a/packages/web/src/app/(user)/profile/edit/page.tsx
+++ b/packages/web/src/app/(user)/profile/edit/page.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { ArrowLeft, Save, Image, FileText, Heart, Target, User, Link2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { ArrowLeft, FileText, Heart, Image, Link2, Save, Target, User } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -15,17 +16,45 @@ import { FormPageSkeleton } from '@/components/ui/page-state';
 
 const INTEREST_OPTIONS = [
   // 개발
-  '프론트엔드', '백엔드', '풀스택', '모바일', 'DevOps', '클라우드',
-  '데이터 엔지니어링', '보안', '시스템 설계', '데이터베이스', '테스팅',
+  '프론트엔드',
+  '백엔드',
+  '풀스택',
+  '모바일',
+  'DevOps',
+  '클라우드',
+  '데이터 엔지니어링',
+  '보안',
+  '시스템 설계',
+  '데이터베이스',
+  '테스팅',
   // AI/트렌드
-  'AI', 'LLM', '데이터 사이언스', 'Web3',
+  'AI',
+  'LLM',
+  '데이터 사이언스',
+  'Web3',
   // 디자인/기획
-  'UX/UI', '프로덕트 매니지먼트', '서비스 기획', '브랜딩', '디자인 시스템',
+  'UX/UI',
+  '프로덕트 매니지먼트',
+  '서비스 기획',
+  '브랜딩',
+  '디자인 시스템',
   // 커리어/성장
-  '커리어 성장', '사이드 프로젝트', '스타트업', '오픈소스', '기술 블로그',
+  '커리어 성장',
+  '사이드 프로젝트',
+  '스타트업',
+  '오픈소스',
+  '기술 블로그',
   // 인문/일상
-  '독서', '글쓰기', '생산성', '자기계발', '인문학', '심리학',
-  '경제/재테크', '건강/운동', '여행', '일상 기록',
+  '독서',
+  '글쓰기',
+  '생산성',
+  '자기계발',
+  '인문학',
+  '심리학',
+  '경제/재테크',
+  '건강/운동',
+  '여행',
+  '일상 기록',
 ];
 
 interface ProfileData {
@@ -79,7 +108,7 @@ export default function ProfileEditPage() {
           return;
         }
         const data: ProfileData = await response.json();
-        
+
         if (!data.member) {
           router.push('/profile');
           return;
@@ -105,7 +134,8 @@ export default function ProfileEditPage() {
         if (data.member.githubUrl) setGithubUrl(data.member.githubUrl);
         if (data.member.linkedinUrl) setLinkedinUrl(data.member.linkedinUrl);
         if (data.member.instagramUrl) setInstagramUrl(data.member.instagramUrl);
-        if (data.member.rssConsent !== undefined && data.member.rssConsent !== null) setRssConsent(data.member.rssConsent);
+        if (data.member.rssConsent !== undefined && data.member.rssConsent !== null)
+          setRssConsent(data.member.rssConsent);
       } catch (err) {
         console.error(err);
         router.push('/profile');
@@ -156,11 +186,12 @@ export default function ProfileEditPage() {
       const result = await response.json();
 
       if (!response.ok) {
-        setError(result.message || '저장에 실패했습니다.');
+        setError(result.message || result.error?.message || '저장에 실패했습니다.');
         return;
       }
 
       setSuccess(true);
+      toast.success('프로필이 저장되었습니다.');
       setTimeout(() => {
         router.push('/profile');
       }, 1000);
@@ -184,9 +215,7 @@ export default function ProfileEditPage() {
         </Button>
         <div className="min-w-0">
           <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">프로필 수정</h1>
-          <p className="text-muted-foreground text-sm">
-            프로필 정보를 수정하세요.
-          </p>
+          <p className="text-muted-foreground text-sm">프로필 정보를 수정하세요.</p>
         </div>
       </div>
 
@@ -271,9 +300,7 @@ export default function ProfileEditPage() {
               <Image className="h-5 w-5" />
               <CardTitle>프로필 이미지</CardTitle>
             </div>
-            <CardDescription>
-              프로필에 표시될 이미지 URL을 입력하세요.
-            </CardDescription>
+            <CardDescription>프로필에 표시될 이미지 URL을 입력하세요.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <AvatarUpload
@@ -298,9 +325,7 @@ export default function ProfileEditPage() {
           <CardContent className="space-y-2">
             <Label htmlFor="bio">
               자기소개 <span className="text-destructive">*</span>
-              <span className="text-xs text-muted-foreground ml-2">
-                (최소 100자, 최대 200자)
-              </span>
+              <span className="text-xs text-muted-foreground ml-2">(최소 100자, 최대 200자)</span>
             </Label>
             <textarea
               id="bio"
@@ -311,9 +336,11 @@ export default function ProfileEditPage() {
               rows={4}
               className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 resize-none"
             />
-            <p className={`text-xs text-right ${
-              bio.trim().length >= 100 ? 'text-muted-foreground' : 'text-destructive'
-            }`}>
+            <p
+              className={`text-xs text-right ${
+                bio.trim().length >= 100 ? 'text-muted-foreground' : 'text-destructive'
+              }`}
+            >
               {bio.trim().length}/100자 이상 (최대 200자)
             </p>
           </CardContent>
@@ -369,9 +396,7 @@ export default function ProfileEditPage() {
               onChange={(e) => setResolution(e.target.value)}
               maxLength={300}
             />
-            <p className="text-xs text-muted-foreground text-right">
-              {resolution.length}/300
-            </p>
+            <p className="text-xs text-muted-foreground text-right">{resolution.length}/300</p>
           </CardContent>
         </Card>
 
@@ -382,9 +407,7 @@ export default function ProfileEditPage() {
               <FileText className="h-5 w-5" />
               <CardTitle>RSS 설정</CardTitle>
             </div>
-            <CardDescription>
-              블로그 글 자동 수집 설정을 관리하세요.
-            </CardDescription>
+            <CardDescription>블로그 글 자동 수집 설정을 관리하세요.</CardDescription>
           </CardHeader>
           <CardContent>
             <div className="flex items-center justify-between rounded-lg border p-3">
@@ -398,11 +421,7 @@ export default function ProfileEditPage() {
                   </p>
                 )}
               </div>
-              <Switch
-                id="rssConsent"
-                checked={rssConsent}
-                onCheckedChange={setRssConsent}
-              />
+              <Switch id="rssConsent" checked={rssConsent} onCheckedChange={setRssConsent} />
             </div>
           </CardContent>
         </Card>
@@ -453,19 +472,24 @@ export default function ProfileEditPage() {
         </Card>
 
         {/* Messages */}
-        {error && (
-          <p className="text-sm text-destructive text-center">{error}</p>
-        )}
-        {success && (
-          <p className="text-sm text-success text-center">프로필이 수정되었습니다!</p>
-        )}
+        {error && <p className="text-sm text-destructive text-center">{error}</p>}
+        {success && <p className="text-sm text-success text-center">프로필이 수정되었습니다!</p>}
 
         {/* Submit Button */}
         <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end sm:gap-4">
           <Button type="button" variant="outline" onClick={() => router.back()}>
             취소
           </Button>
-          <Button type="submit" disabled={saving || !name.trim() || !nickname.trim() || interests.length < 3 || bio.trim().length < 100}>
+          <Button
+            type="submit"
+            disabled={
+              saving ||
+              !name.trim() ||
+              !nickname.trim() ||
+              interests.length < 3 ||
+              bio.trim().length < 100
+            }
+          >
             <Save className="h-4 w-4 mr-2" />
             {saving ? '저장 중...' : '저장'}
           </Button>

--- a/packages/web/src/app/api/admin/curation/crawl/route.ts
+++ b/packages/web/src/app/api/admin/curation/crawl/route.ts
@@ -2,8 +2,13 @@ import { NextRequest } from 'next/server';
 import { eq } from 'drizzle-orm';
 import { parseFeed } from 'feedsmith';
 import { getDb } from '@/lib/db';
-import { curationSources, curationItems } from '@blog-study/shared/db';
-import { verifyAdminAccess, createUnauthorizedResponse, createForbiddenResponse } from '@/lib/admin';
+import { curationItems, curationSources } from '@blog-study/shared/db';
+import {
+  createForbiddenResponse,
+  createUnauthorizedResponse,
+  verifyAdminAccess,
+} from '@/lib/admin';
+import { isSafeUrl } from '@/lib/rss-detect';
 
 interface CrawlSourceResult {
   sourceId: string;
@@ -44,7 +49,9 @@ function extractFeedItems(result: ReturnType<typeof parseFeed>): NormalizedFeedI
       link: item.link,
       pubDate: item.pubDate ? String(item.pubDate) : undefined,
       description: item.description,
-      categories: item.categories?.map((c) => typeof c === 'string' ? c : c.name).filter(Boolean) as string[],
+      categories: item.categories
+        ?.map((c) => (typeof c === 'string' ? c : c.name))
+        .filter(Boolean) as string[],
     }));
   }
 
@@ -86,14 +93,16 @@ function sanitizeDescription(html: string | undefined): string | null {
  */
 async function extractOgImage(url: string): Promise<string | null> {
   try {
+    if (!isSafeUrl(url)) return null;
     const response = await fetch(url, {
       headers: { 'User-Agent': 'BlogStudyBot/1.0' },
       signal: AbortSignal.timeout(5000),
     });
     if (!response.ok) return null;
     const html = await response.text();
-    const match = html.match(/<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']/i)
-      || html.match(/<meta[^>]+content=["']([^"']+)["'][^>]+property=["']og:image["']/i);
+    const match =
+      html.match(/<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']/i) ||
+      html.match(/<meta[^>]+content=["']([^"']+)["'][^>]+property=["']og:image["']/i);
     return match?.[1] ?? null;
   } catch {
     return null;
@@ -174,6 +183,21 @@ export async function POST(request: NextRequest) {
         });
 
         try {
+          // SSRF 방지: RSS URL 검증
+          if (!isSafeUrl(source.rssUrl!)) {
+            const result: CrawlSourceResult = {
+              sourceId: source.id,
+              sourceName: source.name,
+              success: false,
+              itemsFound: 0,
+              newItemsAdded: 0,
+              error: '안전하지 않은 URL입니다.',
+            };
+            results.push(result);
+            send('progress', { index: i, result });
+            continue;
+          }
+
           // Fetch RSS feed
           const response = await fetch(source.rssUrl!, {
             headers: { 'User-Agent': 'BlogStudyBot/1.0' },

--- a/packages/web/src/app/api/admin/fines/[id]/route.ts
+++ b/packages/web/src/app/api/admin/fines/[id]/route.ts
@@ -3,6 +3,7 @@ import { eq } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { withAdminAuth } from '@/lib/admin';
+import { errorResponse, Errors } from '@/lib/api-error';
 
 const { fines, FineStatus } = sharedDb;
 
@@ -17,10 +18,7 @@ export const PATCH = withAdminAuth(async (request: NextRequest, _adminAuth) => {
     const id = url.pathname.split('/').pop();
 
     if (!id) {
-      return NextResponse.json(
-        { message: '벌금 ID가 필요합니다.' },
-        { status: 400 }
-      );
+      return Errors.badRequest('벌금 ID가 필요합니다.').toResponse();
     }
 
     const body = await request.json();
@@ -28,31 +26,21 @@ export const PATCH = withAdminAuth(async (request: NextRequest, _adminAuth) => {
 
     // Validate status
     if (!status || ![FineStatus.PAID, FineStatus.WAIVED].includes(status)) {
-      return NextResponse.json(
-        { message: '유효하지 않은 상태입니다. (paid 또는 waived만 가능)' },
-        { status: 400 }
-      );
+      return Errors.badRequest('유효하지 않은 상태입니다. (paid 또는 waived만 가능)').toResponse();
     }
 
     const database = db();
 
     // Check if fine exists
-    const [existingFine] = await database
-      .select()
-      .from(fines)
-      .where(eq(fines.id, id))
-      .limit(1);
+    const [existingFine] = await database.select().from(fines).where(eq(fines.id, id)).limit(1);
 
     if (!existingFine) {
-      return NextResponse.json(
-        { message: '벌금을 찾을 수 없습니다.' },
-        { status: 404 }
-      );
+      return Errors.notFound('벌금을 찾을 수 없습니다.').toResponse();
     }
 
     // Update fine status
     const updateData: { status: string; paidAt?: Date } = { status };
-    
+
     // Set paidAt timestamp if marking as paid
     if (status === FineStatus.PAID) {
       updateData.paidAt = new Date();
@@ -65,10 +53,7 @@ export const PATCH = withAdminAuth(async (request: NextRequest, _adminAuth) => {
       .returning();
 
     if (!updatedFine) {
-      return NextResponse.json(
-        { message: '벌금 업데이트에 실패했습니다.' },
-        { status: 500 }
-      );
+      return Errors.internalError('벌금 업데이트에 실패했습니다.').toResponse();
     }
 
     return NextResponse.json({
@@ -81,9 +66,6 @@ export const PATCH = withAdminAuth(async (request: NextRequest, _adminAuth) => {
     });
   } catch (error) {
     console.error('Admin fine update API error:', error);
-    return NextResponse.json(
-      { message: '서버 오류가 발생했습니다.' },
-      { status: 500 }
-    );
+    return errorResponse(error);
   }
 });

--- a/packages/web/src/app/api/admin/fines/route.ts
+++ b/packages/web/src/app/api/admin/fines/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
-import { eq, desc } from 'drizzle-orm';
+import { desc, eq } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { withAdminAuth } from '@/lib/admin';
+import { errorResponse } from '@/lib/api-error';
 
 const { members, rounds, fines, FineStatus } = sharedDb;
 
@@ -61,16 +62,19 @@ export const GET = withAdminAuth(async (_request, _adminAuth) => {
     };
 
     // Group by member for summary view
-    const byMember = new Map<string, {
-      memberId: string;
-      memberName: string;
-      memberDiscordUsername: string;
-      memberPart: string;
-      unpaidCount: number;
-      unpaidAmount: number;
-      totalCount: number;
-      totalAmount: number;
-    }>();
+    const byMember = new Map<
+      string,
+      {
+        memberId: string;
+        memberName: string;
+        memberDiscordUsername: string;
+        memberPart: string;
+        unpaidCount: number;
+        unpaidAmount: number;
+        totalCount: number;
+        totalAmount: number;
+      }
+    >();
 
     for (const fine of allFines) {
       const existing = byMember.get(fine.memberId);
@@ -115,9 +119,6 @@ export const GET = withAdminAuth(async (_request, _adminAuth) => {
     });
   } catch (error) {
     console.error('Admin fines API error:', error);
-    return NextResponse.json(
-      { message: '서버 오류가 발생했습니다.' },
-      { status: 500 }
-    );
+    return errorResponse(error);
   }
 });

--- a/packages/web/src/app/api/admin/settings/route.ts
+++ b/packages/web/src/app/api/admin/settings/route.ts
@@ -4,6 +4,7 @@ import { getDb } from '@/lib/db';
 import { config, members, rounds } from '@blog-study/shared/db';
 import { getAdminDiscordIds, getEnvAdminIds, withAdminAuth } from '@/lib/admin';
 import { generateAllRoundDates, getPreviousMonday, isMonday } from '@blog-study/shared/utils';
+import { errorResponse } from '@/lib/api-error';
 
 function formatDateToString(date: Date): string {
   return date.toISOString().split('T')[0]!;
@@ -81,7 +82,7 @@ export const GET = withAdminAuth(async (_request: NextRequest, adminAuth) => {
     });
   } catch (error) {
     console.error('Error fetching settings:', error);
-    return NextResponse.json({ error: 'Failed to fetch settings' }, { status: 500 });
+    return errorResponse(error);
   }
 });
 
@@ -161,6 +162,6 @@ export const PATCH = withAdminAuth(async (request: NextRequest, _adminAuth) => {
     return NextResponse.json({ success: true, roundsCreated });
   } catch (error) {
     console.error('Error updating settings:', error);
-    return NextResponse.json({ error: 'Failed to update settings' }, { status: 500 });
+    return errorResponse(error);
   }
 });

--- a/packages/web/src/app/api/auth/logout/route.ts
+++ b/packages/web/src/app/api/auth/logout/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { errorResponse, successResponse } from '@/lib/api-error';
 
 /**
  * POST /api/auth/logout
@@ -10,15 +10,9 @@ export async function POST() {
     const supabase = await createClient();
     await supabase.auth.signOut();
 
-    return NextResponse.json(
-      { success: true, message: '로그아웃되었습니다.' },
-      { status: 200 }
-    );
+    return successResponse(null, '로그아웃되었습니다.');
   } catch (error) {
     console.error('Logout error:', error);
-    return NextResponse.json(
-      { success: false, message: '서버 오류가 발생했습니다.' },
-      { status: 500 }
-    );
+    return errorResponse(error);
   }
 }

--- a/packages/web/src/app/api/auth/me/route.ts
+++ b/packages/web/src/app/api/auth/me/route.ts
@@ -3,6 +3,7 @@ import { eq } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { createClient } from '@/lib/supabase/server';
+import { errorResponse, Errors } from '@/lib/api-error';
 
 const { members } = sharedDb;
 
@@ -13,18 +14,16 @@ const { members } = sharedDb;
 export async function GET() {
   try {
     const supabase = await createClient();
-    const { data: { user }, error } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser();
 
     if (error || !user) {
-      return NextResponse.json(
-        { message: '인증이 필요합니다.' },
-        { status: 401 }
-      );
+      return Errors.unauthorized().toResponse();
     }
 
-    const discordIdentity = user.identities?.find(
-      (identity) => identity.provider === 'discord'
-    );
+    const discordIdentity = user.identities?.find((identity) => identity.provider === 'discord');
     const discordId = discordIdentity?.id as string | undefined;
 
     if (!discordId) {
@@ -62,9 +61,6 @@ export async function GET() {
     });
   } catch (error) {
     console.error('Get user error:', error);
-    return NextResponse.json(
-      { message: '서버 오류가 발생했습니다.' },
-      { status: 500 }
-    );
+    return errorResponse(error);
   }
 }

--- a/packages/web/src/app/api/board/[id]/route.ts
+++ b/packages/web/src/app/api/board/[id]/route.ts
@@ -6,6 +6,7 @@ import { getBoardAuth } from '@/lib/board-auth';
 import { errorResponse, Errors, successResponse } from '@/lib/api-error';
 import { getAdminDiscordIds } from '@/lib/admin';
 import { isValidCategory } from '@/lib/board-config';
+import { sanitizeTiptapContent } from '@/lib/sanitize';
 
 const { boardPosts, boardComments, members } = sharedDb;
 
@@ -172,7 +173,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
         .set({
           ...(category && { category }),
           ...(title && { title: title.trim() }),
-          ...(content && { content }),
+          ...(content && { content: sanitizeTiptapContent(content) }),
           ...(contentText && { contentText: contentText.trim() }),
           ...(isSecret !== undefined && { isSecret }),
           isPinned: effectiveCategory === 'notice',

--- a/packages/web/src/app/api/board/route.ts
+++ b/packages/web/src/app/api/board/route.ts
@@ -12,6 +12,7 @@ import {
 } from '@/lib/api-error';
 import { getAdminDiscordIds } from '@/lib/admin';
 import { isValidCategory } from '@/lib/board-config';
+import { sanitizeTiptapContent } from '@/lib/sanitize';
 
 const { boardPosts, members } = sharedDb;
 
@@ -149,7 +150,7 @@ export async function POST(request: NextRequest) {
           memberId: auth.memberId,
           category,
           title: title.trim(),
-          content,
+          content: sanitizeTiptapContent(content),
           contentText: contentText.trim(),
           isSecret: isSecret || false,
           isPinned: category === 'notice',

--- a/packages/web/src/app/api/members/[id]/route.ts
+++ b/packages/web/src/app/api/members/[id]/route.ts
@@ -1,8 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { eq, count, desc, sql } from 'drizzle-orm';
+import { NextRequest } from 'next/server';
+import { count, desc, eq, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { createClient } from '@/lib/supabase/server';
+import { errorResponse, Errors, successResponse, withCache } from '@/lib/api-error';
 
 const { members, posts, attendance, AttendanceStatus } = sharedDb;
 
@@ -11,40 +12,30 @@ const { members, posts, attendance, AttendanceStatus } = sharedDb;
  * Get member profile by ID
  * Requirement: 20.6
  */
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const supabase = await createClient();
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
     if (authError || !user) {
-      return NextResponse.json({ message: '인증이 필요합니다.' }, { status: 401 });
+      return Errors.unauthorized().toResponse();
     }
 
     const { id } = await params;
 
     if (!id) {
-      return NextResponse.json(
-        { message: '멤버 ID가 필요합니다.' },
-        { status: 400 }
-      );
+      return Errors.badRequest('멤버 ID가 필요합니다.').toResponse();
     }
 
     const database = db();
 
     // Get member by ID
-    const [member] = await database
-      .select()
-      .from(members)
-      .where(eq(members.id, id))
-      .limit(1);
+    const [member] = await database.select().from(members).where(eq(members.id, id)).limit(1);
 
     if (!member) {
-      return NextResponse.json(
-        { message: '멤버를 찾을 수 없습니다.' },
-        { status: 404 }
-      );
+      return Errors.notFound('멤버를 찾을 수 없습니다.').toResponse();
     }
 
     // Get post count
@@ -79,46 +70,45 @@ export async function GET(
       .orderBy(desc(posts.publishedAt))
       .limit(5);
 
-    return NextResponse.json({
-      member: {
-        id: member.id,
-        discordUsername: member.discordUsername,
-        name: member.name,
-        nickname: member.nickname,
-        part: member.part,
-        blogUrl: member.blogUrl,
-        profileImageUrl: member.profileImageUrl,
-        bio: member.bio,
-        interests: member.interests,
-        resolution: member.resolution,
-        status: member.status,
-        joinedAt: member.joinedAt,
-        githubUrl: member.githubUrl,
-        linkedinUrl: member.linkedinUrl,
-        instagramUrl: member.instagramUrl,
-      },
-      stats: {
-        postCount: postCount?.count ?? 0,
-        totalRounds: attStats.total,
-        submittedRounds: attStats.submitted,
-        lateRounds: attStats.late,
-        absentRounds: attStats.absent,
-        attendanceRate: attStats.total > 0 
-          ? Math.round((attStats.submitted / attStats.total) * 100) 
-          : 0,
-      },
-      recentPosts: recentPosts.map((post) => ({
-        id: post.id,
-        title: post.title,
-        url: post.url,
-        publishedAt: post.publishedAt?.toISOString(),
-      })),
-    });
+    return withCache(
+      successResponse({
+        member: {
+          id: member.id,
+          discordUsername: member.discordUsername,
+          name: member.name,
+          nickname: member.nickname,
+          part: member.part,
+          blogUrl: member.blogUrl,
+          profileImageUrl: member.profileImageUrl,
+          bio: member.bio,
+          interests: member.interests,
+          resolution: member.resolution,
+          status: member.status,
+          joinedAt: member.joinedAt,
+          githubUrl: member.githubUrl,
+          linkedinUrl: member.linkedinUrl,
+          instagramUrl: member.instagramUrl,
+        },
+        stats: {
+          postCount: postCount?.count ?? 0,
+          totalRounds: attStats.total,
+          submittedRounds: attStats.submitted,
+          lateRounds: attStats.late,
+          absentRounds: attStats.absent,
+          attendanceRate:
+            attStats.total > 0 ? Math.round((attStats.submitted / attStats.total) * 100) : 0,
+        },
+        recentPosts: recentPosts.map((post) => ({
+          id: post.id,
+          title: post.title,
+          url: post.url,
+          publishedAt: post.publishedAt?.toISOString(),
+        })),
+      }),
+      60
+    );
   } catch (error) {
     console.error('Member profile API error:', error);
-    return NextResponse.json(
-      { message: '서버 오류가 발생했습니다.' },
-      { status: 500 }
-    );
+    return errorResponse(error);
   }
 }

--- a/packages/web/src/app/api/members/route.ts
+++ b/packages/web/src/app/api/members/route.ts
@@ -1,8 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { eq, count, sql } from 'drizzle-orm';
+import { NextRequest } from 'next/server';
+import { count, eq, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { createClient } from '@/lib/supabase/server';
+import { errorResponse, Errors, successResponse, withCache } from '@/lib/api-error';
 
 const { members, posts, attendance, AttendanceStatus } = sharedDb;
 
@@ -15,25 +16,25 @@ const ALLOWED_STATUSES = ['active', 'dormant'];
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
     if (authError || !user) {
-      return NextResponse.json({ message: '인증이 필요합니다.' }, { status: 401 });
+      return Errors.unauthorized().toResponse();
     }
 
     const { searchParams } = new URL(request.url);
     const status = searchParams.get('status') || 'active';
 
     if (!ALLOWED_STATUSES.includes(status)) {
-      return NextResponse.json({ message: 'Invalid status' }, { status: 400 });
+      return Errors.badRequest('유효하지 않은 상태입니다.').toResponse();
     }
 
     const database = db();
 
     // Get members by status
-    const membersList = await database
-      .select()
-      .from(members)
-      .where(eq(members.status, status));
+    const membersList = await database.select().from(members).where(eq(members.status, status));
 
     // Get post counts for all members
     const postCounts = await database
@@ -63,9 +64,8 @@ export async function GET(request: NextRequest) {
     const result = membersList.map((member) => {
       const postCount = postCountMap.get(member.id) || 0;
       const attStats = attendanceMap.get(member.id) || { total: 0, submitted: 0 };
-      const attendanceRate = attStats.total > 0
-        ? Math.round((attStats.submitted / attStats.total) * 100)
-        : 0;
+      const attendanceRate =
+        attStats.total > 0 ? Math.round((attStats.submitted / attStats.total) * 100) : 0;
 
       return {
         id: member.id,
@@ -86,15 +86,9 @@ export async function GET(request: NextRequest) {
       };
     });
 
-    return NextResponse.json({
-      members: result,
-      total: result.length,
-    });
+    return withCache(successResponse({ members: result, total: result.length }), 60);
   } catch (error) {
     console.error('Members API error:', error);
-    return NextResponse.json(
-      { message: '서버 오류가 발생했습니다.' },
-      { status: 500 }
-    );
+    return errorResponse(error);
   }
 }

--- a/packages/web/src/app/api/posts/manual/route.ts
+++ b/packages/web/src/app/api/posts/manual/route.ts
@@ -3,6 +3,8 @@ import { eq, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { createClient } from '@/lib/supabase/server';
+import { errorResponse, Errors, successResponse } from '@/lib/api-error';
+import { isSafeUrl } from '@/lib/rss-detect';
 
 const { posts, members, rounds, ActivityScoreType } = sharedDb;
 
@@ -18,7 +20,9 @@ function getTodayDateString(): string {
 /**
  * OG 태그에서 제목과 발행일 추출
  */
-async function fetchOgData(url: string): Promise<{ title: string | null; publishedAt: string | null }> {
+async function fetchOgData(
+  url: string
+): Promise<{ title: string | null; publishedAt: string | null }> {
   try {
     const response = await fetch(url, {
       headers: { 'User-Agent': 'BlogStudyBot/1.0' },
@@ -30,14 +34,18 @@ async function fetchOgData(url: string): Promise<{ title: string | null; publish
     const html = await response.text();
 
     // title: og:title > <title>
-    const ogTitleMatch = html.match(/<meta[^>]*property=["']og:title["'][^>]*content=["']([^"']+)["']/i)
-      || html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*property=["']og:title["']/i);
+    const ogTitleMatch =
+      html.match(/<meta[^>]*property=["']og:title["'][^>]*content=["']([^"']+)["']/i) ||
+      html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*property=["']og:title["']/i);
     const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/i);
     const title = ogTitleMatch?.[1] || titleMatch?.[1] || null;
 
     // publishedAt: article:published_time
-    const pubMatch = html.match(/<meta[^>]*property=["']article:published_time["'][^>]*content=["']([^"']+)["']/i)
-      || html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*property=["']article:published_time["']/i);
+    const pubMatch =
+      html.match(
+        /<meta[^>]*property=["']article:published_time["'][^>]*content=["']([^"']+)["']/i
+      ) ||
+      html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*property=["']article:published_time["']/i);
     const publishedAt = pubMatch?.[1] || null;
 
     return { title: title?.trim() || null, publishedAt };
@@ -53,35 +61,31 @@ async function fetchOgData(url: string): Promise<{ title: string | null; publish
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
 
     if (authError || !user) {
-      return NextResponse.json({ message: '인증이 필요합니다.' }, { status: 401 });
+      return Errors.unauthorized().toResponse();
     }
 
-    const discordIdentity = user.identities?.find(
-      (identity) => identity.provider === 'discord'
-    );
+    const discordIdentity = user.identities?.find((identity) => identity.provider === 'discord');
     const discordId = discordIdentity?.id;
     if (!discordId) {
-      return NextResponse.json({ message: 'Discord 계정이 필요합니다.' }, { status: 400 });
+      return Errors.badRequest('Discord 계정이 필요합니다.').toResponse();
     }
 
     const body = await request.json();
     const { url, title: manualTitle } = body;
 
     if (!url || typeof url !== 'string') {
-      return NextResponse.json({ message: 'URL은 필수입니다.' }, { status: 400 });
+      return Errors.badRequest('URL은 필수입니다.').toResponse();
     }
 
-    // URL 형식 검증
-    try {
-      const parsed = new URL(url);
-      if (!['http:', 'https:'].includes(parsed.protocol)) {
-        return NextResponse.json({ message: 'http 또는 https URL만 허용됩니다.' }, { status: 400 });
-      }
-    } catch {
-      return NextResponse.json({ message: '유효하지 않은 URL입니다.' }, { status: 400 });
+    // URL 형식 및 SSRF 검증
+    if (!isSafeUrl(url)) {
+      return Errors.badRequest('유효하지 않은 URL입니다.').toResponse();
     }
 
     const database = db();
@@ -94,7 +98,7 @@ export async function POST(request: NextRequest) {
       .limit(1);
 
     if (!member) {
-      return NextResponse.json({ message: '멤버 정보를 찾을 수 없습니다.' }, { status: 404 });
+      return Errors.notFound('멤버 정보를 찾을 수 없습니다.').toResponse();
     }
 
     // 중복 URL 체크
@@ -105,7 +109,7 @@ export async function POST(request: NextRequest) {
       .limit(1);
 
     if (existing) {
-      return NextResponse.json({ message: '이미 등록된 URL입니다.' }, { status: 409 });
+      return Errors.conflict('이미 등록된 URL입니다.').toResponse();
     }
 
     // OG 크롤링 시도
@@ -122,7 +126,8 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // 크롤링 실패 + 수동 제목 없음
+    // 크롤링 실패 + 수동 제목 없음 → 422로 클라이언트에 제목 입력 요청
+    // 의도적으로 표준 에러 엔벨로프 대신 { needsTitle: true } 사용 (posts/page.tsx에서 분기 처리)
     if (!title) {
       return NextResponse.json(
         { message: '제목을 자동으로 가져올 수 없습니다. 직접 입력해주세요.', needsTitle: true },
@@ -168,12 +173,9 @@ export async function POST(request: NextRequest) {
       RETURNING points
     `);
 
-    return NextResponse.json({
-      message: '글이 등록되었습니다.',
-      post: newPost,
-    });
+    return successResponse({ post: newPost }, '글이 등록되었습니다.');
   } catch (error) {
     console.error('Manual post API error:', error);
-    return NextResponse.json({ message: '서버 오류가 발생했습니다.' }, { status: 500 });
+    return errorResponse(error);
   }
 }

--- a/packages/web/src/app/api/posts/route.ts
+++ b/packages/web/src/app/api/posts/route.ts
@@ -1,12 +1,13 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { desc, count, eq } from 'drizzle-orm';
+import { NextRequest } from 'next/server';
+import { count, desc, eq } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import {
-  successResponse,
+  createPaginationMeta,
   errorResponse,
+  Errors,
   parsePagination,
-  createPaginationMeta
+  successResponse,
 } from '@/lib/api-error';
 import { createClient } from '@/lib/supabase/server';
 
@@ -20,9 +21,12 @@ const { posts, members, rounds } = sharedDb;
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
     if (authError || !user) {
-      return NextResponse.json({ message: '인증이 필요합니다.' }, { status: 401 });
+      return Errors.unauthorized().toResponse();
     }
 
     const { searchParams } = new URL(request.url);
@@ -31,9 +35,7 @@ export async function GET(request: NextRequest) {
     const database = db();
 
     // Get total count
-    const totalCountResult = await database
-      .select({ count: count() })
-      .from(posts);
+    const totalCountResult = await database.select({ count: count() }).from(posts);
     const totalCount = totalCountResult[0]?.count ?? 0;
 
     // Get paginated posts with member and round info

--- a/packages/web/src/app/api/profile/edit/route.ts
+++ b/packages/web/src/app/api/profile/edit/route.ts
@@ -1,8 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { eq } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { createClient } from '@/lib/supabase/server';
+import { errorResponse, Errors, successResponse } from '@/lib/api-error';
 
 const { members } = sharedDb;
 
@@ -13,24 +14,19 @@ const { members } = sharedDb;
 export async function PUT(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user }, error } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser();
 
     if (error || !user) {
-      return NextResponse.json(
-        { message: '인증이 필요합니다.' },
-        { status: 401 }
-      );
+      return Errors.unauthorized().toResponse();
     }
 
-    const discordIdentity = user.identities?.find(
-      (identity) => identity.provider === 'discord'
-    );
+    const discordIdentity = user.identities?.find((identity) => identity.provider === 'discord');
     const discordId = discordIdentity?.id as string | undefined;
     if (!discordId) {
-      return NextResponse.json(
-        { message: '스터디원 계정이 연결되어 있지 않습니다.' },
-        { status: 400 }
-      );
+      return Errors.badRequest('스터디원 계정이 연결되어 있지 않습니다.').toResponse();
     }
 
     const database = db();
@@ -41,80 +37,71 @@ export async function PUT(request: NextRequest) {
       .limit(1);
 
     if (!memberData) {
-      return NextResponse.json(
-        { message: '스터디원 정보를 찾을 수 없습니다.' },
-        { status: 404 }
-      );
+      return Errors.notFound('스터디원 정보를 찾을 수 없습니다.').toResponse();
     }
 
     const body = await request.json();
-    const { name, nickname, part, profileImageUrl, bio, interests, resolution, githubUrl, linkedinUrl, instagramUrl, rssConsent } = body;
+    const {
+      name,
+      nickname,
+      part,
+      profileImageUrl,
+      bio,
+      interests,
+      resolution,
+      githubUrl,
+      linkedinUrl,
+      instagramUrl,
+      rssConsent,
+    } = body;
 
     if (part && (typeof part !== 'string' || part.length > 50)) {
-      return NextResponse.json(
-        { message: '파트는 50자 이내의 문자열이어야 합니다.' },
-        { status: 400 }
-      );
+      return Errors.badRequest('파트는 50자 이내의 문자열이어야 합니다.').toResponse();
     }
 
     if (profileImageUrl) {
       try {
         const url = new URL(profileImageUrl);
         if (!['http:', 'https:'].includes(url.protocol)) {
-          return NextResponse.json(
-            { message: '프로필 이미지 URL은 http 또는 https만 허용됩니다.' },
-            { status: 400 }
-          );
+          return Errors.badRequest(
+            '프로필 이미지 URL은 http 또는 https만 허용됩니다.'
+          ).toResponse();
         }
       } catch {
-        return NextResponse.json(
-          { message: '유효하지 않은 프로필 이미지 URL입니다.' },
-          { status: 400 }
-        );
+        return Errors.badRequest('유효하지 않은 프로필 이미지 URL입니다.').toResponse();
       }
     }
 
     if (bio && typeof bio === 'string' && bio.trim().length < 100) {
-      return NextResponse.json(
-        { message: '자기소개는 100자 이상 작성해주세요.' },
-        { status: 400 }
-      );
+      return Errors.badRequest('자기소개는 100자 이상 작성해주세요.').toResponse();
     }
 
     if (bio && typeof bio === 'string' && bio.length > 200) {
-      return NextResponse.json(
-        { message: '자기소개는 200자 이내로 작성해주세요.' },
-        { status: 400 }
-      );
+      return Errors.badRequest('자기소개는 200자 이내로 작성해주세요.').toResponse();
     }
 
     if (resolution && resolution.length > 300) {
-      return NextResponse.json(
-        { message: '다짐은 300자 이내로 작성해주세요.' },
-        { status: 400 }
-      );
+      return Errors.badRequest('다짐은 300자 이내로 작성해주세요.').toResponse();
     }
 
     if (interests) {
       if (!Array.isArray(interests) || interests.length > 20) {
-        return NextResponse.json(
-          { message: '관심 분야는 최대 20개까지 입력 가능합니다.' },
-          { status: 400 }
-        );
+        return Errors.badRequest('관심 분야는 최대 20개까지 입력 가능합니다.').toResponse();
       }
       if (!interests.every((i: unknown) => typeof i === 'string' && i.length <= 50)) {
-        return NextResponse.json(
-          { message: '관심 분야는 각 50자 이내의 문자열이어야 합니다.' },
-          { status: 400 }
-        );
+        return Errors.badRequest('관심 분야는 각 50자 이내의 문자열이어야 합니다.').toResponse();
       }
     }
 
     await database
       .update(members)
       .set({
-        ...(name && typeof name === 'string' && name.trim().length > 0 ? { name: name.trim() } : {}),
-        ...(nickname && typeof nickname === 'string' && nickname.trim().length > 0 ? { nickname: nickname.trim() } : {}),
+        ...(name && typeof name === 'string' && name.trim().length > 0
+          ? { name: name.trim() }
+          : {}),
+        ...(nickname && typeof nickname === 'string' && nickname.trim().length > 0
+          ? { nickname: nickname.trim() }
+          : {}),
         ...(part ? { part } : {}),
         profileImageUrl: profileImageUrl || null,
         bio: bio || null,
@@ -128,14 +115,9 @@ export async function PUT(request: NextRequest) {
       })
       .where(eq(members.id, memberData.id));
 
-    return NextResponse.json({
-      message: '프로필이 수정되었습니다.',
-    });
+    return successResponse(null, '프로필이 수정되었습니다.');
   } catch (error) {
     console.error('Profile edit API error:', error);
-    return NextResponse.json(
-      { message: '서버 오류가 발생했습니다.' },
-      { status: 500 }
-    );
+    return errorResponse(error);
   }
 }

--- a/packages/web/src/app/api/profile/route.ts
+++ b/packages/web/src/app/api/profile/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
-import { eq, count, sql } from 'drizzle-orm';
+import { count, eq, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { createClient } from '@/lib/supabase/server';
+import { errorResponse, Errors } from '@/lib/api-error';
 
 const { members, posts, attendance, fines, AttendanceStatus, FineStatus } = sharedDb;
 
@@ -13,18 +14,16 @@ const { members, posts, attendance, fines, AttendanceStatus, FineStatus } = shar
 export async function GET() {
   try {
     const supabase = await createClient();
-    const { data: { user }, error } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser();
 
     if (error || !user) {
-      return NextResponse.json(
-        { message: '인증이 필요합니다.' },
-        { status: 401 }
-      );
+      return Errors.unauthorized().toResponse();
     }
 
-    const discordIdentity = user.identities?.find(
-      (identity) => identity.provider === 'discord'
-    );
+    const discordIdentity = user.identities?.find((identity) => identity.provider === 'discord');
     const discordId = discordIdentity?.id as string | undefined;
     let memberData = null;
     let stats = null;
@@ -72,9 +71,8 @@ export async function GET() {
           submittedRounds: attStats.submitted,
           lateRounds: attStats.late,
           absentRounds: attStats.absent,
-          attendanceRate: attStats.total > 0
-            ? Math.round((attStats.submitted / attStats.total) * 100)
-            : 0,
+          attendanceRate:
+            attStats.total > 0 ? Math.round((attStats.submitted / attStats.total) * 100) : 0,
           totalFines: fStats.totalFines,
           unpaidFines: fStats.unpaidFines,
         };
@@ -89,35 +87,34 @@ export async function GET() {
         avatarUrl: user.user_metadata?.avatar_url,
         memberId: memberData?.id ?? null,
       },
-      member: memberData ? {
-        id: memberData.id,
-        discordId: memberData.discordId,
-        discordUsername: memberData.discordUsername,
-        name: memberData.name,
-        nickname: memberData.nickname,
-        part: memberData.part,
-        blogUrl: memberData.blogUrl,
-        rssUrl: memberData.rssUrl,
-        profileImageUrl: memberData.profileImageUrl,
-        bio: memberData.bio,
-        interests: memberData.interests,
-        resolution: memberData.resolution,
-        rssConsent: memberData.rssConsent ?? true,
-        onboardingCompleted: memberData.onboardingCompleted,
-        status: memberData.status,
-        dormantUsed: memberData.dormantUsed,
-        joinedAt: memberData.joinedAt,
-        githubUrl: memberData.githubUrl,
-        linkedinUrl: memberData.linkedinUrl,
-        instagramUrl: memberData.instagramUrl,
-      } : null,
+      member: memberData
+        ? {
+            id: memberData.id,
+            discordId: memberData.discordId,
+            discordUsername: memberData.discordUsername,
+            name: memberData.name,
+            nickname: memberData.nickname,
+            part: memberData.part,
+            blogUrl: memberData.blogUrl,
+            rssUrl: memberData.rssUrl,
+            profileImageUrl: memberData.profileImageUrl,
+            bio: memberData.bio,
+            interests: memberData.interests,
+            resolution: memberData.resolution,
+            rssConsent: memberData.rssConsent ?? true,
+            onboardingCompleted: memberData.onboardingCompleted,
+            status: memberData.status,
+            dormantUsed: memberData.dormantUsed,
+            joinedAt: memberData.joinedAt,
+            githubUrl: memberData.githubUrl,
+            linkedinUrl: memberData.linkedinUrl,
+            instagramUrl: memberData.instagramUrl,
+          }
+        : null,
       stats,
     });
   } catch (error) {
     console.error('Profile API error:', error);
-    return NextResponse.json(
-      { message: '서버 오류가 발생했습니다.' },
-      { status: 500 }
-    );
+    return errorResponse(error);
   }
 }

--- a/packages/web/src/app/api/profile/withdraw/route.ts
+++ b/packages/web/src/app/api/profile/withdraw/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from 'next/server';
 import { eq } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { createClient } from '@/lib/supabase/server';
+import { errorResponse, Errors, successResponse } from '@/lib/api-error';
 
 const { members, MemberStatus } = sharedDb;
 
@@ -19,16 +19,13 @@ export async function POST() {
     } = await supabase.auth.getUser();
 
     if (error || !user) {
-      return NextResponse.json({ message: '인증이 필요합니다.' }, { status: 401 });
+      return Errors.unauthorized().toResponse();
     }
 
     const discordIdentity = user.identities?.find((identity) => identity.provider === 'discord');
     const discordId = discordIdentity?.id as string | undefined;
     if (!discordId) {
-      return NextResponse.json(
-        { message: '스터디원 계정이 연결되어 있지 않습니다.' },
-        { status: 400 }
-      );
+      return Errors.badRequest('스터디원 계정이 연결되어 있지 않습니다.').toResponse();
     }
 
     const database = db();
@@ -39,11 +36,11 @@ export async function POST() {
       .limit(1);
 
     if (!memberData) {
-      return NextResponse.json({ message: '스터디원 정보를 찾을 수 없습니다.' }, { status: 404 });
+      return Errors.notFound('스터디원 정보를 찾을 수 없습니다.').toResponse();
     }
 
     if (memberData.status === MemberStatus.WITHDRAWN) {
-      return NextResponse.json({ message: '이미 탈퇴한 계정입니다.' }, { status: 400 });
+      return Errors.badRequest('이미 탈퇴한 계정입니다.').toResponse();
     }
 
     await database
@@ -54,11 +51,9 @@ export async function POST() {
       })
       .where(eq(members.id, memberData.id));
 
-    return NextResponse.json({
-      message: '탈퇴가 완료되었습니다.',
-    });
+    return successResponse(null, '탈퇴가 완료되었습니다.');
   } catch (error) {
     console.error('Withdraw API error:', error);
-    return NextResponse.json({ message: '서버 오류가 발생했습니다.' }, { status: 500 });
+    return errorResponse(error);
   }
 }

--- a/packages/web/src/app/api/ranking/route.ts
+++ b/packages/web/src/app/api/ranking/route.ts
@@ -1,8 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { count, desc, eq, inArray, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
-import { errorResponse, successResponse } from '@/lib/api-error';
+import { errorResponse, Errors, successResponse, withCache } from '@/lib/api-error';
 import { createClient } from '@/lib/supabase/server';
 
 const { members, posts, attendance, rounds, activityScores, MemberStatus, AttendanceStatus } =
@@ -114,7 +114,7 @@ export async function GET(request: NextRequest) {
       error: authError,
     } = await supabase.auth.getUser();
     if (authError || !user) {
-      return NextResponse.json({ message: '인증이 필요합니다.' }, { status: 401 });
+      return Errors.unauthorized().toResponse();
     }
 
     const { searchParams } = new URL(request.url);
@@ -364,14 +364,17 @@ export async function GET(request: NextRequest) {
       currentUserId = currentMember[0]?.id ?? null;
     }
 
-    return successResponse({
-      rankings: rankingsWithDelta,
-      totalMembers: rankingsWithDelta.length,
-      currentUserId,
-      currentRound: currentRound[0]
-        ? { id: currentRound[0].id, roundNumber: currentRound[0].roundNumber }
-        : null,
-    });
+    return withCache(
+      successResponse({
+        rankings: rankingsWithDelta,
+        totalMembers: rankingsWithDelta.length,
+        currentUserId,
+        currentRound: currentRound[0]
+          ? { id: currentRound[0].id, roundNumber: currentRound[0].roundNumber }
+          : null,
+      }),
+      30
+    );
   } catch (error) {
     console.error('Ranking API error:', error);
     return errorResponse(error);

--- a/packages/web/src/app/api/rounds/[id]/route.ts
+++ b/packages/web/src/app/api/rounds/[id]/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest } from 'next/server';
-import { eq, count } from 'drizzle-orm';
+import { count, eq } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
-import { Errors, successResponse, errorResponse } from '@/lib/api-error';
+import { errorResponse, Errors, successResponse } from '@/lib/api-error';
+import { createClient } from '@/lib/supabase/server';
 
 const { rounds, attendance, posts, AttendanceStatus } = sharedDb;
 
@@ -14,11 +15,17 @@ interface RouteParams {
  * GET /api/rounds/[id]
  * Get a single round with statistics
  */
-export async function GET(
-  _request: NextRequest,
-  { params }: RouteParams
-) {
+export async function GET(_request: NextRequest, { params }: RouteParams) {
   try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return Errors.unauthorized().toResponse();
+    }
+
     const { id } = await params;
 
     if (!id) {
@@ -29,7 +36,7 @@ export async function GET(
 
     // Get round by ID (can be numeric ID or round number)
     let roundData;
-    
+
     // Try to parse as number for round number lookup
     const roundNumber = parseInt(id, 10);
     if (!isNaN(roundNumber)) {
@@ -81,10 +88,10 @@ export async function GET(
     const endDate = new Date(roundData.endDate);
     const graceEndDate = new Date(roundData.graceEndDate);
     const startDate = new Date(roundData.startDate);
-    
+
     const timeDiff = endDate.getTime() - now.getTime();
     const daysRemaining = Math.ceil(timeDiff / (1000 * 60 * 60 * 24));
-    
+
     const isGracePeriod = now > endDate && now <= graceEndDate;
     const isCompleted = now > graceEndDate;
     const isUpcoming = now < startDate;

--- a/packages/web/src/app/api/rounds/route.ts
+++ b/packages/web/src/app/api/rounds/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { eq, asc, desc } from 'drizzle-orm';
+import { asc, desc, eq } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
-import { successResponse, errorResponse } from '@/lib/api-error';
+import { errorResponse, Errors, successResponse } from '@/lib/api-error';
+import { createClient } from '@/lib/supabase/server';
 
 const { rounds } = sharedDb;
 
@@ -12,6 +13,15 @@ const { rounds } = sharedDb;
  */
 export async function GET(request: NextRequest) {
   try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return Errors.unauthorized().toResponse();
+    }
+
     const { searchParams } = new URL(request.url);
     const current = searchParams.get('current');
     const sortOrder = searchParams.get('sort') || 'asc';
@@ -37,11 +47,11 @@ export async function GET(request: NextRequest) {
       const now = new Date();
       const endDate = new Date(currentRound.endDate);
       const graceEndDate = new Date(currentRound.graceEndDate);
-      
+
       // Calculate days remaining
       const timeDiff = endDate.getTime() - now.getTime();
       const daysRemaining = Math.ceil(timeDiff / (1000 * 60 * 60 * 24));
-      
+
       // Check if in grace period
       const isGracePeriod = now > endDate && now <= graceEndDate;
 

--- a/packages/web/src/app/api/scores/route.ts
+++ b/packages/web/src/app/api/scores/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { desc, eq, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
-import { errorResponse, successResponse } from '@/lib/api-error';
+import { errorResponse, Errors, successResponse } from '@/lib/api-error';
 import { createClient } from '@/lib/supabase/server';
 import { isAdminDiscordId } from '@/lib/admin';
 
@@ -22,7 +22,7 @@ export async function GET(request: NextRequest) {
       error: authError,
     } = await supabase.auth.getUser();
     if (authError || !user) {
-      return NextResponse.json({ message: '인증이 필요합니다.' }, { status: 401 });
+      return Errors.unauthorized().toResponse();
     }
 
     const { searchParams } = new URL(request.url);

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next';
 import { ThemeProvider } from 'next-themes';
+import { Toaster } from 'sonner';
 import './globals.css';
 
 export const viewport: Viewport = {
@@ -51,6 +52,17 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           disableTransitionOnChange
         >
           {children}
+          <Toaster
+            position="bottom-center"
+            toastOptions={{
+              className: 'font-sans',
+              style: {
+                fontFamily: '"Pretendard Variable", Pretendard, sans-serif',
+              },
+            }}
+            richColors
+            closeButton
+          />
         </ThemeProvider>
       </body>
     </html>

--- a/packages/web/src/app/not-found.tsx
+++ b/packages/web/src/app/not-found.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center gap-4 p-4">
+      <div className="text-center space-y-2">
+        <p className="text-6xl font-bold text-muted-foreground/30">404</p>
+        <h1 className="text-lg font-semibold">페이지를 찾을 수 없습니다</h1>
+        <p className="text-sm text-muted-foreground">
+          요청하신 페이지가 존재하지 않거나 이동되었을 수 있습니다.
+        </p>
+      </div>
+      <Link
+        href="/dashboard"
+        className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+      >
+        대시보드로 돌아가기
+      </Link>
+    </div>
+  );
+}

--- a/packages/web/src/lib/api-error.ts
+++ b/packages/web/src/lib/api-error.ts
@@ -172,6 +172,21 @@ export function validateRequired(
 }
 
 /**
+ * Set Cache-Control header on a NextResponse
+ * @param response - NextResponse to modify
+ * @param maxAge - Cache duration in seconds (0 = no-store)
+ * @param scope - 'private' for user-specific data (default), 'public' for shared data
+ */
+export function withCache<T>(response: NextResponse<T>, maxAge: number, scope: 'private' | 'public' = 'private'): NextResponse<T> {
+  if (maxAge <= 0) {
+    response.headers.set('Cache-Control', 'no-store');
+  } else {
+    response.headers.set('Cache-Control', `${scope}, max-age=${maxAge}, stale-while-revalidate=${maxAge * 2}`);
+  }
+  return response;
+}
+
+/**
  * Parse pagination parameters from URL search params
  */
 export function parsePagination(searchParams: URLSearchParams): {

--- a/packages/web/src/lib/rss-detect.ts
+++ b/packages/web/src/lib/rss-detect.ts
@@ -13,7 +13,7 @@ const HTTP_TIMEOUT = 10000;
  * SSRF 방지: 안전한 외부 URL인지 검증
  * 로컬호스트, 프라이빗 네트워크, 메타데이터 엔드포인트 차단
  */
-function isSafeUrl(urlString: string): boolean {
+export function isSafeUrl(urlString: string): boolean {
   try {
     const url = new URL(urlString);
     const hostname = url.hostname.replace(/^\[|\]$/g, ''); // strip IPv6 brackets

--- a/packages/web/src/lib/sanitize.ts
+++ b/packages/web/src/lib/sanitize.ts
@@ -17,6 +17,34 @@ export function sanitizeDescription(input: string): string {
 }
 
 /**
+ * Tiptap JSON content에서 위험한 링크 href 제거
+ * javascript:, data:, vbscript: 프로토콜 차단
+ */
+const DANGEROUS_PROTOCOLS = /^(javascript|data|vbscript):/i;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function sanitizeTiptapContent(content: any): any {
+  if (!content || typeof content !== 'object') return content;
+
+  // Mark 레벨 검사 (link mark의 href)
+  if (Array.isArray(content.marks)) {
+    content.marks = content.marks.filter((mark: { type: string; attrs?: { href?: string } }) => {
+      if (mark.type === 'link' && mark.attrs?.href) {
+        return !DANGEROUS_PROTOCOLS.test(mark.attrs.href.trim());
+      }
+      return true;
+    });
+  }
+
+  // 재귀적으로 자식 노드 처리
+  if (Array.isArray(content.content)) {
+    content.content = content.content.map(sanitizeTiptapContent);
+  }
+
+  return content;
+}
+
+/**
  * KST (UTC+9) 기준 오늘 날짜 문자열 (YYYY-MM-DD)
  */
 export function getTodayKST(): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^2.3.0
         version: 2.6.0
@@ -4328,6 +4331,12 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -8888,6 +8897,11 @@ snapshots:
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
+
+  sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary
- 전체 웹 API 라우트를 표준 에러/성공 응답 패턴으로 통일
- 보안 레이어 강화 (XSS, SSRF, CSP)
- 에러 처리 UX 개선 (에러 바운더리, 404, 토스트)

## Changes

### API 표준화 (16개 라우트)
| 파일 | 변경 |
|------|------|
| `api/auth/me`, `api/auth/logout` | `Errors.unauthorized()` + `successResponse()` 적용 |
| `api/profile/route`, `edit`, `withdraw` | 전체 에러 응답 `Errors.*()` 통일 |
| `api/members/route`, `[id]` | `withCache(successResponse(...), 60)` 적용 |
| `api/posts/route`, `manual` | `Errors.unauthorized()` + SSRF 체크 추가 |
| `api/ranking/route` | `withCache(successResponse(...), 30)` 적용 |
| `api/scores/route` | `Errors.unauthorized()` 적용 |
| `api/rounds/route`, `[id]` | 미인증 엔드포인트에 auth 체크 추가 |
| `api/admin/fines/route`, `[id]` | `errorResponse()` 통일 |
| `api/admin/settings/route` | `errorResponse()` 통일 |
| `api/board/route`, `[id]` | `sanitizeTiptapContent()` XSS 방어 적용 |

### 보안 강화
| 파일 | 변경 |
|------|------|
| `lib/sanitize.ts` | `sanitizeTiptapContent()` 추가 (javascript:/data:/vbscript: 링크 제거) |
| `lib/rss-detect.ts` | `isSafeUrl()` export로 변경 (SSRF 방어 재사용) |
| `api/admin/curation/crawl/route.ts` | SSRF 체크 (`isSafeUrl()`) 적용 |
| `api/posts/manual/route.ts` | SSRF 체크 적용 |
| `next.config.js` | Content-Security-Policy 헤더 추가 |

### 에러 처리 & UX
| 파일 | 변경 |
|------|------|
| `lib/api-error.ts` | `withCache()` 유틸 추가 |
| `app/layout.tsx` | sonner `<Toaster />` 추가 |
| `app/not-found.tsx` | 커스텀 404 페이지 (신규) |
| `app/(user)/error.tsx` | 사용자 에러 바운더리 (신규) |
| `app/(admin)/error.tsx` | 관리자 에러 바운더리 (신규) |
| `admin/fines/page.tsx` | inline 토스트 → sonner `toast.success/error` |
| `profile/edit/page.tsx` | 저장 성공 토스트 추가 |
| `board/write`, `board/[id]/edit` | 작성/수정 성공 토스트 추가 |
| `posts/page.tsx` | 중복 `fetchPosts` → `useCallback` 통합 |

### 문서
| 파일 | 변경 |
|------|------|
| `CLAUDE.md` | sonner, sanitize, withCache, 보안 컨벤션 추가 |
| `docs/26-03-06-patterns.md` | Cache-Control, 새니타이즈, SSRF, 토스트 패턴 추가 |
| `docs/ARCHITECTURE.md` | 보안 섹션 + 에러 처리 섹션 추가 |

## Design Decisions
| 결정 | 이유 |
|------|------|
| `withCache()` scope 기본값 `private` | 인증 필수 API이므로 CDN 캐싱 방지 |
| `sanitizeTiptapContent()` 서버사이드 적용 | 클라이언트 우회 가능하므로 저장 시점에서 방어 |
| sonner 선택 | shadcn/ui 공식 추천 토스트 라이브러리, 번들 크기 작음 |
| CSP에 `unsafe-inline` 포함 | Next.js App Router가 인라인 스크립트/스타일 사용 |

## Test Plan
- [x] 로그인 후 각 페이지 정상 렌더링 확인
- [x] API 에러 시 표준 JSON 응답 반환 확인
- [x] 게시글 작성 시 javascript: 링크 필터링 확인
- [x] 벌금 관리 페이지 토스트 정상 동작 확인
- [x] 404 페이지 표시 확인 (/nonexistent)
- [x] CSP 헤더 응답에 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)