### PR TITLE
feat: RSS 수집 시 출석 상태 업데이트 및 결석/지각 벌금 자동 부과

### DIFF
--- a/packages/bot/src/scheduler-registry.ts
+++ b/packages/bot/src/scheduler-registry.ts
@@ -85,17 +85,20 @@ export async function registerAllJobs(boss: PgBoss, client: Client): Promise<voi
         // P0 #3: 출석 상태 업데이트 (제출 또는 지각)
         if (currentRound) {
           // 회차 기간 내 제출 여부 판단
-          const roundEndDate = new Date(currentRound.endDate);
-          roundEndDate.setHours(23, 59, 59, 999); // 마감일 23:59:59.999까지
+          // endDate는 YYYY-MM-DD 포맷이며, KST (Asia/Seoul) 기준 23:59:59.999까지를 마감으로 처리
+          const roundEndDate = new Date(`${currentRound.endDate}T23:59:59.999+09:00`);
 
           const isLate = item.pubDate > roundEndDate;
 
           if (isLate) {
             // 지각: 출석 상태 업데이트 + 벌금 부과
+            // markLate()와 fineService.create()는 내부에서 중복 방지 로직을 가짐:
+            // - markLate(): PENDING 상태일 때만 LATE로 변경 (기존 LATE/ABSENT 유지)
+            // - fineService.create(): 동일 회차 벌금이 이미 있으면 기존 벌금 반환
             await attendanceService.markLate(member.id, currentRound.id);
             console.log(`⏰ ${member.name} 지각 처리 (${currentRound.roundNumber}회차)`);
 
-            // 지각 벌금 생성
+            // 지각 벌금 생성 (이미 존재하면 기존 벌금 반환)
             const fine = await fineService.create(member.id, currentRound.id, 'late');
             await sendFineNotification(
               client,
@@ -107,6 +110,7 @@ export async function registerAllJobs(boss: PgBoss, client: Client): Promise<voi
             );
           } else {
             // 정상 제출
+            // markSubmitted()는 내부에서 PENDING 상태일 때만 SUBMITTED로 변경 (기존 LATE/ABSENT 유지)
             await attendanceService.markSubmitted(member.id, currentRound.id);
             console.log(`✅ ${member.name} 제출 완료 (${currentRound.roundNumber}회차)`);
           }

--- a/packages/bot/src/scheduler-registry.ts
+++ b/packages/bot/src/scheduler-registry.ts
@@ -17,7 +17,9 @@ import type { CrawledContent } from './services/curation.service';
 import { getPostService } from './services/post.service';
 import { getNotificationService } from './services/notification.service';
 import { getScoreService } from './services/score.service';
-import { ActivityScoreType, curationSources, getDb } from '@blog-study/shared/db';
+import { getAttendanceService, getFineService } from './services';
+import { sendFineNotification } from './handlers/dm-handler';
+import { getDb, members, ActivityScoreType, curationSources } from '@blog-study/shared/db';
 import { getCurrentRound } from './services/round.service';
 import { eq } from 'drizzle-orm';
 
@@ -54,10 +56,12 @@ export async function registerAllJobs(boss: PgBoss, client: Client): Promise<voi
   curationCrawler.setClient(client);
   weeklyRanking.setClient(client);
 
-  // Set up RSS poller callback: new post → save to DB + send notification + grant score
+  // Set up RSS poller callback: new post → save to DB + send notification + grant score + update attendance
   const postService = getPostService();
   const notificationService = getNotificationService();
   const scoreService = getScoreService();
+  const attendanceService = getAttendanceService();
+  const fineService = getFineService();
 
   // 2025-07-01 이후 발행된 글만 수집
   const POST_CUTOFF_DATE = new Date('2025-07-01T00:00:00Z');
@@ -78,6 +82,36 @@ export async function registerAllJobs(boss: PgBoss, client: Client): Promise<voi
       });
 
       if (result.isNew) {
+        // P0 #3: 출석 상태 업데이트 (제출 또는 지각)
+        if (currentRound) {
+          // 회차 기간 내 제출 여부 판단
+          const roundEndDate = new Date(currentRound.endDate);
+          roundEndDate.setHours(23, 59, 59, 999); // 마감일 23:59:59.999까지
+
+          const isLate = item.pubDate > roundEndDate;
+
+          if (isLate) {
+            // 지각: 출석 상태 업데이트 + 벌금 부과
+            await attendanceService.markLate(member.id, currentRound.id);
+            console.log(`⏰ ${member.name} 지각 처리 (${currentRound.roundNumber}회차)`);
+
+            // 지각 벌금 생성
+            const fine = await fineService.create(member.id, currentRound.id, 'late');
+            await sendFineNotification(
+              client,
+              member.discordId,
+              fine.id,
+              fine.amount,
+              'late',
+              currentRound.roundNumber
+            );
+          } else {
+            // 정상 제출
+            await attendanceService.markSubmitted(member.id, currentRound.id);
+            console.log(`✅ ${member.name} 제출 완료 (${currentRound.roundNumber}회차)`);
+          }
+        }
+
         // 블로그 포스트 점수 부여 (+30점, 일일 2편 상한)
         const safeTitle = item.title.replace(/[<>"'&]/g, '').slice(0, 200);
         await scoreService.grantScore(
@@ -92,6 +126,41 @@ export async function registerAllJobs(boss: PgBoss, client: Client): Promise<voi
           roundNumber: currentRound?.roundNumber ?? null,
         });
       }
+    }
+  });
+
+  // P0 #4: 결석/지각 벌금 콜백 설정
+  // 결석 콜백: 화요일 00:00에 결석자 판정 시 자동 벌금 부과
+  attendanceChecker.setOnAbsentCallback(async (attendance, round) => {
+    try {
+      const db = getDb();
+      const [member] = await db
+        .select()
+        .from(members)
+        .where(eq(members.id, attendance.memberId))
+        .limit(1);
+
+      if (!member) {
+        console.error(`❌ Member not found: ${attendance.memberId}`);
+        return;
+      }
+
+      // 결석 벌금 생성
+      const fine = await fineService.create(attendance.memberId, round.id, 'absent');
+
+      // DM으로 벌금 알림 발송
+      await sendFineNotification(
+        client,
+        member.discordId,
+        fine.id,
+        fine.amount,
+        'absent',
+        round.roundNumber
+      );
+
+      console.log(`❌ ${member.name} 결석 벌금 부과 (${round.roundNumber}회차, ${fine.amount}원)`);
+    } catch (error) {
+      console.error(`❌ Failed to process absent callback for ${attendance.memberId}:`, error);
     }
   });
 


### PR DESCRIPTION
## 🎯 Summary
> 이 PR의 목적을 한 줄로 요약해주세요
- RSS에서 새 글 수집 시 자동으로 출석 상태 업데이트하고, 지각/결석 시 벌금 자동 부과 기능 추가

---

## 🔴 AS-IS
> 기존 상태 또는 문제점
- RSS 폴러가 새 글을 DB에 저장하지만 출석 상태 업데이트는 별도로 수동 처리해야 했음
- 지각/결석 시 벌금 부과가 자동화되지 않아 관리자가 수동으로 처리해야 했음
- 화요일 00:00 출석 체크 시 결석자 판정은 되지만 벌금 부과 로직이 없었음

## 🟢 TO-BE
> 변경 후 상태 또는 개선점
- RSS 콜백에서 새 글 생성 시 자동으로 출석 상태 업데이트 (SUBMITTED/LATE 판단)
- 마감일(23:59:59.999) 이후 제출 시 자동으로 `LATE` 처리 + 벌금 3,000원 부과
- 화요일 00:00 출석 체크 시 결석자 자동으로 벌금 5,000원 부과 + DM 발송
- 관리자 개입 없이 전체 자동화

---

## 💬 참고사항
> 리뷰어가 알아야 할 내용, 논의 포인트, 주의사항 등
- **P0 #3, #4 해결**: (docs/plans/26-03-10-bot-review-findings.md 참조)
- **테스트 완료**: 최호 계정으로 실제 "테스트 글" 발행 → 자동으로 출석 상태 `SUBMITTED`로 업데이트 확인
- **동작 흐름**:
  1. RSS 폴러가 5분마다 자동 실행
  2. 최호가 블로그에 글 발행
  3. RSS 수집 → 포스트 저장 → 출석 상태 `SUBMITTED` 자동 업데이트
  4. 지각 시: `LATE` + 벌금 3,000원 + DM
  5. 결석 시: 화요일 00:00 체크 → 벌금 5,000원 + DM

- **지각 판단 로직**:
  ```typescript
  const roundEndDate = new Date(currentRound.endDate);
  roundEndDate.setHours(23, 59, 59, 999); // 마감일 23:59:59.999까지
  const isLate = item.pubDate > roundEndDate;
  ```

- **결석 콜백**: `attendanceChecker.setOnAbsentCallback()` 설정
- **테스트 회차**: 1000회차 (2026-03-10 ~ 2026-03-16, 지각 마감 2026-03-20)

---

## 기술 변경 사항

### scheduler-registry.ts
- RSS 콜백에 출석 상태 업데이트 로직 추가 (lines 84-113)
- 지각 시 `attendanceService.markLate()` + 벌금 생성 + DM 발송
- 정상 제출 시 `attendanceService.markSubmitted()`
- 결석 콜백 설정 (`attendanceChecker.setOnAbsentCallback()`)

### import 추가
- `getAttendanceService`, `getFineService`, `sendFineNotification`
- `getDb`, `members` (결석 콜백에서 멤버 조회)

---

## Co-Authored-By
Claude Sonnet 4.6 <noreply@anthropic.com>