### PR TITLE
fix: Fine Reminder 3일 간격 로직 수정 (P1 #10)

### DIFF
--- a/packages/bot/src/schedulers/fine-reminder.ts
+++ b/packages/bot/src/schedulers/fine-reminder.ts
@@ -82,20 +82,21 @@ export class FineReminder {
       // P1 #10: 3일마다 리마인드 로직 수정
       // lastReminderAt을 확인하여 정확히 3일 간격으로 리마인드 발송
       const now = new Date();
-      const threeDaysAgo = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000);
 
       const finesNeedingReminder = finesWithInfo.filter(({ fine }) => {
         // 미납 벌금만 대상
         if (fine.status !== 'PENDING') return false;
 
-        // 벌금 생성 3일 이전인지 확인
         const createdAt = fine.createdAt ? new Date(fine.createdAt) : new Date();
-        if (createdAt < threeDaysAgo) return false;
 
-        // 마지막 리마인드가 없거나, 3일 이전인지 확인
+        // 벌금 생성 후 최소 3일 경과했는지 확인
+        const threeDaysSinceCreation = new Date(createdAt.getTime() + 3 * 24 * 60 * 60 * 1000);
+        if (now < threeDaysSinceCreation) return false;
+
+        // 마지막 리마인드가 없거나, 3일 이상 경과했는지 확인
         const lastReminderAt = fine.lastReminderAt ? new Date(fine.lastReminderAt) : null;
         if (!lastReminderAt) {
-          // 첫 리마인드: 생성 3일 이후
+          // 첫 리마인드: 생성 3일 이후 경과함 (위에서 이미 확인됨)
           return true;
         }
 

--- a/packages/bot/src/schedulers/fine-reminder.ts
+++ b/packages/bot/src/schedulers/fine-reminder.ts
@@ -75,21 +75,33 @@ export class FineReminder {
 
     try {
       const fineService = getFineService();
-      
+
       // Get all unpaid fines with member info
       const finesWithInfo = await fineService.getFinesWithMemberInfo();
 
-      // Filter fines that need reminders (created more than 3 days ago)
-      // and check if today is a reminder day (every 3 days)
+      // P1 #10: 3일마다 리마인드 로직 수정
+      // lastReminderAt을 확인하여 정확히 3일 간격으로 리마인드 발송
       const now = new Date();
+      const threeDaysAgo = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000);
+
       const finesNeedingReminder = finesWithInfo.filter(({ fine }) => {
+        // 미납 벌금만 대상
+        if (fine.status !== 'PENDING') return false;
+
+        // 벌금 생성 3일 이전인지 확인
         const createdAt = fine.createdAt ? new Date(fine.createdAt) : new Date();
-        const daysSinceCreation = Math.floor(
-          (now.getTime() - createdAt.getTime()) / (1000 * 60 * 60 * 24)
-        );
-        
-        // Send reminder if 3+ days have passed and it's a multiple of 3 days
-        return daysSinceCreation >= 3 && daysSinceCreation % 3 === 0;
+        if (createdAt < threeDaysAgo) return false;
+
+        // 마지막 리마인드가 없거나, 3일 이전인지 확인
+        const lastReminderAt = fine.lastReminderAt ? new Date(fine.lastReminderAt) : null;
+        if (!lastReminderAt) {
+          // 첫 리마인드: 생성 3일 이후
+          return true;
+        }
+
+        // 이전 리마인드로부터 3일 이상 경과했는지 확인
+        const threeDaysSinceLastReminder = new Date(lastReminderAt.getTime() + 3 * 24 * 60 * 60 * 1000);
+        return now >= threeDaysSinceLastReminder;
       });
 
       console.log(
@@ -116,6 +128,8 @@ export class FineReminder {
 
           if (success) {
             sentCount++;
+            // P1 #10: 리마인드 발송 후 lastReminderAt 업데이트
+            await fineService.updateLastReminderAt(fine.id);
           } else {
             failedCount++;
           }

--- a/packages/bot/src/services/fine.service.ts
+++ b/packages/bot/src/services/fine.service.ts
@@ -387,6 +387,24 @@ export class FineService {
     }
     return this.markWaived(fine.id);
   }
+
+  /**
+   * Update last reminder timestamp
+   * P1 #10: 3일 간격 리마인드를 위해 마지막 리마인드 시간 저장
+   */
+  async updateLastReminderAt(fineId: string): Promise<Fine> {
+    const [updated] = await this.db
+      .update(fines)
+      .set({ lastReminderAt: new Date() })
+      .where(eq(fines.id, fineId))
+      .returning();
+
+    if (!updated) {
+      throw new Error(`Fine ${fineId} not found`);
+    }
+
+    return updated;
+  }
 }
 
 // Singleton instance

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -201,11 +201,13 @@ export const fines = pgTable(
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
     paidAt: timestamp('paid_at', { withTimezone: true }),
     pendingConfirmation: boolean('pending_confirmation').default(true),
+    lastReminderAt: timestamp('last_reminder_at', { withTimezone: true }),
   },
   (table) => ({
     memberRoundUnique: uniqueIndex('fines_member_round_unique').on(table.memberId, table.roundId),
     statusIdx: index('idx_fines_status').on(table.status),
     pendingConfirmationIdx: index('idx_fines_pending_confirmation').on(table.pendingConfirmation),
+    lastReminderAtIdx: index('idx_fines_last_reminder_at').on(table.lastReminderAt),
   })
 );
 


### PR DESCRIPTION
## 🎯 Summary
> 이 PR의 목적을 한 줄로 요약해주세요
Fine Reminder가 정확히 3일 간격으로 발송되도록 수정 (매일 중복 발송 버그 해결)

---

## 🔴 AS-IS
> 기존 상태 또는 문제점
- 매일 10:00에 크론이 실행됨
- `daysSinceCreation % 3 === 0` 로직으로 3일 간격 체크
- **문제**: 3일째 10:00부터 4일째 10:00까지도 `daysSinceCreation = 3`으로 계산되어 매일 리마인드 발송

## 🟢 TO-BE
> 변경 후 상태 또는 개선점
- `fines` 테이블에 `lastReminderAt` 컬럼 추가
- 리마인드 발송 후 `lastReminderAt` 타임스탬프 업데이트
- **개선**: 마지막 리마인드로부터 정확히 3일 경과 시에만 재발송 (3일, 6일, 9일...)

---

## 💬 참고사항
> 리뷰어가 알아야 할 내용, 논의 포인트, 주의사항 등

### DB 스키마 변경
```sql
-- fines 테이블에 컬럼 추가
ALTER TABLE fines ADD COLUMN last_reminder_at TIMESTAMPTZ;
CREATE INDEX idx_fines_last_reminder_at ON fines(last_reminder_at);
```

### 필터 로직
```typescript
// 이전: daysSinceCreation % 3 === 0
// 신규: 마지막 리마인드로부터 3일 이상 경과 확인

const threeDaysSinceLastReminder = new Date(
  lastReminderAt.getTime() + 3 * 24 * 60 * 60 * 1000
);
return now >= threeDaysSinceLastReminder;
```

### 마이그레이션
```bash
cd packages/shared
export $(grep DATABASE_URL ../../.env.local | head -1 | xargs)
npx drizzle-kit push --force
```