### PR TITLE
fix(web): Firebase SW API 키 하드코딩 제거

### DIFF
--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -29,6 +29,15 @@ const nextConfig: NextConfig = {
     },
   },
 
+  async rewrites() {
+    return [
+      {
+        source: '/firebase-messaging-sw.js',
+        destination: '/api/firebase-sw',
+      },
+    ];
+  },
+
   async headers() {
     return [
       {

--- a/packages/web/src/app/api/firebase-sw/route.ts
+++ b/packages/web/src/app/api/firebase-sw/route.ts
@@ -1,15 +1,16 @@
-// Firebase Cloud Messaging Service Worker
-// Firebase client API key는 설계상 공개 식별자입니다 (Security Rules + 도메인 제한으로 보호).
-// https://firebase.google.com/docs/projects/api-keys#api-keys-for-firebase-are-different
+import { NextResponse } from 'next/server';
 
 const firebaseConfig = {
-  apiKey: "AIzaSyB66yQiuAXxbLbWz_Cf5unRLuNvESo5sYM",
-  authDomain: "kusting-159f4.firebaseapp.com",
-  projectId: "kusting-159f4",
-  storageBucket: "kusting-159f4.firebasestorage.app",
-  messagingSenderId: "816173354609",
-  appId: "1:816173354609:web:a127a7308cd35cbbaf95d0",
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY ?? '',
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN ?? '',
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ?? '',
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ?? '',
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID ?? '',
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID ?? '',
 };
+
+const swScript = `// Firebase Cloud Messaging Service Worker (auto-generated)
+const firebaseConfig = ${JSON.stringify(firebaseConfig)};
 
 self.addEventListener('push', (event) => {
   const payload = event.data?.json();
@@ -52,3 +53,14 @@ self.addEventListener('notificationclick', (event) => {
     })
   );
 });
+`;
+
+export function GET() {
+  return new NextResponse(swScript, {
+    headers: {
+      'Content-Type': 'application/javascript',
+      'Service-Worker-Allowed': '/',
+      'Cache-Control': 'public, max-age=0, must-revalidate',
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- GitHub Secret Scanning에서 탐지된 Firebase API 키 하드코딩 이슈 해결
- `public/firebase-messaging-sw.js`의 하드코딩된 키를 환경변수 동적 주입으로 전환

## Changes
| 파일 | 변경 내용 |
|------|-----------|
| `packages/web/public/firebase-messaging-sw.js` | 삭제 (하드코딩된 API 키 포함) |
| `packages/web/src/app/api/firebase-sw/route.ts` | 신규 — `NEXT_PUBLIC_FIREBASE_*` 환경변수로 SW 코드 동적 생성 |
| `packages/web/next.config.ts` | rewrite 추가 (`/firebase-messaging-sw.js` → `/api/firebase-sw`) |

## Design Decisions
| 결정 | 이유 |
|------|------|
| API route로 SW 서빙 | 빌드 스크립트 불필요, Next.js 생태계 권장 패턴 |
| rewrite로 기존 경로 유지 | `client.ts`의 SW 등록 코드 변경 불필요 |
| `Service-Worker-Allowed: /` 헤더 | API route 경로에서도 루트 스코프 SW 등록 보장 |

## Test Plan
- [ ] 로컬에서 푸시 알림 정상 수신 확인
- [ ] `/firebase-messaging-sw.js` 접근 시 SW 코드 정상 응답 확인
- [ ] Vercel 배포 후 환경변수 주입 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)