### PR TITLE
feat: 벌금 납부 확인을 버튼 기반으로 변경

### DIFF
--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -9,8 +9,8 @@ export function createBotClient(): Client {
       GatewayIntentBits.Guilds,
       GatewayIntentBits.GuildMessages,
       GatewayIntentBits.DirectMessages,
-      // MessageContent Intent는 Discord Developer Portal에서 활성화 필요
-      // 임시로 비활성화 (활성화 후 아래 주석 제거)
+      // MessageContent Intent 없이 버튼/인터랙션 방식으로 동작
+      // 봇이 100개 미만 서버라 Intent 활성화 불가능
       // GatewayIntentBits.MessageContent,
       GatewayIntentBits.GuildMessageReactions,
     ],

--- a/packages/bot/src/handlers/dm-handler.ts
+++ b/packages/bot/src/handlers/dm-handler.ts
@@ -5,7 +5,7 @@
  * MessageContent Intent 없이 동작하도록 버튼/인터랙션 방식 사용
  */
 
-import { Client, Events, ButtonBuilder, ButtonStyle, ActionRowBuilder, Interaction } from 'discord.js';
+import { Client, Events, ButtonBuilder, ButtonStyle, ActionRowBuilder, Interaction, ChannelType } from 'discord.js';
 import {
   getFineService,
   formatFineReason,
@@ -68,7 +68,7 @@ async function handleButtonInteraction(interaction: Interaction): Promise<void> 
   }
 
   // Only handle interactions in DMs
-  if (!interaction.channel || interaction.channel.type !== 1) { // 1 = DM
+  if (!interaction.channel || interaction.channel.type !== ChannelType.DM) {
     return;
   }
 

--- a/packages/bot/src/handlers/dm-handler.ts
+++ b/packages/bot/src/handlers/dm-handler.ts
@@ -1,13 +1,13 @@
 /**
  * DM Handler
- * 벌금 납부 확인을 위한 DM 응답 처리
+ * 벌금 납부 확인을 위한 버튼 기반 상호작용 처리
  * Requirements: 8.2
+ * MessageContent Intent 없이 동작하도록 버튼/인터랙션 방식 사용
  */
 
-import { Message, Client, Events } from 'discord.js';
+import { Client, Events, ButtonBuilder, ButtonStyle, ActionRowBuilder, Interaction } from 'discord.js';
 import {
   getFineService,
-  isPaymentConfirmation,
   formatFineReason,
 } from '../services';
 
@@ -57,64 +57,78 @@ export function clearPendingConfirmations(discordId: string): void {
 
 
 /**
- * Handle DM message for fine payment confirmation
- * Requirements: 8.2 - Parse confirmation words and update fine status
+ * Handle button interaction for fine payment confirmation
+ * Requirements: 8.2 - Handle button click to confirm payment
+ * MessageContent Intent 없이 동작 - 버튼 인터랙션 사용
  */
-async function handleDMMessage(message: Message): Promise<void> {
-  // Ignore bot messages
-  if (message.author.bot) {
+async function handleButtonInteraction(interaction: Interaction): Promise<void> {
+  // Only handle button interactions
+  if (!interaction.isButton()) {
     return;
   }
 
-  // Only process DMs
-  if (message.guild) {
+  // Only handle interactions in DMs
+  if (!interaction.channel || interaction.channel.type !== 1) { // 1 = DM
     return;
   }
 
-  const discordId = message.author.id;
-  const pendingFineIds = getPendingConfirmations(discordId);
+  const customId = interaction.customId;
 
-  // If no pending confirmations, ignore
-  if (pendingFineIds.length === 0) {
+  // Check if this is a payment confirmation button
+  if (!customId.startsWith('confirm_payment_')) {
     return;
   }
 
-  // Check if message contains confirmation words
-  if (!isPaymentConfirmation(message.content)) {
+  const fineId = customId.replace('confirm_payment_', '');
+  const discordId = interaction.user.id;
+
+  // Verify this fine is pending for this user
+  const pendingFines = getPendingConfirmations(discordId);
+  if (!pendingFines.includes(fineId)) {
+    try {
+      await interaction.reply({
+        content: '❌ 이 벌금은 이미 처리되었거나 유효하지 않습니다.',
+        ephemeral: true,
+      });
+    } catch (error) {
+      console.error('❌ Failed to send error reply:', error);
+    }
     return;
   }
 
   const fineService = getFineService();
 
-  // Mark all pending fines as paid
-  const paidFines: string[] = [];
-  for (const fineId of pendingFineIds) {
-    try {
-      await fineService.markPaid(fineId);
-      paidFines.push(fineId);
-      removePendingConfirmation(discordId, fineId);
-      
-      console.log(`✅ Fine ${fineId} marked as paid for user ${discordId}`);
-    } catch (error) {
-      console.error(`❌ Failed to mark fine ${fineId} as paid:`, error);
-    }
-  }
+  try {
+    await fineService.markPaid(fineId);
+    removePendingConfirmation(discordId, fineId);
 
-  // Send confirmation message
-  if (paidFines.length > 0) {
+    console.log(`✅ Fine ${fineId} marked as paid for user ${discordId}`);
+
     try {
-      await message.reply({
-        content: `✅ 벌금 납부가 확인되었습니다! (${paidFines.length}건)\n감사합니다. 🙏`,
+      await interaction.reply({
+        content: '✅ 벌금 납부가 확인되었습니다! 감사합니다. 🙏',
+        ephemeral: false,
       });
     } catch (error) {
       console.error('❌ Failed to send confirmation reply:', error);
+    }
+  } catch (error) {
+    console.error(`❌ Failed to mark fine ${fineId} as paid:`, error);
+    try {
+      await interaction.reply({
+        content: '❌ 납부 처리 중 오류가 발생했습니다. 관리자에게 문의해주세요.',
+        ephemeral: true,
+      });
+    } catch (replyError) {
+      console.error('❌ Failed to send error reply:', replyError);
     }
   }
 }
 
 /**
- * Send fine notification DM to a user
+ * Send fine notification DM to a user with payment confirmation button
  * Requirements: 8.1 - Send DM with fine amount, reason, and payment instructions
+ * MessageContent Intent 없이 동작 - 버튼 사용
  */
 export async function sendFineNotification(
   client: Client,
@@ -140,15 +154,26 @@ export async function sendFineNotification(
       `💰 **금액**: ${amount.toLocaleString()}원`,
       `📝 **사유**: ${reason}`,
       ``,
-      `납부 완료 후 이 메시지에 "납부완료" 또는 "완료"라고 답장해주세요.`,
-      `(영어로 "yes", "done", "paid"도 가능합니다)`,
+      `납부 완료 후 아래 버튼을 클릭해주세요.`,
     ].join('\n');
 
-    await user.send(message);
-    
+    // Create payment confirmation button
+    const row = new ActionRowBuilder<ButtonBuilder>()
+      .addComponents(
+        new ButtonBuilder()
+          .setCustomId(`confirm_payment_${fineId}`)
+          .setLabel('✅ 납부 완료')
+          .setStyle(ButtonStyle.Success)
+      );
+
+    await user.send({
+      content: message,
+      components: [row],
+    });
+
     // Track pending confirmation
     addPendingConfirmation(discordId, fineId);
-    
+
     console.log(`📤 Fine notification sent to ${discordId} for fine ${fineId}`);
     return true;
   } catch (error) {
@@ -158,8 +183,9 @@ export async function sendFineNotification(
 }
 
 /**
- * Send fine reminder DM to a user
+ * Send fine reminder DM to a user with payment confirmation button
  * Requirements: 8.4 - Send reminder for unpaid fines
+ * MessageContent Intent 없이 동작 - 버튼 사용
  */
 export async function sendFineReminder(
   client: Client,
@@ -186,14 +212,26 @@ export async function sendFineReminder(
       ``,
       `💰 **금액**: ${amount.toLocaleString()}원`,
       ``,
-      `납부 완료 후 이 메시지에 "납부완료" 또는 "완료"라고 답장해주세요.`,
+      `납부 완료 후 아래 버튼을 클릭해주세요.`,
     ].join('\n');
 
-    await user.send(message);
-    
+    // Create payment confirmation button
+    const row = new ActionRowBuilder<ButtonBuilder>()
+      .addComponents(
+        new ButtonBuilder()
+          .setCustomId(`confirm_payment_${fineId}`)
+          .setLabel('✅ 납부 완료')
+          .setStyle(ButtonStyle.Success)
+      );
+
+    await user.send({
+      content: message,
+      components: [row],
+    });
+
     // Ensure pending confirmation is tracked
     addPendingConfirmation(discordId, fineId);
-    
+
     console.log(`📤 Fine reminder sent to ${discordId} for fine ${fineId}`);
     return true;
   } catch (error) {
@@ -204,15 +242,17 @@ export async function sendFineReminder(
 
 /**
  * Setup DM handler for the bot client
+ * MessageContent Intent 없이 버튼 인터랙션으로 동작
  */
 export function setupDMHandler(client: Client): void {
-  client.on(Events.MessageCreate, async (message) => {
+  // Listen for button interactions
+  client.on(Events.InteractionCreate, async (interaction) => {
     try {
-      await handleDMMessage(message);
+      await handleButtonInteraction(interaction);
     } catch (error) {
-      console.error('❌ Error handling DM message:', error);
+      console.error('❌ Error handling button interaction:', error);
     }
   });
 
-  console.log('📬 DM handler setup complete');
+  console.log('📬 DM handler setup complete (button-based)');
 }

--- a/packages/bot/src/handlers/dm-handler.ts
+++ b/packages/bot/src/handlers/dm-handler.ts
@@ -3,56 +3,60 @@
  * 벌금 납부 확인을 위한 버튼 기반 상호작용 처리
  * Requirements: 8.2
  * MessageContent Intent 없이 동작하도록 버튼/인터랙션 방식 사용
+ * P0 #9 해결: 인메모리 Map → DB 영속화로 변경
  */
 
 import { Client, Events, ButtonBuilder, ButtonStyle, ActionRowBuilder, Interaction, ChannelType } from 'discord.js';
+import { getDb, fines } from '@blog-study/shared/db';
+import { eq } from 'drizzle-orm';
 import {
   getFineService,
   formatFineReason,
 } from '../services';
 
 /**
- * Track pending fine confirmations
- * Maps Discord user ID to their pending fine IDs
- */
-const pendingConfirmations = new Map<string, string[]>();
-
-/**
  * Add a pending fine confirmation for a user
+ * DB의 pendingConfirmation 컬럼을 true로 설정
  */
-export function addPendingConfirmation(discordId: string, fineId: string): void {
-  const existing = pendingConfirmations.get(discordId) || [];
-  if (!existing.includes(fineId)) {
-    existing.push(fineId);
-    pendingConfirmations.set(discordId, existing);
+export async function addPendingConfirmation(_discordId: string, fineId: string): Promise<void> {
+  const db = getDb();
+  try {
+    await db
+      .update(fines)
+      .set({ pendingConfirmation: true })
+      .where(eq(fines.id, fineId));
+  } catch (error) {
+    console.error(`❌ Failed to add pending confirmation for fine ${fineId}:`, error);
   }
 }
 
 /**
  * Remove a pending fine confirmation for a user
+ * DB의 pendingConfirmation 컬럼을 false로 설정
  */
-export function removePendingConfirmation(discordId: string, fineId: string): void {
-  const existing = pendingConfirmations.get(discordId) || [];
-  const filtered = existing.filter(id => id !== fineId);
-  if (filtered.length > 0) {
-    pendingConfirmations.set(discordId, filtered);
-  } else {
-    pendingConfirmations.delete(discordId);
+export async function removePendingConfirmation(_discordId: string, fineId: string): Promise<void> {
+  const db = getDb();
+  try {
+    await db
+      .update(fines)
+      .set({ pendingConfirmation: false })
+      .where(eq(fines.id, fineId));
+  } catch (error) {
+    console.error(`❌ Failed to remove pending confirmation for fine ${fineId}:`, error);
   }
 }
 
 /**
- * Get pending fine confirmations for a user
+ * Check if a fine has pending confirmation
  */
-export function getPendingConfirmations(discordId: string): string[] {
-  return pendingConfirmations.get(discordId) || [];
-}
-
-/**
- * Clear all pending confirmations for a user
- */
-export function clearPendingConfirmations(discordId: string): void {
-  pendingConfirmations.delete(discordId);
+async function isPendingConfirmation(fineId: string): Promise<boolean> {
+  const db = getDb();
+  const [fine] = await db
+    .select({ pendingConfirmation: fines.pendingConfirmation })
+    .from(fines)
+    .where(eq(fines.id, fineId))
+    .limit(1);
+  return fine?.pendingConfirmation || false;
 }
 
 
@@ -82,9 +86,9 @@ async function handleButtonInteraction(interaction: Interaction): Promise<void> 
   const fineId = customId.replace('confirm_payment_', '');
   const discordId = interaction.user.id;
 
-  // Verify this fine is pending for this user
-  const pendingFines = getPendingConfirmations(discordId);
-  if (!pendingFines.includes(fineId)) {
+  // Verify this fine is pending for this user (DB 조회)
+  const isPending = await isPendingConfirmation(fineId);
+  if (!isPending) {
     try {
       await interaction.reply({
         content: '❌ 이 벌금은 이미 처리되었거나 유효하지 않습니다.',
@@ -100,7 +104,7 @@ async function handleButtonInteraction(interaction: Interaction): Promise<void> 
 
   try {
     await fineService.markPaid(fineId);
-    removePendingConfirmation(discordId, fineId);
+    await removePendingConfirmation(discordId, fineId);
 
     console.log(`✅ Fine ${fineId} marked as paid for user ${discordId}`);
 
@@ -171,8 +175,8 @@ export async function sendFineNotification(
       components: [row],
     });
 
-    // Track pending confirmation
-    addPendingConfirmation(discordId, fineId);
+    // Track pending confirmation in DB
+    await addPendingConfirmation(discordId, fineId);
 
     console.log(`📤 Fine notification sent to ${discordId} for fine ${fineId}`);
     return true;
@@ -229,8 +233,8 @@ export async function sendFineReminder(
       components: [row],
     });
 
-    // Ensure pending confirmation is tracked
-    addPendingConfirmation(discordId, fineId);
+    // Ensure pending confirmation is tracked in DB
+    await addPendingConfirmation(discordId, fineId);
 
     console.log(`📤 Fine reminder sent to ${discordId} for fine ${fineId}`);
     return true;
@@ -243,6 +247,7 @@ export async function sendFineReminder(
 /**
  * Setup DM handler for the bot client
  * MessageContent Intent 없이 버튼 인터랙션으로 동작
+ * P0 #9 해결: 인메모리 Map → DB 영속화로 변경
  */
 export function setupDMHandler(client: Client): void {
   // Listen for button interactions
@@ -254,5 +259,5 @@ export function setupDMHandler(client: Client): void {
     }
   });
 
-  console.log('📬 DM handler setup complete (button-based)');
+  console.log('📬 DM handler setup complete (button-based, DB-persistent)');
 }

--- a/packages/bot/src/services/fine.service.ts
+++ b/packages/bot/src/services/fine.service.ts
@@ -27,6 +27,8 @@ export const FineAmounts = {
 
 /**
  * Confirmation words for payment (Korean and English)
+ * @deprecated 버튼 기반으로 변경되어 더 이상 사용되지 않음 (26-03-10)
+ * 이전 텍스트 파싱 방식에서 사용되던 상수로, 테스트 호환성을 위해 유지
  */
 export const PaymentConfirmationWords = [
   'yes',
@@ -68,11 +70,12 @@ export class FineError extends Error {
 
 /**
  * Check if a message contains payment confirmation words
+ * @deprecated 버튼 기반으로 변경되어 더 이상 사용되지 않음 (26-03-10)
  * Requirements: 8.2 - Parse confirmation words from DM reply
  */
 export function isPaymentConfirmation(message: string): boolean {
   const normalizedMessage = message.toLowerCase().trim();
-  return PaymentConfirmationWords.some(word => 
+  return PaymentConfirmationWords.some(word =>
     normalizedMessage.includes(word.toLowerCase())
   );
 }

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -200,10 +200,12 @@ export const fines = pgTable(
     status: varchar('status', { length: 20 }).notNull().default(FineStatus.UNPAID),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
     paidAt: timestamp('paid_at', { withTimezone: true }),
+    pendingConfirmation: boolean('pending_confirmation').default(true),
   },
   (table) => ({
     memberRoundUnique: uniqueIndex('fines_member_round_unique').on(table.memberId, table.roundId),
     statusIdx: index('idx_fines_status').on(table.status),
+    pendingConfirmationIdx: index('idx_fines_pending_confirmation').on(table.pendingConfirmation),
   })
 );
 


### PR DESCRIPTION
## 🎯 Summary
> 이 PR의 목적을 한 줄로 요약해주세요
- MessageContent Intent 없이 동작하도록 벌금 납부 확인을 텍스트 파싱에서 Discord 버튼/인터랙션 방식으로 변경

---

## 🔴 AS-IS
> 기존 상태 또는 문제점
- MessageContent Intent가 비활성화되어 있어 `message.content`가 빈 문자열로 반환됨
- 봇이 100개 미만 서버라 Discord에서 Message Content Intent 활성화 불가
- 사용자가 DM으로 "납부완료"라고 답장해도 인식하지 못해 벌금 상태가 업데이트되지 않음

## 🟢 TO-BE
> 변경 후 상태 또는 개선점
- 벌금 알림 DM에 "✅ 납부 완료" 버튼 추가
- 버튼 클릭 시 `InteractionCreate` 이벤트로 처리하여 MessageContent Intent 불필요
- 사용자가 버튼 클릭 한 번으로 벌금 상태 `PAID`로 자동 변경
- Discord Developer Portal 설정 없이 동작

---

## 💬 참고사항
> 리뷰어가 알아야 할 내용, 논의 포인트, 주의사항 등
- **P0 #2 문제 해결** (docs/plans/26-03-10-bot-review-findings.md)
- 테스트 완료: 최호 계정으로 실제 DM 발송 및 버튼 클릭 테스트 성공
- 레거시 함수 `isPaymentConfirmation()`, `PaymentConfirmationWords`는 @deprecated 마크 (테스트 호환성 유지)
- 각 벌금마다 별도 버튼 생성으로 여러 벌금이 있어도 개별 납부 가능