### PR TITLE
fix(web): Firebase SW 환경변수 런타임 주입

### DIFF
--- a/packages/web/src/app/api/firebase-sw/route.ts
+++ b/packages/web/src/app/api/firebase-sw/route.ts
@@ -1,15 +1,18 @@
 import { NextResponse } from 'next/server';
 
-const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY ?? '',
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN ?? '',
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ?? '',
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ?? '',
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID ?? '',
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID ?? '',
-};
+export const dynamic = 'force-dynamic';
 
-const swScript = `// Firebase Cloud Messaging Service Worker (auto-generated)
+export function GET() {
+  const firebaseConfig = {
+    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY ?? '',
+    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN ?? '',
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ?? '',
+    storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ?? '',
+    messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID ?? '',
+    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID ?? '',
+  };
+
+  const swScript = `// Firebase Cloud Messaging Service Worker (auto-generated)
 const firebaseConfig = ${JSON.stringify(firebaseConfig)};
 
 self.addEventListener('push', (event) => {
@@ -55,7 +58,6 @@ self.addEventListener('notificationclick', (event) => {
 });
 `;
 
-export function GET() {
   return new NextResponse(swScript, {
     headers: {
       'Content-Type': 'application/javascript',


### PR DESCRIPTION
## Summary
- 빌드 타임에 환경변수가 빈 문자열로 고정되는 문제 수정
- `force-dynamic` + GET 핸들러 내부에서 환경변수를 읽도록 변경

## Changes
| 파일 | 변경 내용 |
|------|-----------|
| `packages/web/src/app/api/firebase-sw/route.ts` | `firebaseConfig`를 GET 핸들러 안으로 이동 + `force-dynamic` 추가 |

## Design Decisions
| 결정 | 이유 |
|------|------|
| `force-dynamic` export | Next.js가 route를 정적 빌드하지 않도록 보장 |
| GET 핸들러 내부에서 env 읽기 | 요청 시점에 런타임 환경변수 참조 (빌드 타임 고정 방지) |

## Test Plan
- [ ] Vercel 배포 후 `/firebase-messaging-sw.js` 응답에 apiKey 정상 포함 확인
- [ ] 푸시 알림 정상 수신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)