### PR TITLE
fix(a11y): P2 접근성 이슈 개선 (Landmark, Skip-to-Content, ARIA Labels)

### DIFF
--- a/packages/web/src/app/(user)/board/page.tsx
+++ b/packages/web/src/app/(user)/board/page.tsx
@@ -440,14 +440,9 @@ function BoardContent() {
               <span id="pinned-notice-title" className="text-xs font-semibold text-amber-700 dark:text-amber-500 uppercase tracking-wider">
                 공지사항
               </span>
-          <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-amber-200/60 dark:border-amber-800/30">
-            <Pin className="h-3.5 w-3.5 text-amber-600 dark:text-amber-500 shrink-0" />
-            <span className="text-xs font-semibold text-amber-700 dark:text-amber-500 uppercase tracking-wider">
-              공지사항
-            </span>
-          </div>
+            </div>
 
-          {/* Desktop: pinned table */}
+            {/* Desktop: pinned table */}
           <div className="hidden md:block">
             <Table>
               <TableBody>

--- a/packages/web/src/app/(user)/board/page.tsx
+++ b/packages/web/src/app/(user)/board/page.tsx
@@ -401,37 +401,45 @@ function BoardContent() {
   return (
     <div className="space-y-4">
       {/* Controls: Tabs + Write button */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <Tabs value={currentCategory} onValueChange={handleCategoryChange}>
-          <TabsList className="h-9 gap-0.5 bg-muted/60 p-1 flex-wrap">
-            {ALL_TABS.map((tab) => (
-              <TabsTrigger
-                key={tab.value}
-                value={tab.value}
-                className="h-7 px-2.5 text-xs data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm"
-              >
-                {tab.label}
-              </TabsTrigger>
-            ))}
-          </TabsList>
-        </Tabs>
+      <section aria-label="게시판 필터 및 글쓰기">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <Tabs value={currentCategory} onValueChange={handleCategoryChange}>
+            <TabsList className="h-9 gap-0.5 bg-muted/60 p-1 flex-wrap" aria-label="카테고리 필터">
+              {ALL_TABS.map((tab) => (
+                <TabsTrigger
+                  key={tab.value}
+                  value={tab.value}
+                  className="h-7 px-2.5 text-xs data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm"
+                >
+                  {tab.label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
 
-        <div className="flex items-center gap-2 self-end sm:self-auto">
-          <span className="text-xs text-muted-foreground tabular-nums">
-            총 {totalCount}개
-          </span>
-          <Button asChild size="sm" className="h-8 gap-1.5 text-xs">
-            <Link href="/board/write">
-              <PenSquare className="h-3.5 w-3.5" />
-              글쓰기
-            </Link>
-          </Button>
+          <div className="flex items-center gap-2 self-end sm:self-auto">
+            <span className="text-xs text-muted-foreground tabular-nums">
+              총 {totalCount}개
+            </span>
+            <Button asChild size="sm" className="h-8 gap-1.5 text-xs">
+              <Link href="/board/write">
+                <PenSquare className="h-3.5 w-3.5" aria-hidden="true" />
+                글쓰기
+              </Link>
+            </Button>
+          </div>
         </div>
-      </div>
+      </section>
 
       {/* Pinned notices section */}
       {showPinned && (
-        <div className="rounded-xl border border-amber-200/70 bg-amber-50/50 dark:border-amber-800/30 dark:bg-amber-950/10 overflow-hidden">
+        <section aria-labelledby="pinned-notice-title">
+          <div className="rounded-xl border border-amber-200/70 bg-amber-50/50 dark:border-amber-800/30 dark:bg-amber-950/10 overflow-hidden">
+            <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-amber-200/60 dark:border-amber-800/30">
+              <Pin className="h-3.5 w-3.5 text-amber-600 dark:text-amber-500 shrink-0" aria-hidden="true" />
+              <span id="pinned-notice-title" className="text-xs font-semibold text-amber-700 dark:text-amber-500 uppercase tracking-wider">
+                공지사항
+              </span>
           <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-amber-200/60 dark:border-amber-800/30">
             <Pin className="h-3.5 w-3.5 text-amber-600 dark:text-amber-500 shrink-0" />
             <span className="text-xs font-semibold text-amber-700 dark:text-amber-500 uppercase tracking-wider">
@@ -456,11 +464,13 @@ function BoardContent() {
               <PinnedCard key={post.id} post={post} />
             ))}
           </div>
-        </div>
+          </div>
+        </section>
       )}
 
       {/* Normal posts */}
-      <Card className="border-border/60 shadow-none overflow-hidden">
+      <section aria-labelledby="posts-title">
+        <Card className="border-border/60 shadow-none overflow-hidden">
         {posts.length > 0 ? (
           <>
             {/* Desktop: table */}
@@ -499,15 +509,19 @@ function BoardContent() {
 
             {/* Pagination */}
             {pagination && pagination.totalPages > 1 && (
-              <div className="flex flex-wrap items-center justify-center gap-1 border-t border-border/40 py-4">
+              <nav
+                className="flex flex-wrap items-center justify-center gap-1 border-t border-border/40 py-4"
+                aria-label="게시글 페이지네이션"
+              >
                 <Button
                   variant="ghost"
                   size="sm"
                   onClick={() => handlePageChange(currentPage - 1)}
                   disabled={currentPage <= 1}
                   className="h-8 px-2 text-xs text-muted-foreground hover:text-foreground disabled:opacity-40"
+                  aria-label="이전 페이지"
                 >
-                  <ChevronLeft className="h-3.5 w-3.5 mr-0.5" />
+                  <ChevronLeft className="h-3.5 w-3.5 mr-0.5" aria-hidden="true" />
                   이전
                 </Button>
                 {(() => {
@@ -526,6 +540,8 @@ function BoardContent() {
                       variant="ghost"
                       size="sm"
                       onClick={() => handlePageChange(page)}
+                      aria-label={`${page} 페이지${page === currentPage ? ' (현재 페이지)' : ''}`}
+                      aria-current={page === currentPage ? 'page' : undefined}
                       className={`h-8 w-8 p-0 text-xs tabular-nums ${
                         page === currentPage
                           ? 'bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground'
@@ -542,16 +558,17 @@ function BoardContent() {
                   onClick={() => handlePageChange(currentPage + 1)}
                   disabled={currentPage >= pagination.totalPages}
                   className="h-8 px-2 text-xs text-muted-foreground hover:text-foreground disabled:opacity-40"
+                  aria-label="다음 페이지"
                 >
                   다음
-                  <ChevronRight className="h-3.5 w-3.5 ml-0.5" />
+                  <ChevronRight className="h-3.5 w-3.5 ml-0.5" aria-hidden="true" />
                 </Button>
-              </div>
+              </nav>
             )}
           </>
         ) : (
           <div className="flex flex-col items-center justify-center py-16 gap-2">
-            <LayoutList className="h-8 w-8 text-muted-foreground/40" />
+            <LayoutList className="h-8 w-8 text-muted-foreground/40" aria-hidden="true" />
             <p className="text-sm text-muted-foreground">
               {currentCategory === 'all'
                 ? '아직 작성된 게시글이 없습니다.'
@@ -563,6 +580,7 @@ function BoardContent() {
           </div>
         )}
       </Card>
+    </section>
     </div>
   );
 }

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -312,6 +312,27 @@
   display: none;
 }
 
+/* ── Skip to Content Link (Accessibility) ── */
+.skip-to-content {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  z-index: 9999;
+  padding: 1rem 2rem;
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  text-decoration: none;
+  border-radius: 0 0 0.5rem 0;
+  border: 1px solid hsl(var(--border));
+  border-top: none;
+}
+
+.skip-to-content:focus {
+  left: 0;
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: -2px;
+}
+
 /* ── Landing Page ── */
 @keyframes marquee {
   0% { transform: translateX(0); }

--- a/packages/web/src/components/landing/landing-client.tsx
+++ b/packages/web/src/components/landing/landing-client.tsx
@@ -102,9 +102,9 @@ function Hero() {
   return (
     <section className="relative flex min-h-[calc(100vh-56px)] flex-col items-center justify-center overflow-hidden px-6 py-24 text-center">
       {/* Glow background */}
-      <div className="landing-glow absolute inset-0 pointer-events-none" />
+      <div className="landing-glow absolute inset-0 pointer-events-none" aria-hidden="true" />
       {/* Grid pattern overlay */}
-      <div className="grid-pattern absolute inset-0 pointer-events-none" />
+      <div className="grid-pattern absolute inset-0 pointer-events-none" aria-hidden="true" />
 
       <div className="relative z-10 flex flex-col items-center">
         {/* Badge pill */}
@@ -307,6 +307,7 @@ function AvatarMarquee() {
                 key={`${seed}-${i}`}
                 src={`https://api.dicebear.com/9.x/fun-emoji/svg?seed=${seed}`}
                 alt=""
+                aria-hidden="true"
                 width={48}
                 height={48}
                 className="rounded-full border border-white/10 shrink-0"
@@ -322,7 +323,7 @@ function AvatarMarquee() {
 function FinalCTA() {
   return (
     <section className="relative overflow-hidden px-6 py-24 sm:py-32 text-center">
-      <div className="landing-glow-bottom absolute inset-0 pointer-events-none" />
+      <div className="landing-glow-bottom absolute inset-0 pointer-events-none" aria-hidden="true" />
 
       <div className="relative z-10 mx-auto max-w-2xl">
         <FadeUp delay={0}>
@@ -354,6 +355,7 @@ function Footer() {
             href="https://github.com/bbbang105"
             target="_blank"
             rel="noopener noreferrer"
+            aria-label="bbbang105 GitHub 프로필 (새 탭에서 열림)"
             className="text-zinc-500 hover:text-white transition-colors"
           >
             @bbbang105
@@ -363,6 +365,7 @@ function Footer() {
             href="https://github.com/choihooo"
             target="_blank"
             rel="noopener noreferrer"
+            aria-label="choihooo GitHub 프로필 (새 탭에서 열림)"
             className="text-zinc-500 hover:text-white transition-colors"
           >
             @choihooo
@@ -380,8 +383,11 @@ function Footer() {
 export function LandingClient({ stats }: LandingClientProps) {
   return (
     <div className="min-h-screen bg-[#0a0a0a] text-white">
+      <a href="#main-content" className="skip-to-content">
+        본문으로 바로가기
+      </a>
       <Nav />
-      <main>
+      <main id="main-content" tabIndex={-1}>
         <Hero />
         <StatsBar stats={stats} />
         <FeaturesBento />

--- a/packages/web/src/components/layout/bottom-nav.tsx
+++ b/packages/web/src/components/layout/bottom-nav.tsx
@@ -61,12 +61,13 @@ export function BottomNav({ isAdmin = false }: BottomNavProps) {
             <Link
               key={item.href}
               href={item.href}
+              aria-current={isActive ? 'page' : undefined}
               className={cn(
                 'flex flex-1 flex-col items-center justify-center gap-0.5 py-1 text-[10px] font-medium transition-colors',
                 isActive ? 'text-primary' : 'text-muted-foreground active:text-foreground'
               )}
             >
-              <Icon className={cn('h-5 w-5', isActive && 'text-primary')} />
+              <Icon className={cn('h-5 w-5', isActive && 'text-primary')} aria-hidden="true" />
               <span>{item.title}</span>
             </Link>
           );

--- a/packages/web/src/components/layout/main-layout.tsx
+++ b/packages/web/src/components/layout/main-layout.tsx
@@ -35,6 +35,8 @@ function MainContent({
 }) {
   return (
     <main
+      id="main-content"
+      tabIndex={-1}
       className={cn(
         'flex-1 min-w-0 transition-[margin-left] duration-200',
         showSidebar && (collapsed ? 'md:ml-16' : 'md:ml-60'),
@@ -80,6 +82,9 @@ export function MainLayout({
 
   return (
     <div className="min-h-screen flex flex-col overflow-x-hidden">
+      <a href="#main-content" className="skip-to-content">
+        본문으로 바로가기
+      </a>
       <Header user={user} isAdmin={isAdmin} onLogout={handleLogout} />
       {!isAdmin && <NoticeBanner />}
       <PullToRefresh>

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -71,6 +71,7 @@ function NavLink({ item, isActive, collapsed }: NavLinkProps) {
     <Link
       href={item.href}
       title={collapsed ? item.title : undefined}
+      aria-current={isActive ? 'page' : undefined}
       className={cn(
         // Base layout
         'group relative flex items-center gap-3 rounded-md px-3 py-2.5 text-[15px] font-medium',
@@ -102,6 +103,7 @@ function NavLink({ item, isActive, collapsed }: NavLinkProps) {
             : 'text-zinc-400 dark:text-zinc-500 group-hover:text-zinc-700 dark:group-hover:text-zinc-300',
           'transition-colors duration-200'
         )}
+        aria-hidden="true"
       />
       {!collapsed && <span className="truncate leading-none">{item.title}</span>}
     </Link>


### PR DESCRIPTION
## 🎯 Summary
> Web Interface Accessibility Audit P2 이슈 수정

`docs/26-03-11-web-accessibility-audit.md` 문서의 P2 이슈를 수정하여 웹 접근성을 개선합니다.

---

## 🔴 AS-IS
> 기존 상태 또는 문제점

- **Skip-to-Content Link 없음**: 키보드/스크린 리더 사용자가 상단 내비게이션을 건너뛰고 본문으로 바로 이동할 수 없음
- **Landmark Region 부족**: 시맨틱 구조가 명확하지 않아 스크린 리더가 문서 구조를 파악하기 어려움
- **ARIA Label 부족**: 활성 링크, 페이지네이션 등 현재 상태를 나타내는 label이 부족
- **Decorative 요소 노출**: 장식용 요소가 스크린 리더에 불필요하게 읽힘

---

## 🟢 TO-BE
> 변경 후 상태 또는 개선점

### 1. Skip-to-Content Link 추가
- globals.css에 `.skip-to-content` 스타일 추가 (탭 포커스 시에만 표시)
- MainLayout과 랜딩 페이지에 "본문으로 바로가기" 링크 추가
- main 요소에 `id="main-content"`와 `tabIndex={-1}` 추가

### 2. Landmark Region 개선
- 게시판 필터 섹션: `<section aria-label="게시판 필터 및 글쓰기">`
- 공지사항 섹션: `<section aria-labelledby="pinned-notice-title">`
- 게시글 목록: `<section aria-labelledby="posts-title">`
- 페이지네이션: `<nav aria-label="게시글 페이지네이션">`

### 3. 구체적인 ARIA Label 추가
- **내비게이션**: 활성 링크에 `aria-current="page"` 추가
- **페이지네이션**: `1 페이지`, `2 페이지 (현재 페이지)` 등 구체적 label
- **외부 링크**: GitHub 링크에 `(새 탭에서 열림)` 표시
- **아이콘**: 모든 decorative 아이콘에 `aria-hidden="true"` 추가

### 4. Decorative 요소 처리
- 랜딩 페이지: glow background, grid pattern, 아바타 이미지에 `aria-hidden="true"` 추가
- 게시판: Pin, PenSquare 등 아이콘에 `aria-hidden="true"` 추가

---

## 💬 참고사항
> 리뷰어가 알아야 할 내용, 논의 포인트, 주의사항 등

- **적용 범위**: P2 이슈 중 공통 레이아웃과 자주 사용하는 페이지 위주로 수정
- **P0/P1 이슈**: 해당 PR에는 포함되지 않음 (별도 작업 필요)
- **테스트 방법**:
  - Tab 키로 탐색 시 "본문으로 바로가기" 링크가 첫 번째로 포커스되는지 확인
  - 스크린 리더(NVDA/VoiceOver)로 landmark 탐색 시 섹션이 제대로 인식되는지 확인
- **관련 문서**: `docs/26-03-11-web-accessibility-audit.md`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)