### PR TITLE
fix(web): 푸시 알림 after() 전환 + SW 정리 + 알림 로직 개선

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,8 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 - **API 응답**: 모든 API 라우트는 `Errors.*()` + `successResponse()` + `errorResponse()` 패턴 사용 (직접 `NextResponse.json` 금지)
 - **캐시**: 읽기 전용 API에 `withCache(response, maxAge)` 적용 (members: 60s, ranking: 30s)
 - **보안**: Tiptap content는 저장 전 `sanitizeTiptapContent()` 적용, 외부 URL fetch 시 `isSafeUrl()` SSRF 체크
+- **백그라운드 작업**: API route에서 푸시 알림/점수 부여 등 fire-and-forget 작업은 `after()` from `next/server` 사용 (Vercel 서버리스 종료 방지)
+- **비밀댓글 알림**: 비밀댓글(`isSecret`)의 푸시 알림은 내용 마스킹 (`'비밀 댓글이 달렸습니다.'`)
 
 ## 핵심 파일 위치
 
@@ -111,7 +113,7 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 | `packages/web/src/components/settings/push-notification-settings.tsx` | 알림 설정 UI (타입별 토글 + 테스트 전송) |
 | `packages/web/src/app/api/push/test/route.ts` | 테스트 푸시 알림 API (레이트 리밋 5/min) |
 | `packages/web/src/app/api/notification-preferences/route.ts` | 알림 타입별 설정 CRUD API |
-| `packages/web/public/firebase-messaging-sw.js` | FCM 서비스 워커 (백그라운드 알림 수신) |
+| `packages/web/src/app/api/firebase-sw/route.ts` | FCM 서비스 워커 동적 서빙 (rewrite: `/firebase-messaging-sw.js` → `/api/firebase-sw`) |
 | `packages/bot/src/scripts/rss-collect.ts` | 수동 RSS 수집 스크립트 (봇 없이 독립 실행) |
 | `packages/bot/src/scripts/setup-channels.ts` | 디스코드 채널 일괄 생성 스크립트 |
 | `packages/bot/src/scripts/list-channels.ts` | 서버 채널 구조 조회 스크립트 |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -437,7 +437,7 @@ erDiagram
 - **Dialog/AlertDialog**: Safari PWA 스크롤 대응 — `flex flex-col` + `inset-y-0 my-auto` 센터링 + `overflow-y-auto` (grid/transform 방식은 Safari에서 클리핑 발생)
 - **Pull-to-Refresh**: 커스텀 터치 제스처 기반 새로고침 (`PullToRefresh` + `usePullToRefresh`), Safari PWA 최적화, 다이얼로그 열림 시 `data-scroll-locked` 가드로 비활성화
 - **PWA**: `manifest.json` + 커스텀 로고 아이콘 (SVG/192/512, maskable) → 홈 화면 추가 지원
-- **FCM 푸시**: Firebase Cloud Messaging 서비스 워커 (`firebase-messaging-sw.js`) → 백그라운드 알림. 타입별(댓글/답글/공지) 개별 설정, 테스트 알림 전송 지원
+- **FCM 푸시**: Firebase Cloud Messaging 서비스 워커 (API route `/api/firebase-sw` → rewrite `/firebase-messaging-sw.js`) → 백그라운드 알림. 타입별(댓글/답글/공지) 개별 설정, 테스트 알림 전송 지원. 푸시/점수 등 백그라운드 작업은 `after()` from `next/server` 사용
 
 ## 스케줄러 (pg-boss)
 

--- a/packages/web/src/app/api/board/[id]/comments/route.ts
+++ b/packages/web/src/app/api/board/[id]/comments/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, after } from 'next/server';
 import { and, eq, isNull, sql } from 'drizzle-orm';
 import { getDb } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
@@ -88,22 +88,39 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
 
     // 게시판 댓글 활동 점수 (+2, 일일 상한 10) — 본인 글 제외
     if (post.memberId !== auth.memberId) {
-      grantWebScore(
-        auth.memberId,
-        ActivityScoreType.BOARD_COMMENT,
-        sanitizeDescription(content.trim().slice(0, 50))
-      ).catch((err) => console.error('[score] grantWebScore failed:', err));
+      after(async () => {
+        try {
+          await grantWebScore(
+            auth.memberId,
+            ActivityScoreType.BOARD_COMMENT,
+            sanitizeDescription(content.trim().slice(0, 50))
+          );
+        } catch (err) {
+          console.error('[score] grantWebScore failed:', err);
+        }
+      });
     }
 
-    // 1. 내가 쓴 글에 댓글이 달리면 무조건 알림 (본인 제외)
-    if (post.memberId !== auth.memberId) {
-      const postIdentifier = postId;
-      sendPushToMember(post.memberId, {
-        title: '새 댓글이 달렸습니다',
-        body: `${content.trim().slice(0, 50)}${content.length > 50 ? '...' : ''}`,
-        clickUrl: `/board/${postIdentifier}`,
-        data: { type: 'board_comment', postId: postIdentifier, commentId: newComment.id },
-      }).catch((err) => console.error('[push] Comment notification failed:', err));
+    // 비밀댓글은 알림 내용 마스킹
+    const notificationBody = (isSecret || false)
+      ? '비밀 댓글이 달렸습니다.'
+      : `${content.trim().slice(0, 50)}${content.length > 50 ? '...' : ''}`;
+
+    // 1. 내가 쓴 글에 댓글이 달리면 알림 (본인 제외, 답글 대상자와 중복 시 생략)
+    const isReplyToPostAuthor = parentId && parent && parent.memberId === post.memberId;
+    if (post.memberId !== auth.memberId && !isReplyToPostAuthor) {
+      after(async () => {
+        try {
+          await sendPushToMember(post.memberId, {
+            title: '새 댓글이 달렸습니다',
+            body: notificationBody,
+            clickUrl: `/board/${postId}`,
+            data: { type: 'board_comment', postId, commentId: newComment.id },
+          });
+        } catch (err) {
+          console.error('[push] Comment notification failed:', err);
+        }
+      });
     }
 
     // 2. 대댓글의 경우 원댓글 작성자에게도 알림
@@ -113,13 +130,18 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
 
       // 내 댓글에 답글이 달리면 알림 (작성자 본인 제외)
       if (pmid !== amid) {
-        const postIdentifier = postId;
-        sendPushToMember(pmid, {
-          title: '💬 답글이 달렸습니다',
-          body: `${content.trim().slice(0, 50)}${content.length > 50 ? '...' : ''}`,
-          clickUrl: `/board/${postIdentifier}`,
-          data: { type: 'board_reply', postId: postIdentifier, commentId: newComment.id },
-        }).catch((err) => console.error('[push] Reply notification failed:', err));
+        after(async () => {
+          try {
+            await sendPushToMember(pmid, {
+              title: '💬 답글이 달렸습니다',
+              body: notificationBody,
+              clickUrl: `/board/${postId}`,
+              data: { type: 'board_reply', postId, commentId: newComment.id },
+            });
+          } catch (err) {
+            console.error('[push] Reply notification failed:', err);
+          }
+        });
       }
     }
 

--- a/packages/web/src/app/api/board/route.ts
+++ b/packages/web/src/app/api/board/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, after } from 'next/server';
 import { and, count, desc, eq, isNull } from 'drizzle-orm';
 import { getDb } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
@@ -252,11 +252,17 @@ export async function POST(request: NextRequest) {
     });
 
     // 게시판 글 작성 활동 점수 (+10, 일일 상한 20)
-    grantWebScore(
-      auth.memberId,
-      ActivityScoreType.BOARD_POST,
-      sanitizeDescription(title.trim().slice(0, 50))
-    ).catch((err) => console.error('[score] grantWebScore failed:', err));
+    after(async () => {
+      try {
+        await grantWebScore(
+          auth.memberId,
+          ActivityScoreType.BOARD_POST,
+          sanitizeDescription(title.trim().slice(0, 50))
+        );
+      } catch (err) {
+        console.error('[score] grantWebScore failed:', err);
+      }
+    });
 
     // 공지사항인 경우 활성 멤버 전체에게 알림
     if (category === 'notice') {
@@ -265,15 +271,19 @@ export async function POST(request: NextRequest) {
         .from(members)
         .where(eq(members.status, MemberStatus.ACTIVE));
 
-      sendPushToMembers(
-        activeMembers.map((m) => m.id),
-        {
-          title: '📢 새 공지사항',
-          body: title.trim(),
-          clickUrl: `/board/${result.id}`,
-          data: { type: 'board_notice', postId: result.id },
+      const memberIds = activeMembers.map((m) => m.id).filter((id) => id !== auth.memberId);
+      after(async () => {
+        try {
+          await sendPushToMembers(memberIds, {
+            title: '📢 새 공지사항',
+            body: title.trim(),
+            clickUrl: `/board/${result.id}`,
+            data: { type: 'board_notice', postId: result.id },
+          });
+        } catch (err) {
+          console.error('[push] Notice notification failed:', err);
         }
-      ).catch((err) => console.error('[push] Notice notification failed:', err));
+      });
     }
 
     return successResponse(result, '게시글이 작성되었습니다.', 201);

--- a/packages/web/src/app/api/firebase-sw/route.ts
+++ b/packages/web/src/app/api/firebase-sw/route.ts
@@ -1,19 +1,6 @@
 import { NextResponse } from 'next/server';
 
-export const dynamic = 'force-dynamic';
-
-export function GET() {
-  const firebaseConfig = {
-    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY ?? '',
-    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN ?? '',
-    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ?? '',
-    storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ?? '',
-    messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID ?? '',
-    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID ?? '',
-  };
-
-  const swScript = `// Firebase Cloud Messaging Service Worker (auto-generated)
-const firebaseConfig = ${JSON.stringify(firebaseConfig)};
+const swScript = `// Firebase Cloud Messaging Service Worker (auto-generated)
 
 self.addEventListener('push', (event) => {
   const payload = event.data?.json();
@@ -58,11 +45,12 @@ self.addEventListener('notificationclick', (event) => {
 });
 `;
 
+export function GET() {
   return new NextResponse(swScript, {
     headers: {
       'Content-Type': 'application/javascript',
       'Service-Worker-Allowed': '/',
-      'Cache-Control': 'public, max-age=0, must-revalidate',
+      'Cache-Control': 'public, max-age=86400, immutable',
     },
   });
 }

--- a/packages/web/src/app/api/posts/[id]/comments/route.ts
+++ b/packages/web/src/app/api/posts/[id]/comments/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, after } from 'next/server';
 import { and, asc, eq, isNull, sql } from 'drizzle-orm';
 import { getDb } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
@@ -158,22 +158,35 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
 
       // 방금 작성한 댓글 포함해서 1개뿐이면 = 첫 댓글 → 점수 부여
       if (priorComments.length <= 1) {
-        grantWebScore(
-          auth.memberId,
-          ActivityScoreType.POST_COMMENT,
-          sanitizeDescription(content.trim().slice(0, 50))
-        ).catch((err) => console.error('[score] grantWebScore failed:', err));
+        after(async () => {
+          try {
+            await grantWebScore(
+              auth.memberId,
+              ActivityScoreType.POST_COMMENT,
+              sanitizeDescription(content.trim().slice(0, 50))
+            );
+          } catch (err) {
+            console.error('[score] grantWebScore failed:', err);
+          }
+        });
       }
     }
 
-    // 1. 내가 쓴 포스트에 댓글이 달리면 무조건 알림 (본인 제외)
-    if (post.memberId !== auth.memberId) {
-      sendPushToMember(post.memberId, {
-        title: '새 댓글이 달렸습니다',
-        body: `${content.trim().slice(0, 50)}${content.length > 50 ? '...' : ''}`,
-        clickUrl: `/posts/${postId}`,
-        data: { type: 'post_comment', postId, commentId: newComment?.id ?? '' },
-      }).catch((err) => console.error('[push] Post comment notification failed:', err));
+    // 1. 내가 쓴 포스트에 댓글이 달리면 알림 (본인 제외, 답글 대상자와 중복 시 생략)
+    const isReplyToPostAuthor = parentId && parent && parent.memberId === post.memberId;
+    if (post.memberId !== auth.memberId && !isReplyToPostAuthor) {
+      after(async () => {
+        try {
+          await sendPushToMember(post.memberId, {
+            title: '새 댓글이 달렸습니다',
+            body: `${content.trim().slice(0, 50)}${content.length > 50 ? '...' : ''}`,
+            clickUrl: `/posts/${postId}`,
+            data: { type: 'post_comment', postId, commentId: newComment?.id ?? '' },
+          });
+        } catch (err) {
+          console.error('[push] Post comment notification failed:', err);
+        }
+      });
     }
 
     // 2. 대댓글의 경우 원댓글 작성자에게도 알림
@@ -183,12 +196,18 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
 
       // 내 댓글에 답글이 달리면 알림 (작성자 본인 제외)
       if (pmid !== amid) {
-        sendPushToMember(pmid, {
-          title: '💬 답글이 달렸습니다',
-          body: `${content.trim().slice(0, 50)}${content.length > 50 ? '...' : ''}`,
-          clickUrl: `/posts/${postId}`,
-          data: { type: 'post_reply', postId, commentId: newComment?.id ?? '' },
-        }).catch((err) => console.error('[push] Post reply notification failed:', err));
+        after(async () => {
+          try {
+            await sendPushToMember(pmid, {
+              title: '💬 답글이 달렸습니다',
+              body: `${content.trim().slice(0, 50)}${content.length > 50 ? '...' : ''}`,
+              clickUrl: `/posts/${postId}`,
+              data: { type: 'post_reply', postId, commentId: newComment?.id ?? '' },
+            });
+          } catch (err) {
+            console.error('[push] Post reply notification failed:', err);
+          }
+        });
       }
     }
 


### PR DESCRIPTION
## Summary
- Vercel 서버리스에서 fire-and-forget 비동기 작업이 잘리는 문제 해결
- Firebase SW 정리 및 푸시 알림 로직 개선

## Changes
| 파일 | 변경 내용 |
|------|-----------|
| `api/posts/[id]/comments/route.ts` | `sendPushToMember`, `grantWebScore` → `after()` 전환, 중복 알림 방지 |
| `api/board/[id]/comments/route.ts` | 동일 + 비밀댓글 푸시 내용 마스킹 |
| `api/board/route.ts` | `sendPushToMembers`, `grantWebScore` → `after()` 전환, 공지 알림 본인 제외 |
| `api/firebase-sw/route.ts` | 미사용 firebaseConfig 제거, 정적 스크립트로 단순화, `force-dynamic` 제거 |
| `CLAUDE.md` | `after()` 패턴, 비밀댓글 알림 규칙, SW 파일 경로 업데이트 |
| `docs/ARCHITECTURE.md` | FCM 푸시 아키텍처 설명 업데이트 |

## Design Decisions
| 결정 | 이유 |
|------|------|
| `after()` from `next/server` | Vercel 서버리스에서 응답 후 백그라운드 작업 보장 (waitUntil 기반) |
| SW에서 firebaseConfig 제거 | native Push API만 사용, Firebase SDK 미임포트 → dead code |
| 답글 중복 알림 방지 | post author = parent author일 때 "새 댓글" + "답글" 이중 발송 방지 |
| 비밀댓글 마스킹 | 잠금화면 알림에서 비밀댓글 내용 노출 방지 |

## Test Plan
- [ ] 다른 유저가 내 포스트에 댓글 → 푸시 알림 수신 확인
- [ ] 내 댓글에 답글 → 답글 알림만 수신 (중복 없음)
- [ ] 비밀댓글 → 푸시 알림에 내용 마스킹 확인
- [ ] 공지사항 작성 → 작성자 본인에게 알림 안 감
- [ ] 활동 점수 정상 부여 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)