### PR TITLE
feat: QA3 — 포스트 비밀댓글 + 대시보드 출석 칩 + 랜딩 리뉴얼 + UX 개선

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,11 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 - **토스트**: `sonner` 라이브러리 사용 (`toast.success()`, `toast.error()`) — inline 상태 관리 토스트 금지
 - **API 응답**: 모든 API 라우트는 `Errors.*()` + `successResponse()` + `errorResponse()` 패턴 사용 (직접 `NextResponse.json` 금지)
 - **캐시**: 읽기 전용 API에 `withCache(response, maxAge)` 적용 (members: 60s, ranking: 30s)
-- **보안**: Tiptap content는 저장 전 `sanitizeTiptapContent()` 적용, 외부 URL fetch 시 `isSafeUrl()` SSRF 체크
+- **보안**: Tiptap content는 저장 전 `sanitizeTiptapContent()` 적용, 댓글 content는 `sanitizeDescription()` 적용, 외부 URL fetch 시 `isSafeUrl()` SSRF 체크
+- **댓글 길이**: 최대 5000자 제한 (API에서 검증)
 - **백그라운드 작업**: API route에서 푸시 알림/점수 부여 등 fire-and-forget 작업은 `after()` from `next/server` 사용 (Vercel 서버리스 종료 방지)
-- **비밀댓글 알림**: 비밀댓글(`isSecret`)의 푸시 알림은 내용 마스킹 (`'비밀 댓글이 달렸습니다.'`)
+- **비밀댓글 알림**: 비밀댓글(`isSecret`)의 푸시 알림은 내용 마스킹 (`'비밀 댓글이 달렸습니다.'`), 포스트/게시판 댓글 모두 적용
+- **비밀댓글 isSecret 토글**: PATCH 시 본인만 변경 가능 (관리자도 타인 비밀 상태 변경 불가)
 
 ## 핵심 파일 위치
 

--- a/README.md
+++ b/README.md
@@ -1,62 +1,116 @@
-# Study Admin
+# 큐스팅 4th · 블로그 글쓰기 스터디
 
-블로그 스터디 운영 자동화 플랫폼. Discord 봇 + 웹 대시보드.
+2주에 한 편, 블로그 글을 쓰며 함께 성장하는 스터디 플랫폼.
+웹 대시보드 + Discord 봇으로 스터디 운영을 자동화합니다.
 
-## 구조
+## 아키텍처
 
-```
-packages/
-  bot/      Discord 봇 (discord.js, pg-boss, Railway 배포)
-  web/      Next.js 대시보드 (Vercel 배포)
-  shared/   DB 스키마, 타입, 유틸리티 (Drizzle ORM)
+```mermaid
+graph TB
+    subgraph Client["사용자"]
+        BROWSER["브라우저 / PWA"]
+    end
+
+    subgraph Web["Web · Vercel"]
+        NEXT["Next.js 16<br/>App Router"]
+        API["API Routes"]
+        FCM_WEB["FCM Push"]
+    end
+
+    subgraph Bot["Bot · AWS EC2"]
+        DISCORD_BOT["discord.js v14"]
+        SCHEDULER["pg-boss<br/>스케줄러"]
+        BOT_API["Express API<br/>수동 트리거"]
+    end
+
+    subgraph Infra["인프라"]
+        SUPABASE["Supabase<br/>PostgreSQL + Auth"]
+        FIREBASE["Firebase<br/>Cloud Messaging"]
+        SENTRY["Sentry<br/>Error Tracking"]
+        DISCORD["Discord Server"]
+    end
+
+    BROWSER --> NEXT
+    NEXT --> API
+    API --> SUPABASE
+    FCM_WEB --> FIREBASE
+    FIREBASE -->|push| BROWSER
+
+    DISCORD_BOT <-->|WebSocket| DISCORD
+    SCHEDULER --> SUPABASE
+    API -->|트리거| BOT_API
+    BOT_API --> SCHEDULER
+
+    NEXT --> SENTRY
+    DISCORD_BOT --> SENTRY
 ```
 
 ## 기술 스택
 
 | 영역 | 기술 |
 |------|------|
-| Frontend | Next.js 16, React 19, Tailwind CSS v4, shadcn/ui |
-| Backend | Next.js API Routes, Supabase |
-| Bot | discord.js v14, pg-boss |
-| DB | PostgreSQL (Supabase), Drizzle ORM |
-| Deploy | Vercel (Web), AWS EC2 (Bot), Supabase (DB) |
+| Frontend | Next.js 16, React 19, Tailwind CSS v4, shadcn/ui, Framer Motion |
+| Backend | Next.js API Routes, Supabase Auth (Discord OAuth) |
+| Bot | discord.js v14, pg-boss (Job Queue), feedsmith (RSS) |
+| Editor | Tiptap (리치 에디터), sonner (토스트) |
+| DB | PostgreSQL (Supabase) + Drizzle ORM |
+| Push | Firebase Cloud Messaging (FCM) |
+| Monitor | Sentry (에러 모니터링 + PII 스크러빙) |
+| Deploy | Vercel (Web), AWS EC2 Docker (Bot), Supabase (DB) |
+| CI/CD | GitHub Actions → ECR → SSH deploy (Bot), Vercel Git (Web) |
+
+## 프로젝트 구조
+
+```
+packages/
+├── shared/   # DB 스키마, 타입, 유틸 (Drizzle ORM)
+├── bot/      # Discord 봇 (스케줄러 + 이벤트 핸들러)
+└── web/      # Next.js 대시보드 (사용자 + 관리자)
+```
+
+**모노레포**: pnpm workspace
 
 ## 주요 기능
 
-- **RSS 자동 수집** — 블로그 글 발행 감지 및 수집
+### 사용자
+- **대시보드** — 현재 회차, 출석 상태, 활동 점수, 최근 포스트
+- **포스트 피드** — 스터디원 블로그 글 모아보기, 댓글/비밀댓글, 조회수
+- **랭킹** — 활동 기반 실시간 랭킹
+- **커뮤니티 게시판** — 공지/건의/후기/지식공유/일상, 댓글/비밀댓글/투표
+- **프로필** — 활동 내역, 알림 설정, 소셜 링크
+- **PWA 푸시 알림** — 댓글/답글/공지 알림
+
+### 자동화 (봇)
+- **RSS 자동 수집** — 블로그 글 발행 시 자동 감지 및 수집
 - **출석 자동화** — 2주 1회차, 지각/결석 자동 판정
-- **벌금 관리** — 자동 부과, DM 알림, 납부 확인
-- **활동 점수 & 랭킹** — 포스트 수, 출석률, 활동 기반 실시간 랭킹
-- **큐레이션** — 태그 + 관심 키워드 기반 컨퍼런스/아티클 추천
-- **커뮤니티 게시판** — 공지/일반/자유 게시글 + 댓글
+- **벌금 관리** — 자동 부과, DM 리마인드
+- **주간 랭킹** — 매주 활동 점수 랭킹 디스코드 공유
 
 ## 시작하기
 
 ```bash
-# 의존성 설치
-pnpm install
-
-# 웹 개발 서버
-pnpm dev:web
-
-# 봇 개발 서버
-pnpm dev:bot
-
-# 전체 빌드
-pnpm build
-
-# 타입 체크
-pnpm typecheck
+pnpm install        # 의존성 설치
+pnpm dev:web        # 웹 개발 서버 (localhost:3300)
+pnpm dev:bot        # 봇 개발 서버
+pnpm build          # 전체 빌드
+pnpm typecheck      # 타입 체크
+pnpm lint           # 린트
 ```
 
 ## 환경 변수
 
-`.env.example` 참조.
+`.env.example` 참조. 두 곳에 설정 필요:
+- `.env.local` — 루트 (shared/bot용)
+- `packages/web/.env.local` — Next.js용
 
 ## 문서
 
-- [아키텍처](docs/ARCHITECTURE.md)
-- [기술 결정](docs/26-03-06-tech-decisions.md)
-- [UI 디자인 시스템](docs/26-03-06-ui-design-system.md)
-- [개발 환경](docs/26-03-06-development.md)
-- [구현 체크리스트](docs/26-03-06-checklist.md)
+| 문서 | 설명 |
+|------|------|
+| [ARCHITECTURE.md](docs/ARCHITECTURE.md) | 시스템 아키텍처 (Mermaid 다이어그램) |
+| [기술 결정](docs/26-03-06-tech-decisions.md) | 기술 선택 근거 (ADR) |
+| [UI 디자인 시스템](docs/26-03-06-ui-design-system.md) | UI 스펙 |
+| [개발 환경](docs/26-03-06-development.md) | 개발 환경 설정 |
+| [DB 스키마](docs/26-03-06-schema-summary.md) | 테이블/Enum/FK 요약 |
+| [API 패턴](docs/26-03-06-patterns.md) | API 코드 규칙 |
+| [온보딩](docs/ONBOARDING.md) | 팀 온보딩 가이드 |

--- a/docs/26-03-06-schema-summary.md
+++ b/docs/26-03-06-schema-summary.md
@@ -101,6 +101,19 @@
 | `post_id` | uuid FK → posts | not null |
 | unique constraint: `(member_id, post_id)` |
 
+### post_comments
+| 컬럼 | 타입 | 비고 |
+|------|------|------|
+| `id` | uuid PK | defaultRandom |
+| `post_id` | uuid FK → posts | not null |
+| `member_id` | uuid FK → members | not null |
+| `parent_id` | uuid | nullable (대댓글) |
+| `content` | text | not null |
+| `is_secret` | boolean | default false |
+| `created_at`, `updated_at` | timestamptz | defaultNow |
+| `deleted_at` | timestamptz | nullable (soft delete) |
+| 인덱스: `post_id`, `member_id`, `parent_id` |
+
 ### config
 `key` (varchar PK) / `value` (text) / `updated_at` — 설정 키-값 저장소
 
@@ -172,7 +185,9 @@ members ──< post_views (member_id)
 rounds  ──< posts (round_id)
 rounds  ──< attendance (round_id)
 rounds  ──< fines (round_id)
+posts   ──< post_comments (post_id)
 posts   ──< post_views (post_id)
+members ──< post_comments (member_id)
 curation_sources ──< curation_items (source_id)
 members ──< board_posts (member_id)
 members ──< board_comments (member_id)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ graph TB
 
     subgraph DB["Supabase · PostgreSQL"]
         AUTH["Supabase Auth<br/>Discord OAuth"]
-        TABLES["members · posts · rounds<br/>attendance · fines · config<br/>keywords · curation · activity_scores<br/>post_views · board_posts · board_comments<br/>fcm_tokens · notification_preferences"]
+        TABLES["members · posts · rounds<br/>attendance · fines · config<br/>keywords · curation · activity_scores<br/>post_views · post_comments · board_posts<br/>board_comments · fcm_tokens · notification_preferences"]
         PGBOSS["pg-boss<br/>Job Queue"]
     end
 
@@ -297,6 +297,7 @@ erDiagram
     members ||--o{ fines : "벌금"
     members ||--o{ activity_scores : "활동점수"
     members ||--o{ post_views : "조회"
+    members ||--o{ post_comments : "포스트댓글"
     members ||--o{ board_posts : "게시글"
     members ||--o{ board_comments : "댓글"
     members ||--o{ fcm_tokens : "FCM토큰"
@@ -304,6 +305,7 @@ erDiagram
     rounds ||--o{ posts : "회차"
     rounds ||--o{ attendance : "회차"
     rounds ||--o{ fines : "회차"
+    posts ||--o{ post_comments : "포스트댓글"
     posts ||--o{ post_views : "조회기록"
     curation_sources ||--o{ curation_items : "수집"
     board_posts ||--o{ board_comments : "댓글"
@@ -367,6 +369,15 @@ erDiagram
         uuid id PK
         uuid member_id FK
         uuid post_id FK
+    }
+
+    post_comments {
+        uuid id PK
+        uuid post_id FK
+        uuid member_id FK
+        uuid parent_id FK
+        text content
+        boolean is_secret
     }
 
     board_posts {

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -334,6 +334,7 @@ export const postComments = pgTable(
       .references(() => members.id),
     parentId: uuid('parent_id'),
     content: text('content').notNull(),
+    isSecret: boolean('is_secret').default(false),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
     deletedAt: timestamp('deleted_at', { withTimezone: true }),
@@ -430,10 +431,7 @@ export const PollType = {
 
 export type PollTypeType = (typeof PollType)[keyof typeof PollType];
 
-export const pollTypeEnum = pgEnum('poll_type', [
-  'text',
-  'date',
-]);
+export const pollTypeEnum = pgEnum('poll_type', ['text', 'date']);
 
 export const boardPolls = pgTable(
   'board_polls',
@@ -698,10 +696,7 @@ export const boardPollsRelations = relations(boardPolls, ({ one, many }) => ({
   votes: many(boardPollVotes),
 }));
 
-export const boardPollOptionsRelations = relations(boardPollOptions, ({
-  one,
-  many,
-}) => ({
+export const boardPollOptionsRelations = relations(boardPollOptions, ({ one, many }) => ({
   poll: one(boardPolls, {
     fields: [boardPollOptions.pollId],
     references: [boardPolls.id],

--- a/packages/web/src/app/(admin)/admin/scores/page.tsx
+++ b/packages/web/src/app/(admin)/admin/scores/page.tsx
@@ -28,8 +28,9 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { PageError, AdminScoresSkeleton } from '@/components/ui/page-state';
+import { AdminScoresSkeleton, PageError } from '@/components/ui/page-state';
 import { cn } from '@/lib/utils';
+import { getScoreTypeBadgeClass, getScoreTypeLabel } from '@/lib/score-config';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -62,8 +63,6 @@ interface MemberScoreSummary {
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
-
-import { getScoreTypeLabel, getScoreTypeBadgeClass } from '@/lib/score-config';
 
 const TOP_MEMBERS_COUNT = 5;
 
@@ -181,7 +180,6 @@ function MemberSelector({
             <div className="relative">
               <Search className="absolute left-2.5 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
               <Input
-                autoFocus
                 placeholder="이름, 닉네임, 파트 검색..."
                 className="pl-8 h-8 text-sm"
                 value={searchQuery}
@@ -903,9 +901,7 @@ export default function AdminScoresPage() {
               </div>
               <div>
                 <h2 className="text-lg font-semibold">점수 내역 삭제</h2>
-                <p className="text-sm text-muted-foreground">
-                  이 작업은 되돌릴 수 없습니다.
-                </p>
+                <p className="text-sm text-muted-foreground">이 작업은 되돌릴 수 없습니다.</p>
               </div>
             </div>
 
@@ -943,11 +939,7 @@ export default function AdminScoresPage() {
               <Button variant="outline" onClick={handleDeleteClose}>
                 취소
               </Button>
-              <Button
-                variant="destructive"
-                onClick={handleDeleteConfirm}
-                disabled={deleteLoading}
-              >
+              <Button variant="destructive" onClick={handleDeleteConfirm} disabled={deleteLoading}>
                 {deleteLoading ? '삭제 중...' : '삭제'}
               </Button>
             </div>

--- a/packages/web/src/app/(user)/dashboard/page.tsx
+++ b/packages/web/src/app/(user)/dashboard/page.tsx
@@ -19,6 +19,7 @@ interface RoundInfo {
   daysRemaining: number;
   isGracePeriod: boolean;
   submissionRate: number;
+  myAttendanceStatus: string | null;
 }
 
 interface Post {
@@ -125,6 +126,46 @@ function getDdayLabel(days: number, isGrace: boolean): string {
   if (isGrace) return '지각 마감';
   if (days <= 1) return 'D-Day';
   return `D-${days}`;
+}
+
+function getAttendanceChip(
+  status: string | null,
+  isGracePeriod: boolean,
+): { icon: string; label: string; className: string } {
+  switch (status) {
+    case 'SUBMITTED':
+      return {
+        icon: '✓',
+        label: '제출 완료',
+        className: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+      };
+    case 'LATE':
+      return {
+        icon: '△',
+        label: '지각 제출',
+        className: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+      };
+    case 'ABSENT':
+      return {
+        icon: '✗',
+        label: '결석',
+        className: 'bg-destructive/10 text-destructive',
+      };
+    default:
+      // PENDING or null
+      if (isGracePeriod) {
+        return {
+          icon: '⚠',
+          label: '미제출 (지각 기간)',
+          className: 'bg-destructive/10 text-destructive',
+        };
+      }
+      return {
+        icon: '○',
+        label: '미제출',
+        className: 'bg-muted text-muted-foreground',
+      };
+  }
 }
 
 export default function DashboardPage() {
@@ -237,6 +278,21 @@ export default function DashboardPage() {
                 {round.startDate} ~ {round.endDate}
               </span>
             </div>
+
+            {/* My Attendance Status */}
+            {(() => {
+              const chip = getAttendanceChip(round.myAttendanceStatus, round.isGracePeriod);
+              return (
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-muted-foreground">나의 출석</span>
+                  <span
+                    className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${chip.className}`}
+                  >
+                    {chip.icon} {chip.label}
+                  </span>
+                </div>
+              );
+            })()}
 
             {/* Submission Progress */}
             <div className="space-y-2">

--- a/packages/web/src/app/(user)/dashboard/page.tsx
+++ b/packages/web/src/app/(user)/dashboard/page.tsx
@@ -224,6 +224,10 @@ export default function DashboardPage() {
         : 'text-primary'
     : '';
 
+  const attendanceChip = round
+    ? getAttendanceChip(round.myAttendanceStatus, round.isGracePeriod)
+    : null;
+
   return (
     <div className="space-y-6">
       {/* Greeting Header */}
@@ -280,19 +284,16 @@ export default function DashboardPage() {
             </div>
 
             {/* My Attendance Status */}
-            {(() => {
-              const chip = getAttendanceChip(round.myAttendanceStatus, round.isGracePeriod);
-              return (
-                <div className="flex items-center gap-2">
-                  <span className="text-xs text-muted-foreground">나의 출석</span>
-                  <span
-                    className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${chip.className}`}
-                  >
-                    {chip.icon} {chip.label}
-                  </span>
-                </div>
-              );
-            })()}
+            {attendanceChip && (
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-muted-foreground">나의 출석</span>
+                <span
+                  className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${attendanceChip.className}`}
+                >
+                  {attendanceChip.icon} {attendanceChip.label}
+                </span>
+              </div>
+            )}
 
             {/* Submission Progress */}
             <div className="space-y-2">

--- a/packages/web/src/app/(user)/posts/[id]/page.tsx
+++ b/packages/web/src/app/(user)/posts/[id]/page.tsx
@@ -6,21 +6,35 @@ import Link from 'next/link';
 import { toast } from 'sonner';
 import {
   ArrowLeft,
+  Check,
   ExternalLink,
   Loader2,
+  Lock,
   MessageCircle,
   Pencil,
-  Send,
-  Shield,
+  Reply,
   Trash2,
+  X,
 } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Badge } from '@/components/ui/badge';
 import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { MemberAvatar } from '@/components/ui/member-avatar';
 import { PageError } from '@/components/ui/page-state';
-import { getDefaultAvatar } from '@/lib/utils';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { cn, getDefaultAvatar } from '@/lib/utils';
 
 // ─────────────────────────────────────────────
 // Types
@@ -31,6 +45,7 @@ interface CommentMember {
   nickname: string | null;
   discordUsername: string;
   profileImageUrl: string | null;
+  discordId: string;
   isAdmin: boolean;
 }
 
@@ -38,44 +53,340 @@ interface Comment {
   id: string;
   postId: string;
   memberId: string;
+  parentId: string | null;
   content: string;
+  isSecret: boolean;
   createdAt: string;
   updatedAt: string;
+  isDeleted: boolean;
+  isMasked: boolean;
   isOwner: boolean;
   member: CommentMember;
 }
 
+interface CommentNode extends Comment {
+  children: CommentNode[];
+}
+
 // ─────────────────────────────────────────────
-// CommentItem
+// Helpers
 // ─────────────────────────────────────────────
 
-function CommentItem({
-  comment,
-  onEdit,
+function buildCommentTree(comments: Comment[]): CommentNode[] {
+  const map = new Map<string, CommentNode>();
+  const roots: CommentNode[] = [];
+
+  comments.forEach((c) => map.set(c.id, { ...c, children: [] }));
+  comments.forEach((c) => {
+    const node = map.get(c.id)!;
+    if (c.parentId && map.has(c.parentId)) {
+      map.get(c.parentId)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  });
+
+  return roots;
+}
+
+function formatRelativeTime(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  const diffHour = Math.floor(diffMs / 3600000);
+  const diffDay = Math.floor(diffMs / 86400000);
+
+  if (diffMin < 1) return '방금 전';
+  if (diffMin < 60) return `${diffMin}분 전`;
+  if (diffHour < 24) return `${diffHour}시간 전`;
+  if (diffDay < 7) return `${diffDay}일 전`;
+  return date.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+}
+
+// ─────────────────────────────────────────────
+// CommentBody
+// ─────────────────────────────────────────────
+
+function CommentBody({
+  node,
+  displayName,
+  isEdited,
+  editing,
+  editContent,
+  editSecret,
+  saving,
+  replyOpen,
+  canReply,
+  canEdit,
+  canDelete,
+  onEditContentChange,
+  onEditSecretChange,
+  onSaveEdit,
+  onCancelEdit,
+  onStartEdit,
   onDelete,
+  onReply,
 }: {
-  comment: Comment;
-  onEdit: (id: string, content: string) => Promise<void>;
-  onDelete: (id: string) => Promise<void>;
+  node: CommentNode;
+  displayName: string;
+  isEdited: boolean;
+  editing: boolean;
+  editContent: string;
+  editSecret: boolean;
+  saving: boolean;
+  replyOpen: boolean;
+  canReply: boolean;
+  canEdit: boolean;
+  canDelete: boolean;
+  onEditContentChange: (v: string) => void;
+  onEditSecretChange: (v: boolean) => void;
+  onSaveEdit: () => void;
+  onCancelEdit: () => void;
+  onStartEdit: () => void;
+  onDelete: () => void;
+  onReply: () => void;
 }) {
+  return (
+    <div className={cn('flex gap-3 py-3', node.isDeleted && 'opacity-60')}>
+      <MemberAvatar
+        memberId={node.memberId}
+        name={displayName}
+        seed={
+          node.isDeleted
+            ? 'deleted'
+            : node.isMasked
+              ? 'secret'
+              : node.member.discordId || displayName
+        }
+        imageUrl={node.isDeleted || node.isMasked ? null : node.member.profileImageUrl}
+        size="md"
+        noLink={node.isDeleted || node.isMasked}
+        className={node.isDeleted ? 'opacity-40' : undefined}
+      />
+
+      <div className="flex-1 min-w-0 space-y-1">
+        {/* Header row */}
+        <div className="flex items-center gap-2 flex-wrap">
+          {node.isDeleted || node.isMasked ? (
+            <span className="text-sm font-medium text-muted-foreground">{displayName}</span>
+          ) : (
+            <Link
+              href={`/members/${node.memberId}`}
+              className="text-sm font-medium hover:text-primary transition-colors"
+            >
+              {displayName}
+            </Link>
+          )}
+
+          {node.member.isAdmin && !node.isDeleted && !node.isMasked && (
+            <span className="inline-flex items-center gap-0.5 rounded-full bg-sky-100 px-1.5 py-0.5 text-[10px] font-medium text-sky-700 dark:bg-sky-900/30 dark:text-sky-400">
+              관리자
+            </span>
+          )}
+
+          {node.isSecret && !node.isDeleted && (
+            <span className="inline-flex items-center gap-0.5 text-[11px] text-muted-foreground">
+              <Lock className="h-2.5 w-2.5" />
+              비밀댓글
+            </span>
+          )}
+
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {formatRelativeTime(node.createdAt)}
+          </span>
+
+          {isEdited && !node.isDeleted && (
+            <span className="text-[11px] text-muted-foreground/60">(수정됨)</span>
+          )}
+        </div>
+
+        {/* Content */}
+        {!editing && (
+          <p
+            className={cn(
+              'text-sm leading-relaxed break-words whitespace-pre-wrap',
+              node.isDeleted && 'italic text-muted-foreground text-xs',
+              node.isMasked && 'italic text-muted-foreground text-xs bg-muted/40 rounded px-2 py-1'
+            )}
+          >
+            {node.content}
+          </p>
+        )}
+
+        {/* Inline edit */}
+        {editing && (
+          <div className="space-y-2 mt-1">
+            <Textarea
+              value={editContent}
+              onChange={(e) => onEditContentChange(e.target.value)}
+              onKeyDown={(e) => {
+                if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') onSaveEdit();
+                if (e.key === 'Escape') onCancelEdit();
+              }}
+              rows={2}
+              className="resize-none text-sm leading-relaxed"
+              disabled={saving}
+              aria-label="댓글 수정"
+            />
+            <div className="flex items-center gap-2">
+              <Switch
+                id={`edit-secret-${node.id}`}
+                checked={editSecret}
+                onCheckedChange={onEditSecretChange}
+                disabled={saving}
+                className="data-[state=checked]:bg-sky-500"
+              />
+              <Label
+                htmlFor={`edit-secret-${node.id}`}
+                className="flex items-center gap-1 text-xs text-muted-foreground cursor-pointer select-none"
+              >
+                <Lock className="h-3 w-3" />
+                비밀댓글
+              </Label>
+            </div>
+            <div className="flex items-center justify-end gap-1.5">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onCancelEdit}
+                disabled={saving}
+                className="h-7 gap-1 text-xs text-muted-foreground hover:text-foreground"
+              >
+                <X className="h-3 w-3" />
+                취소
+              </Button>
+              <Button
+                size="sm"
+                onClick={onSaveEdit}
+                disabled={saving || !editContent.trim()}
+                className="h-7 gap-1 text-xs bg-sky-500 hover:bg-sky-600 text-white disabled:opacity-50"
+              >
+                {saving ? (
+                  <>
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    저장 중...
+                  </>
+                ) : (
+                  <>
+                    <Check className="h-3 w-3" />
+                    저장
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Action buttons */}
+        {!editing && (
+          <div className="flex items-center gap-1 pt-0.5">
+            {canReply && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onReply}
+                className={cn(
+                  'h-6 gap-1 px-2 text-[11px] text-muted-foreground hover:text-foreground',
+                  replyOpen && 'text-sky-500 hover:text-sky-600'
+                )}
+              >
+                <Reply className="h-3 w-3" />
+                답글
+              </Button>
+            )}
+
+            {canEdit && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onStartEdit}
+                className="h-6 gap-1 px-2 text-[11px] text-muted-foreground hover:text-foreground"
+              >
+                <Pencil className="h-3 w-3" />
+                수정
+              </Button>
+            )}
+
+            {canDelete && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onDelete}
+                className="h-6 gap-1 px-2 text-[11px] text-muted-foreground hover:text-destructive"
+              >
+                <Trash2 className="h-3 w-3" />
+                삭제
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
+// PostCommentItem
+// ─────────────────────────────────────────────
+
+function PostCommentItem({
+  node,
+  depth,
+  postId,
+  onRefresh,
+  onCommentCountChange,
+}: {
+  node: CommentNode;
+  depth: number;
+  postId: string;
+  onRefresh: () => void;
+  onCommentCountChange: (delta: number) => void;
+}) {
+  const [replyOpen, setReplyOpen] = useState(false);
   const [editing, setEditing] = useState(false);
-  const [editContent, setEditContent] = useState(comment.content);
+  const [editContent, setEditContent] = useState(node.content);
+  const [editSecret, setEditSecret] = useState(node.isSecret);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [replyContent, setReplyContent] = useState('');
+  const [replyIsSecret, setReplyIsSecret] = useState(false);
+  const [replySubmitting, setReplySubmitting] = useState(false);
 
-  const displayName =
-    comment.member.nickname || comment.member.name || comment.member.discordUsername;
-  const avatarSrc = comment.member.profileImageUrl || getDefaultAvatar(displayName);
-  const createdAt = new Date(comment.createdAt);
-  const updatedAt = new Date(comment.updatedAt);
-  const isEdited = updatedAt.getTime() - createdAt.getTime() > 1000;
+  const displayName = node.isDeleted
+    ? '알 수 없음'
+    : node.isMasked
+      ? '익명'
+      : node.member.nickname || node.member.name || node.member.discordUsername;
+  const isEdited = new Date(node.updatedAt).getTime() - new Date(node.createdAt).getTime() > 1000;
 
-  const handleSave = async () => {
+  const canEdit = node.isOwner && !node.isDeleted && !node.isMasked;
+  const canDelete = node.isOwner && !node.isDeleted;
+  const canReply = !node.isDeleted && !node.isMasked && depth < 5;
+
+  // 비밀댓글 답글: 자동 비밀 처리
+  const forceReplySecret = node.isSecret;
+
+  const handleSaveEdit = async () => {
     if (!editContent.trim()) return;
     setSaving(true);
     try {
-      await onEdit(comment.id, editContent.trim());
+      const res = await fetch(`/api/posts/${postId}/comments/${node.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: editContent.trim(), isSecret: editSecret }),
+      });
+      if (!res.ok) {
+        toast.error('수정에 실패했습니다.');
+        return;
+      }
       setEditing(false);
+      onRefresh();
     } finally {
       setSaving(false);
     }
@@ -84,113 +395,211 @@ function CommentItem({
   const handleDelete = async () => {
     setDeleting(true);
     try {
-      await onDelete(comment.id);
+      const res = await fetch(`/api/posts/${postId}/comments/${node.id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        toast.error('삭제에 실패했습니다.');
+        return;
+      }
+      setDeleteConfirmOpen(false);
+      onCommentCountChange(-1);
+      onRefresh();
     } finally {
       setDeleting(false);
     }
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      setEditing(false);
-      setEditContent(comment.content);
-    }
-    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-      handleSave();
+  const handleReplySubmit = async () => {
+    if (!replyContent.trim()) return;
+    setReplySubmitting(true);
+    try {
+      const res = await fetch(`/api/posts/${postId}/comments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          content: replyContent.trim(),
+          parentId: node.id,
+          isSecret: forceReplySecret || replyIsSecret,
+        }),
+      });
+      if (!res.ok) {
+        const result = await res.json();
+        toast.error(result.message || '답글 작성에 실패했습니다.');
+        return;
+      }
+      setReplyContent('');
+      setReplyIsSecret(false);
+      setReplyOpen(false);
+      onCommentCountChange(1);
+      onRefresh();
+    } catch {
+      toast.error('서버 오류가 발생했습니다.');
+    } finally {
+      setReplySubmitting(false);
     }
   };
 
-  return (
-    <div className="flex gap-2.5 py-3 group">
-      <Link href={`/members/${comment.memberId}`} className="shrink-0">
-        <Avatar className="h-7 w-7">
-          <AvatarImage src={avatarSrc} alt={displayName} />
-          <AvatarFallback className="text-[10px]">{displayName[0]}</AvatarFallback>
-        </Avatar>
-      </Link>
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-1.5">
-          <Link
-            href={`/members/${comment.memberId}`}
-            className="text-xs font-medium text-foreground hover:underline underline-offset-2"
-          >
-            {displayName}
-          </Link>
-          {comment.member.isAdmin && (
-            <Badge
-              variant="secondary"
-              className="h-4 px-1 text-[10px] gap-0.5 bg-sky-100 text-sky-700 dark:bg-sky-500/20 dark:text-sky-300"
-            >
-              <Shield className="h-2.5 w-2.5" />
-              관리자
-            </Badge>
-          )}
-          <span className="text-[10px] text-muted-foreground">
-            {createdAt.toLocaleDateString('ko-KR')}{' '}
-            {createdAt.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}
-          </span>
-          {isEdited && <span className="text-[10px] text-muted-foreground">(수정됨)</span>}
-        </div>
+  const bodyProps = {
+    node,
+    displayName,
+    isEdited,
+    editing,
+    editContent,
+    editSecret,
+    saving,
+    replyOpen,
+    canReply,
+    canEdit,
+    canDelete,
+    onEditContentChange: setEditContent,
+    onEditSecretChange: setEditSecret,
+    onSaveEdit: handleSaveEdit,
+    onCancelEdit: () => {
+      setEditing(false);
+      setEditContent(node.content);
+      setEditSecret(node.isSecret);
+    },
+    onStartEdit: () => setEditing(true),
+    onDelete: () => setDeleteConfirmOpen(true),
+    onReply: () => setReplyOpen((v) => !v),
+  };
 
-        {editing ? (
-          <div className="mt-1.5 space-y-2">
-            <Textarea
-              value={editContent}
-              onChange={(e) => setEditContent(e.target.value)}
-              onKeyDown={handleKeyDown}
-              className="text-sm min-h-[60px] resize-none"
-              autoFocus
-            />
-            <div className="flex items-center gap-1.5">
-              <Button
-                size="sm"
-                className="h-7 text-xs"
-                onClick={handleSave}
-                disabled={saving || !editContent.trim()}
-              >
-                {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : '저장'}
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-7 text-xs"
-                onClick={() => {
-                  setEditing(false);
-                  setEditContent(comment.content);
-                }}
-              >
-                취소
-              </Button>
+  return (
+    <div>
+      <div style={depth > 0 ? { marginLeft: `${Math.min(depth, 5) * 1.5}rem` } : undefined}>
+        {depth > 0 ? (
+          <div className="flex gap-3">
+            <div className="w-px bg-border/50 shrink-0 mt-1" />
+            <div className="flex-1">
+              <CommentBody {...bodyProps} />
             </div>
           </div>
         ) : (
-          <>
-            <p className="text-sm text-foreground/90 whitespace-pre-wrap mt-0.5 leading-relaxed">
-              {comment.content}
+          <CommentBody {...bodyProps} />
+        )}
+
+        {/* Reply form */}
+        {replyOpen && !editing && (
+          <div
+            className={cn('mt-2 mb-3 rounded-lg border border-border/50 bg-muted/20 p-3', 'ml-9')}
+          >
+            <p className="text-xs font-medium text-muted-foreground mb-2">
+              @{displayName}에게 답글
             </p>
-            {/* Action buttons — visible on hover or for owner/admin */}
-            {comment.isOwner && (
-              <div className="flex items-center gap-1 mt-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                <button
-                  onClick={() => setEditing(true)}
-                  className="flex items-center gap-0.5 text-[10px] text-muted-foreground hover:text-foreground transition-colors p-0.5 rounded"
+            <div className="space-y-2">
+              <Textarea
+                value={replyContent}
+                onChange={(e) => setReplyContent(e.target.value)}
+                onKeyDown={(e) => {
+                  if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') handleReplySubmit();
+                  if (e.key === 'Escape') {
+                    setReplyOpen(false);
+                    setReplyContent('');
+                  }
+                }}
+                placeholder={`@${displayName}에게 답글 달기\u2026`}
+                rows={2}
+                className="resize-none text-sm leading-relaxed"
+                disabled={replySubmitting}
+                aria-label={`${displayName}에게 답글`}
+              />
+              <div className="flex items-center gap-2">
+                <Switch
+                  id={`reply-secret-${node.id}`}
+                  checked={forceReplySecret || replyIsSecret}
+                  onCheckedChange={forceReplySecret ? undefined : setReplyIsSecret}
+                  disabled={replySubmitting || forceReplySecret}
+                  className="data-[state=checked]:bg-sky-500"
+                />
+                <Label
+                  htmlFor={`reply-secret-${node.id}`}
+                  className="flex items-center gap-1 text-xs text-muted-foreground cursor-pointer select-none whitespace-nowrap"
                 >
-                  <Pencil className="h-3 w-3" />
-                  수정
-                </button>
-                <button
-                  onClick={handleDelete}
-                  disabled={deleting}
-                  className="flex items-center gap-0.5 text-[10px] text-muted-foreground hover:text-destructive transition-colors p-0.5 rounded"
-                >
-                  <Trash2 className="h-3 w-3" />
-                  삭제
-                </button>
+                  <Lock className="h-3 w-3" />
+                  비밀댓글{forceReplySecret && ' (자동)'}
+                </Label>
               </div>
-            )}
-          </>
+              <div className="flex items-center justify-end gap-1.5">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setReplyOpen(false);
+                    setReplyContent('');
+                    setReplyIsSecret(false);
+                  }}
+                  disabled={replySubmitting}
+                  className="h-7 gap-1 text-xs text-muted-foreground hover:text-foreground"
+                >
+                  <X className="h-3 w-3" />
+                  취소
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={handleReplySubmit}
+                  disabled={replySubmitting || !replyContent.trim()}
+                  className="h-7 gap-1 text-xs bg-sky-500 hover:bg-sky-600 text-white disabled:opacity-50"
+                >
+                  {replySubmitting ? (
+                    <>
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                      등록 중...
+                    </>
+                  ) : (
+                    '답글 등록'
+                  )}
+                </Button>
+              </div>
+            </div>
+          </div>
         )}
       </div>
+
+      {/* Children */}
+      {node.children.length > 0 && (
+        <div>
+          {node.children.map((child) => (
+            <PostCommentItem
+              key={child.id}
+              node={child}
+              depth={depth + 1}
+              postId={postId}
+              onRefresh={onRefresh}
+              onCommentCountChange={onCommentCountChange}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Delete confirmation */}
+      <AlertDialog open={deleteConfirmOpen} onOpenChange={setDeleteConfirmOpen}>
+        <AlertDialogContent className="max-w-sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-base">댓글을 삭제하시겠습니까?</AlertDialogTitle>
+            <AlertDialogDescription className="text-sm text-muted-foreground">
+              삭제된 댓글은 복구할 수 없습니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting} className="h-9 text-sm">
+              취소
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={deleting}
+              className="h-9 text-sm bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+            >
+              {deleting ? (
+                <span className="flex items-center gap-1.5">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  삭제 중...
+                </span>
+              ) : (
+                '삭제하기'
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }
@@ -203,12 +612,13 @@ export default function PostDetailPage() {
   const { id: postId } = useParams<{ id: string }>();
 
   const [comments, setComments] = useState<Comment[]>([]);
+  const [commentCount, setCommentCount] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [newComment, setNewComment] = useState('');
+  const [newCommentSecret, setNewCommentSecret] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
-  // Fetch post info from the list API (minimal — we mainly need title/author)
   const [postInfo, setPostInfo] = useState<{
     title: string;
     url: string;
@@ -224,6 +634,7 @@ export default function PostDetailPage() {
       if (!res.ok) throw new Error('Failed to load comments');
       const result = await res.json();
       setComments(result.data);
+      setCommentCount(result.data.length);
     } catch (err) {
       setError('댓글을 불러오는데 실패했습니다.');
       console.error(err);
@@ -232,11 +643,9 @@ export default function PostDetailPage() {
     }
   }, [postId]);
 
-  // Fetch post info by checking if it's in the list
   useEffect(() => {
     async function fetchPostInfo() {
       try {
-        // Use a simple search to find this specific post
         const res = await fetch(`/api/posts?page=1&pageSize=100`);
         if (res.ok) {
           const result = await res.json();
@@ -254,7 +663,7 @@ export default function PostDetailPage() {
           }
         }
       } catch {
-        // Non-critical, UI still works without post info
+        // Non-critical
       }
     }
     fetchPostInfo();
@@ -268,15 +677,16 @@ export default function PostDetailPage() {
       const res = await fetch(`/api/posts/${postId}/comments`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: newComment.trim() }),
+        body: JSON.stringify({ content: newComment.trim(), isSecret: newCommentSecret }),
       });
       if (!res.ok) {
         const result = await res.json();
         toast.error(result.message || '댓글 작성에 실패했습니다.');
         return;
       }
-      toast.success('댓글이 작성되었습니다.');
       setNewComment('');
+      setNewCommentSecret(false);
+      setCommentCount((c) => c + 1);
       fetchComments();
     } catch {
       toast.error('서버 오류가 발생했습니다.');
@@ -285,43 +695,11 @@ export default function PostDetailPage() {
     }
   };
 
-  const handleEditComment = async (commentId: string, content: string) => {
-    const res = await fetch(`/api/posts/${postId}/comments/${commentId}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ content }),
-    });
-    if (!res.ok) {
-      const result = await res.json();
-      toast.error(result.message || '수정에 실패했습니다.');
-      return;
-    }
-    toast.success('댓글이 수정되었습니다.');
-    fetchComments();
-  };
-
-  const handleDeleteComment = async (commentId: string) => {
-    const res = await fetch(`/api/posts/${postId}/comments/${commentId}`, {
-      method: 'DELETE',
-    });
-    if (!res.ok) {
-      const result = await res.json();
-      toast.error(result.message || '삭제에 실패했습니다.');
-      return;
-    }
-    toast.success('댓글이 삭제되었습니다.');
-    fetchComments();
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-      handleSubmitComment();
-    }
-  };
-
   if (error && comments.length === 0) {
     return <PageError message={error} />;
   }
+
+  const commentTree = buildCommentTree(comments);
 
   return (
     <div className="space-y-4">
@@ -377,56 +755,90 @@ export default function PostDetailPage() {
       {/* Comments section */}
       <Card className="border-border/60 shadow-none">
         <CardContent className="p-4">
-          <div className="flex items-center gap-1.5 mb-3">
+          <div className="flex items-center gap-2 mb-3">
             <MessageCircle className="h-4 w-4 text-muted-foreground" />
-            <span className="text-sm font-medium">댓글 {comments.length}개</span>
-          </div>
-
-          {/* Comment input */}
-          <div className="flex gap-2 mb-4">
-            <Textarea
-              value={newComment}
-              onChange={(e) => setNewComment(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="댓글을 작성하세요... (Ctrl+Enter로 전송)"
-              className="text-sm min-h-[60px] resize-none flex-1"
-            />
-            <Button
-              size="sm"
-              className="h-auto self-end"
-              onClick={handleSubmitComment}
-              disabled={submitting || !newComment.trim()}
-            >
-              {submitting ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Send className="h-4 w-4" />
-              )}
-            </Button>
+            <span className="text-sm font-medium">댓글</span>
+            <span className="inline-flex items-center justify-center h-5 min-w-5 rounded-full bg-sky-100 px-1.5 text-[11px] font-medium text-sky-700 dark:bg-sky-900/30 dark:text-sky-400">
+              {commentCount}
+            </span>
           </div>
 
           {/* Comments list */}
-          {loading ? (
-            <div className="flex items-center justify-center py-8">
-              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-            </div>
-          ) : comments.length > 0 ? (
-            <div className="divide-y divide-border/40">
-              {comments.map((comment) => (
-                <CommentItem
-                  key={comment.id}
-                  comment={comment}
-                  onEdit={handleEditComment}
-                  onDelete={handleDeleteComment}
+          <div className="border-t border-border/40">
+            {loading ? (
+              <div className="flex justify-center py-6">
+                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+              </div>
+            ) : commentTree.length > 0 ? (
+              <div className="divide-y divide-border/40">
+                {commentTree.map((node) => (
+                  <PostCommentItem
+                    key={node.id}
+                    node={node}
+                    depth={0}
+                    postId={postId}
+                    onRefresh={fetchComments}
+                    onCommentCountChange={(delta) => setCommentCount((c) => c + delta)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="flex flex-col items-center justify-center py-8 gap-1.5 text-center">
+                <p className="text-sm text-muted-foreground">아직 댓글이 없습니다.</p>
+                <p className="text-xs text-muted-foreground/60">첫 댓글을 남겨보세요.</p>
+              </div>
+            )}
+          </div>
+
+          {/* Comment input */}
+          <div className="border-t border-border/40 pt-3 space-y-2">
+            <Textarea
+              value={newComment}
+              onChange={(e) => setNewComment(e.target.value)}
+              onKeyDown={(e) => {
+                if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') handleSubmitComment();
+              }}
+              placeholder="댓글을 입력해주세요\u2026"
+              aria-label="댓글 입력"
+              rows={2}
+              className="resize-none text-sm leading-relaxed"
+            />
+            <div className="flex items-center gap-x-3 gap-y-2">
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="new-comment-secret"
+                  checked={newCommentSecret}
+                  onCheckedChange={setNewCommentSecret}
+                  disabled={submitting}
+                  className="data-[state=checked]:bg-sky-500"
                 />
-              ))}
+                <Label
+                  htmlFor="new-comment-secret"
+                  className="flex items-center gap-1 text-xs text-muted-foreground cursor-pointer select-none whitespace-nowrap"
+                >
+                  <Lock className="h-3 w-3" />
+                  비밀댓글
+                </Label>
+              </div>
+              <div className="ml-auto">
+                <Button
+                  size="sm"
+                  onClick={handleSubmitComment}
+                  disabled={submitting || !newComment.trim()}
+                  className="h-7 gap-1 text-xs bg-sky-500 hover:bg-sky-600 text-white disabled:opacity-50"
+                >
+                  {submitting ? (
+                    <>
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                      등록 중...
+                    </>
+                  ) : (
+                    '댓글 등록'
+                  )}
+                </Button>
+              </div>
             </div>
-          ) : (
-            <div className="flex flex-col items-center justify-center py-8 gap-1.5">
-              <MessageCircle className="h-6 w-6 text-muted-foreground/30" />
-              <p className="text-xs text-muted-foreground">첫 댓글을 남겨보세요.</p>
-            </div>
-          )}
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/packages/web/src/app/(user)/posts/page.tsx
+++ b/packages/web/src/app/(user)/posts/page.tsx
@@ -13,6 +13,7 @@ import {
   Flame,
   Globe,
   Loader2,
+  Lock,
   Medal,
   MessageCircle,
   Pencil,
@@ -27,6 +28,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Textarea } from '@/components/ui/textarea';
 import { PartBadge } from '@/components/ui/part-badge';
@@ -80,9 +82,11 @@ interface Comment {
   memberId: string;
   parentId: string | null;
   content: string;
+  isSecret: boolean;
   createdAt: string;
   updatedAt: string;
   isDeleted: boolean;
+  isMasked: boolean;
   isOwner: boolean;
   member: CommentMember;
 }
@@ -250,14 +254,23 @@ function PostCommentItem({
   const [replyOpen, setReplyOpen] = useState(false);
   const [editing, setEditing] = useState(false);
   const [editContent, setEditContent] = useState(node.content);
+  const [editSecret, setEditSecret] = useState(node.isSecret);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [replyContent, setReplyContent] = useState('');
+  const [replyIsSecret, setReplyIsSecret] = useState(false);
   const [replySubmitting, setReplySubmitting] = useState(false);
 
-  const displayName = node.member.nickname || node.member.name || node.member.discordUsername;
+  const displayName = node.isDeleted
+    ? '알 수 없음'
+    : node.isMasked
+      ? '익명'
+      : node.member.nickname || node.member.name || node.member.discordUsername;
   const isEdited = new Date(node.updatedAt).getTime() - new Date(node.createdAt).getTime() > 1000;
+  const canEdit = node.isOwner && !node.isDeleted && !node.isMasked;
+  const canDelete = node.isOwner && !node.isDeleted;
+  const forceReplySecret = node.isSecret;
 
   const handleSaveEdit = async () => {
     if (!editContent.trim()) return;
@@ -266,7 +279,7 @@ function PostCommentItem({
       const res = await fetch(`/api/posts/${postId}/comments/${node.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: editContent.trim() }),
+        body: JSON.stringify({ content: editContent.trim(), isSecret: editSecret }),
       });
       if (!res.ok) {
         toast.error('수정에 실패했습니다.');
@@ -302,7 +315,11 @@ function PostCommentItem({
       const res = await fetch(`/api/posts/${postId}/comments`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: replyContent.trim(), parentId: node.id }),
+        body: JSON.stringify({
+          content: replyContent.trim(),
+          parentId: node.id,
+          isSecret: forceReplySecret || replyIsSecret,
+        }),
       });
       if (!res.ok) {
         const result = await res.json();
@@ -323,7 +340,7 @@ function PostCommentItem({
   return (
     <div>
       <div style={depth > 0 ? { marginLeft: `${Math.min(depth, 5) * 1.5}rem` } : undefined}>
-        {depth > 0 && (
+        {depth > 0 ? (
           <div className="flex gap-3">
             <div className="w-px bg-border/50 shrink-0 mt-1" />
             <div className="flex-1">
@@ -333,14 +350,19 @@ function PostCommentItem({
                 isEdited={isEdited}
                 editing={editing}
                 editContent={editContent}
+                editSecret={editSecret}
                 saving={saving}
                 replyOpen={replyOpen}
-                showReply={depth < 5}
+                canReply={!node.isDeleted && !node.isMasked && depth < 5}
+                canEdit={canEdit}
+                canDelete={canDelete}
                 onEditContentChange={setEditContent}
+                onEditSecretChange={setEditSecret}
                 onSaveEdit={handleSaveEdit}
                 onCancelEdit={() => {
                   setEditing(false);
                   setEditContent(node.content);
+                  setEditSecret(node.isSecret);
                 }}
                 onStartEdit={() => setEditing(true)}
                 onDelete={() => setDeleteConfirmOpen(true)}
@@ -348,23 +370,26 @@ function PostCommentItem({
               />
             </div>
           </div>
-        )}
-
-        {depth === 0 && (
+        ) : (
           <CommentBody
             node={node}
             displayName={displayName}
             isEdited={isEdited}
             editing={editing}
             editContent={editContent}
+            editSecret={editSecret}
             saving={saving}
             replyOpen={replyOpen}
-            showReply={true}
+            canReply={!node.isDeleted && !node.isMasked && depth < 5}
+            canEdit={canEdit}
+            canDelete={canDelete}
             onEditContentChange={setEditContent}
+            onEditSecretChange={setEditSecret}
             onSaveEdit={handleSaveEdit}
             onCancelEdit={() => {
               setEditing(false);
               setEditContent(node.content);
+              setEditSecret(node.isSecret);
             }}
             onStartEdit={() => setEditing(true)}
             onDelete={() => setDeleteConfirmOpen(true)}
@@ -391,12 +416,28 @@ function PostCommentItem({
                     setReplyContent('');
                   }
                 }}
-                placeholder={`@${displayName}에게 답글 달기...`}
+                placeholder={`@${displayName}에게 답글 달기\u2026`}
                 rows={2}
                 className="resize-none text-sm leading-relaxed"
                 disabled={replySubmitting}
-                autoFocus
+                aria-label={`${displayName}에게 답글`}
               />
+              <div className="flex items-center gap-2">
+                <Switch
+                  id={`reply-secret-${node.id}`}
+                  checked={forceReplySecret || replyIsSecret}
+                  onCheckedChange={forceReplySecret ? undefined : setReplyIsSecret}
+                  disabled={replySubmitting || forceReplySecret}
+                  className="data-[state=checked]:bg-sky-500"
+                />
+                <Label
+                  htmlFor={`reply-secret-${node.id}`}
+                  className="flex items-center gap-1 text-xs text-muted-foreground cursor-pointer select-none whitespace-nowrap"
+                >
+                  <Lock className="h-3 w-3" />
+                  비밀댓글{forceReplySecret && ' (자동)'}
+                </Label>
+              </div>
               <div className="flex items-center justify-end gap-1.5">
                 <Button
                   variant="ghost"
@@ -404,6 +445,7 @@ function PostCommentItem({
                   onClick={() => {
                     setReplyOpen(false);
                     setReplyContent('');
+                    setReplyIsSecret(false);
                   }}
                   disabled={replySubmitting}
                   className="h-7 gap-1 text-xs text-muted-foreground hover:text-foreground"
@@ -492,10 +534,14 @@ function CommentBody({
   isEdited,
   editing,
   editContent,
+  editSecret,
   saving,
   replyOpen,
-  showReply,
+  canReply,
+  canEdit,
+  canDelete,
   onEditContentChange,
+  onEditSecretChange,
   onSaveEdit,
   onCancelEdit,
   onStartEdit,
@@ -507,10 +553,14 @@ function CommentBody({
   isEdited: boolean;
   editing: boolean;
   editContent: string;
+  editSecret: boolean;
   saving: boolean;
   replyOpen: boolean;
-  showReply: boolean;
+  canReply: boolean;
+  canEdit: boolean;
+  canDelete: boolean;
   onEditContentChange: (v: string) => void;
+  onEditSecretChange: (v: boolean) => void;
   onSaveEdit: () => void;
   onCancelEdit: () => void;
   onStartEdit: () => void;
@@ -523,10 +573,16 @@ function CommentBody({
       <MemberAvatar
         memberId={node.memberId}
         name={displayName}
-        seed={node.isDeleted ? 'deleted' : node.member.discordId || displayName}
-        imageUrl={node.isDeleted ? null : node.member.profileImageUrl}
+        seed={
+          node.isDeleted
+            ? 'deleted'
+            : node.isMasked
+              ? 'secret'
+              : node.member.discordId || displayName
+        }
+        imageUrl={node.isDeleted || node.isMasked ? null : node.member.profileImageUrl}
         size="md"
-        noLink={node.isDeleted}
+        noLink={node.isDeleted || node.isMasked}
         className={node.isDeleted ? 'opacity-40' : undefined}
       />
 
@@ -534,7 +590,7 @@ function CommentBody({
       <div className="flex-1 min-w-0 space-y-1">
         {/* Header row */}
         <div className="flex items-center gap-2 flex-wrap">
-          {node.isDeleted ? (
+          {node.isDeleted || node.isMasked ? (
             <span className="text-sm font-medium text-muted-foreground">{displayName}</span>
           ) : (
             <Link
@@ -545,9 +601,16 @@ function CommentBody({
             </Link>
           )}
 
-          {node.member.isAdmin && !node.isDeleted && (
+          {node.member.isAdmin && !node.isDeleted && !node.isMasked && (
             <span className="inline-flex items-center gap-0.5 rounded-full bg-sky-100 px-1.5 py-0.5 text-[10px] font-medium text-sky-700 dark:bg-sky-900/30 dark:text-sky-400">
               관리자
+            </span>
+          )}
+
+          {node.isSecret && !node.isDeleted && (
+            <span className="inline-flex items-center gap-0.5 text-[11px] text-muted-foreground">
+              <Lock className="h-2.5 w-2.5" />
+              비밀댓글
             </span>
           )}
 
@@ -565,7 +628,8 @@ function CommentBody({
           <p
             className={cn(
               'text-sm leading-relaxed break-words whitespace-pre-wrap',
-              node.isDeleted && 'italic text-muted-foreground text-xs'
+              node.isDeleted && 'italic text-muted-foreground text-xs',
+              node.isMasked && 'italic text-muted-foreground text-xs bg-muted/40 rounded px-2 py-1'
             )}
           >
             {node.content}
@@ -585,8 +649,24 @@ function CommentBody({
               rows={2}
               className="resize-none text-sm leading-relaxed"
               disabled={saving}
-              autoFocus
+              aria-label="댓글 수정"
             />
+            <div className="flex items-center gap-2">
+              <Switch
+                id={`edit-secret-${node.id}`}
+                checked={editSecret}
+                onCheckedChange={onEditSecretChange}
+                disabled={saving}
+                className="data-[state=checked]:bg-sky-500"
+              />
+              <Label
+                htmlFor={`edit-secret-${node.id}`}
+                className="flex items-center gap-1 text-xs text-muted-foreground cursor-pointer select-none"
+              >
+                <Lock className="h-3 w-3" />
+                비밀댓글
+              </Label>
+            </div>
             <div className="flex items-center justify-end gap-1.5">
               <Button
                 variant="ghost"
@@ -623,7 +703,7 @@ function CommentBody({
         {/* Action buttons - 항상 표시 */}
         {!editing && (
           <div className="flex items-center gap-1 pt-0.5">
-            {!node.isDeleted && showReply && (
+            {canReply && (
               <Button
                 variant="ghost"
                 size="sm"
@@ -638,7 +718,7 @@ function CommentBody({
               </Button>
             )}
 
-            {node.isOwner && !node.isDeleted && (
+            {canEdit && (
               <Button
                 variant="ghost"
                 size="sm"
@@ -650,7 +730,7 @@ function CommentBody({
               </Button>
             )}
 
-            {node.isOwner && !node.isDeleted && (
+            {canDelete && (
               <Button
                 variant="ghost"
                 size="sm"
@@ -736,6 +816,7 @@ function PostCard({
   const [comments, setComments] = useState<Comment[]>([]);
   const [commentsLoaded, setCommentsLoaded] = useState(false);
   const [newComment, setNewComment] = useState('');
+  const [newCommentSecret, setNewCommentSecret] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [showComments, setShowComments] = useState(false);
 
@@ -764,7 +845,7 @@ function PostCard({
       const res = await fetch(`/api/posts/${post.id}/comments`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: newComment.trim() }),
+        body: JSON.stringify({ content: newComment.trim(), isSecret: newCommentSecret }),
       });
       if (!res.ok) {
         const result = await res.json();
@@ -772,6 +853,7 @@ function PostCard({
         return;
       }
       setNewComment('');
+      setNewCommentSecret(false);
       onCommentCountChange(post.id, 1);
       fetchComments();
     } catch {
@@ -956,27 +1038,45 @@ function PostCard({
                 onKeyDown={(e) => {
                   if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') handleSubmitComment();
                 }}
-                placeholder="댓글을 입력해주세요..."
+                placeholder="댓글을 입력해주세요\u2026"
+                aria-label="댓글 입력"
                 rows={2}
                 className="resize-none text-sm leading-relaxed"
               />
-              <div className="flex items-center justify-between">
-                <p className="text-[11px] text-muted-foreground/60">Ctrl+Enter로 등록</p>
-                <Button
-                  size="sm"
-                  onClick={handleSubmitComment}
-                  disabled={submitting || !newComment.trim()}
-                  className="h-7 gap-1 text-xs bg-sky-500 hover:bg-sky-600 text-white disabled:opacity-50"
-                >
-                  {submitting ? (
-                    <>
-                      <Loader2 className="h-3 w-3 animate-spin" />
-                      등록 중...
-                    </>
-                  ) : (
-                    '댓글 등록'
-                  )}
-                </Button>
+              <div className="flex items-center gap-x-3 gap-y-2">
+                <div className="flex items-center gap-2">
+                  <Switch
+                    id={`comment-secret-${post.id}`}
+                    checked={newCommentSecret}
+                    onCheckedChange={setNewCommentSecret}
+                    disabled={submitting}
+                    className="data-[state=checked]:bg-sky-500"
+                  />
+                  <Label
+                    htmlFor={`comment-secret-${post.id}`}
+                    className="flex items-center gap-1 text-xs text-muted-foreground cursor-pointer select-none whitespace-nowrap"
+                  >
+                    <Lock className="h-3 w-3" />
+                    비밀댓글
+                  </Label>
+                </div>
+                <div className="ml-auto">
+                  <Button
+                    size="sm"
+                    onClick={handleSubmitComment}
+                    disabled={submitting || !newComment.trim()}
+                    className="h-7 gap-1 text-xs bg-sky-500 hover:bg-sky-600 text-white disabled:opacity-50"
+                  >
+                    {submitting ? (
+                      <>
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                        등록 중...
+                      </>
+                    ) : (
+                      '댓글 등록'
+                    )}
+                  </Button>
+                </div>
               </div>
             </div>
           </div>

--- a/packages/web/src/app/api/dashboard/route.ts
+++ b/packages/web/src/app/api/dashboard/route.ts
@@ -1,4 +1,4 @@
-import { count, desc, eq } from 'drizzle-orm';
+import { and, count, desc, eq } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { createClient } from '@/lib/supabase/server';
@@ -28,13 +28,15 @@ export async function GET() {
     const discordIdentity = user.identities?.find((i) => i.provider === 'discord');
     const discordId = discordIdentity?.id;
     let currentUserNickname: string | null = null;
+    let currentMemberId: string | null = null;
     if (discordId) {
       const [me] = await database
-        .select({ nickname: members.nickname, discordUsername: members.discordUsername })
+        .select({ id: members.id, nickname: members.nickname, discordUsername: members.discordUsername })
         .from(members)
         .where(eq(members.discordId, discordId))
         .limit(1);
       currentUserNickname = me?.nickname || me?.discordUsername || null;
+      currentMemberId = me?.id ?? null;
     }
 
     // Get current round
@@ -83,6 +85,22 @@ export async function GET() {
         .where(eq(members.status, MemberStatus.ACTIVE));
       const totalActiveMembers = activeMembersResult?.count ?? 0;
 
+      // Get current user's attendance status for this round
+      let myAttendanceStatus: string | null = null;
+      if (currentMemberId) {
+        const [myAttendance] = await database
+          .select({ status: attendance.status })
+          .from(attendance)
+          .where(
+            and(
+              eq(attendance.roundId, currentRoundData.id),
+              eq(attendance.memberId, currentMemberId),
+            ),
+          )
+          .limit(1);
+        myAttendanceStatus = myAttendance?.status ?? null;
+      }
+
       currentRound = {
         roundNumber: currentRoundData.roundNumber,
         startDate: currentRoundData.startDate,
@@ -92,6 +110,7 @@ export async function GET() {
         isGracePeriod,
         submissionRate:
           totalActiveMembers > 0 ? Math.round((submitted / totalActiveMembers) * 100) : 0,
+        myAttendanceStatus,
       };
     }
 

--- a/packages/web/src/app/api/dashboard/route.ts
+++ b/packages/web/src/app/api/dashboard/route.ts
@@ -39,18 +39,46 @@ export async function GET() {
       currentMemberId = me?.id ?? null;
     }
 
-    // Get current round
-    const [currentRoundData] = await database
-      .select()
-      .from(rounds)
-      .where(eq(rounds.isCurrent, true))
-      .limit(1);
+    // Fan out all top-level independent queries in parallel
+    const [roundRows, recentPostsResult, activeMembersResult, totalPostsResult] =
+      await Promise.all([
+        database
+          .select()
+          .from(rounds)
+          .where(eq(rounds.isCurrent, true))
+          .limit(1),
+
+        database
+          .select({
+            id: posts.id,
+            title: posts.title,
+            url: posts.url,
+            publishedAt: posts.publishedAt,
+            memberId: members.id,
+            memberName: members.name,
+            memberNickname: members.nickname,
+            memberDiscordUsername: members.discordUsername,
+            memberProfileImageUrl: members.profileImageUrl,
+          })
+          .from(posts)
+          .leftJoin(members, eq(posts.memberId, members.id))
+          .orderBy(desc(posts.publishedAt))
+          .limit(5),
+
+        database
+          .select({ count: count() })
+          .from(members)
+          .where(eq(members.status, MemberStatus.ACTIVE)),
+
+        database.select({ count: count() }).from(posts),
+      ]);
+
+    const currentRoundData = roundRows[0];
+    const totalActiveMembers = activeMembersResult[0]?.count ?? 0;
 
     let currentRound = null;
     if (currentRoundData) {
       const now = new Date();
-      // endDate 당일은 마감일이므로 23:59:59까지 정상 기간
-      // 지각은 endDate 다음 날부터 (마감일+1), 결석은 graceEndDate 다음 날부터
       const endDate = new Date(currentRoundData.endDate);
       const endOfDeadline = new Date(endDate);
       endOfDeadline.setHours(23, 59, 59, 999);
@@ -58,48 +86,36 @@ export async function GET() {
       const endOfGrace = new Date(graceEndDate);
       endOfGrace.setHours(23, 59, 59, 999);
 
-      // Calculate days remaining (based on end of deadline day)
       const timeDiff = endOfDeadline.getTime() - now.getTime();
       const daysRemaining = Math.ceil(timeDiff / (1000 * 60 * 60 * 24));
-
-      // Check if in grace period (after deadline day, within grace day)
       const isGracePeriod = now > endOfDeadline && now <= endOfGrace;
 
-      // Get submission stats for current round
-      const attendanceStats = await database
-        .select({
-          status: attendance.status,
-          count: count(),
-        })
-        .from(attendance)
-        .where(eq(attendance.roundId, currentRoundData.id))
-        .groupBy(attendance.status);
+      // Parallelize attendance stats + my attendance query
+      const [attendanceStats, myAttendanceRow] = await Promise.all([
+        database
+          .select({ status: attendance.status, count: count() })
+          .from(attendance)
+          .where(eq(attendance.roundId, currentRoundData.id))
+          .groupBy(attendance.status),
+
+        currentMemberId
+          ? database
+              .select({ status: attendance.status })
+              .from(attendance)
+              .where(
+                and(
+                  eq(attendance.roundId, currentRoundData.id),
+                  eq(attendance.memberId, currentMemberId),
+                ),
+              )
+              .limit(1)
+          : Promise.resolve([] as { status: string }[]),
+      ]);
 
       const statsMap = new Map(attendanceStats.map((s) => [s.status, s.count]));
-      const submitted = statsMap.get(AttendanceStatus.SUBMITTED) || 0;
-
-      // 활성 멤버 수를 기준으로 제출률 계산
-      const [activeMembersResult] = await database
-        .select({ count: count() })
-        .from(members)
-        .where(eq(members.status, MemberStatus.ACTIVE));
-      const totalActiveMembers = activeMembersResult?.count ?? 0;
-
-      // Get current user's attendance status for this round
-      let myAttendanceStatus: string | null = null;
-      if (currentMemberId) {
-        const [myAttendance] = await database
-          .select({ status: attendance.status })
-          .from(attendance)
-          .where(
-            and(
-              eq(attendance.roundId, currentRoundData.id),
-              eq(attendance.memberId, currentMemberId),
-            ),
-          )
-          .limit(1);
-        myAttendanceStatus = myAttendance?.status ?? null;
-      }
+      const submitted =
+        (statsMap.get(AttendanceStatus.SUBMITTED) || 0) +
+        (statsMap.get(AttendanceStatus.LATE) || 0);
 
       currentRound = {
         roundNumber: currentRoundData.roundNumber,
@@ -110,36 +126,9 @@ export async function GET() {
         isGracePeriod,
         submissionRate:
           totalActiveMembers > 0 ? Math.round((submitted / totalActiveMembers) * 100) : 0,
-        myAttendanceStatus,
+        myAttendanceStatus: myAttendanceRow[0]?.status ?? null,
       };
     }
-
-    // Get recent posts with member info
-    const recentPostsResult = await database
-      .select({
-        id: posts.id,
-        title: posts.title,
-        url: posts.url,
-        publishedAt: posts.publishedAt,
-        memberId: members.id,
-        memberName: members.name,
-        memberNickname: members.nickname,
-        memberDiscordUsername: members.discordUsername,
-        memberProfileImageUrl: members.profileImageUrl,
-      })
-      .from(posts)
-      .leftJoin(members, eq(posts.memberId, members.id))
-      .orderBy(desc(posts.publishedAt))
-      .limit(5);
-
-    // Get total active members count
-    const totalMembersResult = await database
-      .select({ count: count() })
-      .from(members)
-      .where(eq(members.status, MemberStatus.ACTIVE));
-
-    // Get total posts count
-    const totalPostsResult = await database.select({ count: count() }).from(posts);
 
     return successResponse({
       nickname: currentUserNickname,
@@ -155,7 +144,7 @@ export async function GET() {
         memberDiscordUsername: post.memberDiscordUsername,
         memberProfileImageUrl: post.memberProfileImageUrl,
       })),
-      totalMembers: totalMembersResult[0]?.count ?? 0,
+      totalMembers: totalActiveMembers,
       totalPosts: totalPostsResult[0]?.count ?? 0,
     });
   } catch (error) {

--- a/packages/web/src/app/api/posts/[id]/comments/[commentId]/route.ts
+++ b/packages/web/src/app/api/posts/[id]/comments/[commentId]/route.ts
@@ -4,6 +4,7 @@ import { getDb } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { getBoardAuth } from '@/lib/board-auth';
 import { errorResponse, Errors, successResponse } from '@/lib/api-error';
+import { sanitizeDescription } from '@/lib/sanitize';
 
 const { posts, postComments } = sharedDb;
 
@@ -38,16 +39,24 @@ export async function PATCH(
     }
 
     const body = await request.json();
-    const { content } = body;
+    const { content, isSecret } = body;
 
     if (!content?.trim()) {
       return Errors.badRequest('댓글 내용을 입력해주세요.').toResponse();
     }
 
+    if (content.trim().length > 5000) {
+      return Errors.badRequest('댓글은 5000자를 초과할 수 없습니다.').toResponse();
+    }
+
+    // isSecret 토글은 본인만 가능 (관리자도 타인 비밀 상태 변경 불가)
+    const canToggleSecret = isSecret !== undefined && existing.memberId === auth.memberId;
+
     const [updated] = await database
       .update(postComments)
       .set({
-        content: content.trim(),
+        content: sanitizeDescription(content.trim()),
+        ...(canToggleSecret && { isSecret }),
         updatedAt: new Date(),
       })
       .where(eq(postComments.id, commentId))

--- a/packages/web/src/app/api/posts/[id]/comments/route.ts
+++ b/packages/web/src/app/api/posts/[id]/comments/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, after } from 'next/server';
+import { after, NextRequest } from 'next/server';
 import { and, asc, eq, isNull, sql } from 'drizzle-orm';
 import { getDb } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
@@ -16,7 +16,7 @@ const { posts, postComments, members, ActivityScoreType } = sharedDb;
  * 블로그 글 댓글 목록 조회
  * - 인증 필요
  * - 삭제된 댓글도 포함 (isDeleted 플래그 + 내용 마스킹)
- * - 작성자 정보 + 관리자 여부 포함
+ * - 비밀댓글: 작성자/포스트작성자/관리자만 열람 가능
  */
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -26,6 +26,13 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     const { id: postId } = await params;
     const database = getDb();
 
+    // 포스트 작성자 조회 (비밀댓글 열람 권한 체크용)
+    const [post] = await database
+      .select({ memberId: posts.memberId })
+      .from(posts)
+      .where(eq(posts.id, postId))
+      .limit(1);
+
     const rows = await database
       .select({
         id: postComments.id,
@@ -33,6 +40,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
         memberId: postComments.memberId,
         parentId: postComments.parentId,
         content: postComments.content,
+        isSecret: postComments.isSecret,
         createdAt: postComments.createdAt,
         updatedAt: postComments.updatedAt,
         deletedAt: postComments.deletedAt,
@@ -51,23 +59,82 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
 
     const comments = rows.map((row) => {
       const isDeleted = row.deletedAt !== null;
+
+      if (isDeleted) {
+        return {
+          id: row.id,
+          postId: row.postId,
+          memberId: row.memberId,
+          parentId: row.parentId,
+          content: '삭제된 댓글입니다.',
+          isSecret: row.isSecret ?? false,
+          createdAt: row.createdAt,
+          updatedAt: row.updatedAt,
+          isDeleted: true,
+          isMasked: false,
+          isOwner: false,
+          member: {
+            name: '알 수 없음',
+            nickname: null,
+            discordUsername: '',
+            profileImageUrl: null,
+            discordId: '',
+            isAdmin: false,
+          },
+        };
+      }
+
+      // 비밀댓글 마스킹: 작성자/포스트작성자/관리자가 아니면 내용 숨김
+      const isSecretComment = row.isSecret ?? false;
+      const shouldMask =
+        isSecretComment &&
+        row.memberId !== auth.memberId &&
+        post?.memberId !== auth.memberId &&
+        !auth.isAdmin;
+
+      if (shouldMask) {
+        return {
+          id: row.id,
+          postId: row.postId,
+          memberId: row.memberId,
+          parentId: row.parentId,
+          content: '비밀 댓글입니다.',
+          isSecret: true,
+          createdAt: row.createdAt,
+          updatedAt: row.updatedAt,
+          isDeleted: false,
+          isMasked: true,
+          isOwner: false,
+          member: {
+            name: '익명',
+            nickname: null,
+            discordUsername: '',
+            profileImageUrl: null,
+            discordId: '',
+            isAdmin: false,
+          },
+        };
+      }
+
       return {
         id: row.id,
         postId: row.postId,
         memberId: row.memberId,
         parentId: row.parentId,
-        content: isDeleted ? '삭제된 댓글입니다.' : row.content,
+        content: row.content,
+        isSecret: isSecretComment,
         createdAt: row.createdAt,
         updatedAt: row.updatedAt,
-        isDeleted,
-        isOwner: !isDeleted && row.memberId === auth.memberId,
+        isDeleted: false,
+        isMasked: false,
+        isOwner: row.memberId === auth.memberId,
         member: {
-          name: isDeleted ? '알 수 없음' : row.memberName,
-          nickname: isDeleted ? null : row.memberNickname,
-          discordUsername: isDeleted ? '' : row.memberDiscordUsername,
-          profileImageUrl: isDeleted ? null : row.memberProfileImageUrl,
-          discordId: isDeleted ? '' : row.memberDiscordId,
-          isAdmin: isDeleted ? false : adminIds.includes(row.memberDiscordId),
+          name: row.memberName,
+          nickname: row.memberNickname,
+          discordUsername: row.memberDiscordUsername,
+          profileImageUrl: row.memberProfileImageUrl,
+          discordId: row.memberDiscordId,
+          isAdmin: adminIds.includes(row.memberDiscordId),
         },
       };
     });
@@ -82,8 +149,8 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
  * POST /api/posts/[id]/comments
  * 블로그 글 댓글 작성
  * - 인증 필요
- * - 글 존재 여부 확인
- * - commentCount 증가
+ * - 비밀댓글 지원 (isSecret)
+ * - 비밀댓글 답글 제한: 작성자/포스트작성자/관리자만
  */
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -103,16 +170,25 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
 
     const body = await request.json();
     const { content, parentId } = body;
+    let { isSecret } = body;
 
     if (!content?.trim()) {
       return Errors.badRequest('댓글 내용을 입력해주세요.').toResponse();
     }
 
-    // parentId 유효성 검증
-    let parent: { id: string; memberId: string } | null = null;
+    if (content.trim().length > 5000) {
+      return Errors.badRequest('댓글은 5000자를 초과할 수 없습니다.').toResponse();
+    }
+
+    // parentId 유효성 검증 + 비밀댓글 답글 제한
+    let parent: { id: string; memberId: string; isSecret: boolean | null } | null = null;
     if (parentId) {
       const [parentData] = await database
-        .select({ id: postComments.id, memberId: postComments.memberId })
+        .select({
+          id: postComments.id,
+          memberId: postComments.memberId,
+          isSecret: postComments.isSecret,
+        })
         .from(postComments)
         .where(
           and(
@@ -124,6 +200,16 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
         .limit(1);
       if (!parentData) return Errors.badRequest('상위 댓글을 찾을 수 없습니다.').toResponse();
       parent = parentData;
+
+      // 비밀댓글 답글: 작성자/포스트작성자/관리자만 가능 + 자동 비밀 처리
+      if (parent.isSecret) {
+        if (parent.memberId !== auth.memberId && post.memberId !== auth.memberId && !auth.isAdmin) {
+          return Errors.forbidden(
+            '비밀 댓글에는 작성자, 글 작성자, 관리자만 답글을 달 수 있습니다.'
+          ).toResponse();
+        }
+        isSecret = true;
+      }
     }
 
     const [newComment] = await database
@@ -132,7 +218,8 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
         postId,
         memberId: auth.memberId,
         parentId: parentId || null,
-        content: content.trim(),
+        content: sanitizeDescription(content.trim()),
+        isSecret: isSecret || false,
       })
       .returning();
 
@@ -141,8 +228,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       .set({ commentCount: sql`${posts.commentCount} + 1` })
       .where(eq(posts.id, postId));
 
-    // 포스트 댓글 활동 점수 (+5, 일일 상한 20)
-    // — 본인 글 제외, 같은 포스트에 이미 댓글 달았으면 제외 (포스트당 1회)
+    // 포스트 댓글 활동 점수
     if (post.memberId !== auth.memberId) {
       const priorComments = await database
         .select({ id: postComments.id })
@@ -156,7 +242,6 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
         )
         .limit(2);
 
-      // 방금 작성한 댓글 포함해서 1개뿐이면 = 첫 댓글 → 점수 부여
       if (priorComments.length <= 1) {
         after(async () => {
           try {
@@ -172,14 +257,20 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       }
     }
 
-    // 1. 내가 쓴 포스트에 댓글이 달리면 알림 (본인 제외, 답글 대상자와 중복 시 생략)
+    // 푸시 알림: 비밀댓글이면 내용 마스킹
+    const notificationBody =
+      isSecret || false
+        ? '비밀 댓글이 달렸습니다.'
+        : `${content.trim().slice(0, 50)}${content.length > 50 ? '...' : ''}`;
+
+    // 1. 포스트 작성자 알림 (본인 제외, 답글 대상자와 중복 시 생략)
     const isReplyToPostAuthor = parentId && parent && parent.memberId === post.memberId;
     if (post.memberId !== auth.memberId && !isReplyToPostAuthor) {
       after(async () => {
         try {
           await sendPushToMember(post.memberId, {
             title: '새 댓글이 달렸습니다',
-            body: `${content.trim().slice(0, 50)}${content.length > 50 ? '...' : ''}`,
+            body: notificationBody,
             clickUrl: `/posts/${postId}`,
             data: { type: 'post_comment', postId, commentId: newComment?.id ?? '' },
           });
@@ -194,13 +285,12 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       const pmid = parent.memberId;
       const amid = auth.memberId;
 
-      // 내 댓글에 답글이 달리면 알림 (작성자 본인 제외)
       if (pmid !== amid) {
         after(async () => {
           try {
             await sendPushToMember(pmid, {
               title: '💬 답글이 달렸습니다',
-              body: `${content.trim().slice(0, 50)}${content.length > 50 ? '...' : ''}`,
+              body: notificationBody,
               clickUrl: `/posts/${postId}`,
               data: { type: 'post_reply', postId, commentId: newComment?.id ?? '' },
             });

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -345,6 +345,11 @@
 .animate-marquee {
   animation: marquee 30s linear infinite;
 }
+@media (prefers-reduced-motion: reduce) {
+  .animate-marquee {
+    animation: none;
+  }
+}
 
 .landing-glow {
   background: radial-gradient(ellipse 60% 40% at 50% 0%, rgba(0, 85, 255, 0.15) 0%, transparent 70%);

--- a/packages/web/src/components/board/comment-tree.tsx
+++ b/packages/web/src/components/board/comment-tree.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { Lock, Reply, Pencil, Trash2, Loader2, Check, X } from 'lucide-react';
+import { Check, Loader2, Lock, Pencil, Reply, Trash2, X } from 'lucide-react';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -121,17 +121,14 @@ function InlineEditForm({ comment, onSaved, onCancel }: InlineEditFormProps) {
     setError(null);
 
     try {
-      const res = await fetch(
-        `/api/board/${comment.postId}/comments/${comment.id}`,
-        {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            content: editContent.trim(),
-            isSecret: editSecret,
-          }),
-        }
-      );
+      const res = await fetch(`/api/board/${comment.postId}/comments/${comment.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          content: editContent.trim(),
+          isSecret: editSecret,
+        }),
+      });
 
       const result = await res.json();
 
@@ -170,7 +167,6 @@ function InlineEditForm({ comment, onSaved, onCancel }: InlineEditFormProps) {
         rows={2}
         className="resize-none text-sm leading-relaxed focus-visible:ring-sky-500/30 focus-visible:border-sky-400 dark:focus-visible:border-sky-600"
         disabled={saving}
-        autoFocus
       />
 
       {error && <p className="text-xs text-destructive">{error}</p>}
@@ -261,20 +257,23 @@ function CommentItem({
   const canEdit = isOwner && !node.isDeleted && !node.isMasked;
   const canDelete = (isOwner || isAdmin) && !node.isDeleted;
   // 비밀댓글 답글: 본인/글작성자/관리자만 가능 (마스킹된 건 볼 수 없으므로 불가)
-  const canReply = !node.isDeleted && !node.isMasked && depth < 5
-    && (!node.isSecret || isOwner || isPostAuthor || isAdmin);
+  const canReply =
+    !node.isDeleted &&
+    !node.isMasked &&
+    depth < 5 &&
+    (!node.isSecret || isOwner || isPostAuthor || isAdmin);
 
   const displayName = node.isDeleted
     ? '알 수 없음'
     : node.isMasked
-    ? '익명'
-    : node.memberName || '알 수 없음';
+      ? '익명'
+      : node.memberName || '알 수 없음';
 
   const avatarSeed = node.isDeleted
     ? 'deleted'
     : node.isMasked
-    ? 'anonymous'
-    : node.memberDiscordId || node.memberName;
+      ? 'anonymous'
+      : node.memberDiscordId || node.memberName;
 
   // 시각적 인덴트: 최대 5단계, 단 깊은 뎁스는 좁은 간격 (모바일 깨짐 방지)
   const indentDepth = Math.min(depth, 5);
@@ -283,10 +282,9 @@ function CommentItem({
     e?.preventDefault();
     setDeleting(true);
     try {
-      const res = await fetch(
-        `/api/board/${node.postId}/comments/${node.id}`,
-        { method: 'DELETE' }
-      );
+      const res = await fetch(`/api/board/${node.postId}/comments/${node.id}`, {
+        method: 'DELETE',
+      });
       if (!res.ok) {
         const result = await res.json();
         console.error(result.message || '댓글 삭제에 실패했습니다.');
@@ -365,7 +363,6 @@ function CommentItem({
         {/* Reply form */}
         {replyOpen && !editing && (
           <div className="mt-2 mb-3 rounded-lg border border-border/50 bg-muted/20 p-2 sm:p-3 ml-9">
-
             <p className="text-xs font-medium text-muted-foreground mb-2">
               @{displayName}에게 답글
             </p>
@@ -493,12 +490,7 @@ function CommentContent({
               {displayName}
             </Link>
           ) : (
-            <span
-              className={cn(
-                'text-sm font-medium',
-                node.isDeleted && 'text-muted-foreground'
-              )}
-            >
+            <span className={cn('text-sm font-medium', node.isDeleted && 'text-muted-foreground')}>
               {displayName}
             </span>
           )}
@@ -531,8 +523,7 @@ function CommentContent({
             className={cn(
               'text-sm leading-relaxed break-words whitespace-pre-wrap',
               node.isDeleted && 'italic text-muted-foreground text-xs',
-              node.isMasked &&
-                'italic text-muted-foreground text-xs bg-muted/40 rounded px-2 py-1'
+              node.isMasked && 'italic text-muted-foreground text-xs bg-muted/40 rounded px-2 py-1'
             )}
           >
             {node.content}

--- a/packages/web/src/components/board/tiptap-editor.tsx
+++ b/packages/web/src/components/board/tiptap-editor.tsx
@@ -185,7 +185,10 @@ export function TiptapEditor({
     },
     editorProps: {
       handleDOMEvents: {
-        compositionstart: () => { composingRef.current = true; return false; },
+        compositionstart: () => {
+          composingRef.current = true;
+          return false;
+        },
         compositionend: (_view, event) => {
           composingRef.current = false;
           // event.target is the editor element; trigger deferred update
@@ -231,7 +234,9 @@ export function TiptapEditor({
               active={editor.isActive('paragraph') && !editor.isActive('heading')}
               title="본문"
             >
-              <span className="text-xs font-semibold w-4 h-4 flex items-center justify-center">T</span>
+              <span className="text-xs font-semibold w-4 h-4 flex items-center justify-center">
+                T
+              </span>
             </ToolbarButton>
             <ToolbarButton
               onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
@@ -360,7 +365,6 @@ export function TiptapEditor({
               value={linkUrl}
               onChange={(e) => setLinkUrl(e.target.value)}
               placeholder="https://example.com"
-              autoFocus
             />
             <DialogFooter className="mt-4">
               <Button

--- a/packages/web/src/components/landing/landing-client.tsx
+++ b/packages/web/src/components/landing/landing-client.tsx
@@ -2,12 +2,10 @@
 
 import Link from 'next/link';
 import {
-  Banknote,
   CalendarCheck,
   FileText,
   LogIn,
   MessageSquare,
-  Newspaper,
   Rss,
   TrendingUp,
   Trophy,
@@ -112,7 +110,7 @@ function Hero() {
         <FadeUp delay={0}>
           <div className="mb-8 inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-3.5 py-1.5 text-xs font-medium text-zinc-300">
             <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
-            큐스팅 4th 관리 플랫폼
+            큐스팅 4th 블로그 스터디
           </div>
         </FadeUp>
 
@@ -128,7 +126,9 @@ function Hero() {
         {/* Subtext */}
         <FadeUp delay={0.2}>
           <p className="mt-6 max-w-xl text-base leading-relaxed text-zinc-400 sm:text-lg">
-            글을 쓰면 봇이 수집하고, 출석을 관리하고, 대시보드에서 모든 활동을 한눈에 확인하세요.
+            혼자 쓰면 멈추게 되지만, 함께 쓰면 계속하게 돼요.
+            <br className="hidden sm:block" />
+            2주에 한 편, 서로의 글에 응원을 나누며 꾸준함을 만들어가는 스터디입니다.
           </p>
         </FadeUp>
 
@@ -139,13 +139,13 @@ function Hero() {
               href="/login"
               className="glow-button btn-gradient inline-flex items-center gap-2 rounded-xl px-8 py-3.5 text-sm font-semibold text-white"
             >
-              Discord로 시작하기
+              Discord로 참여하기
             </Link>
           </div>
         </FadeUp>
 
         <FadeUp delay={0.4}>
-          <p className="mt-3 text-xs text-zinc-400">무료 · 설정 5분 완료</p>
+          <p className="mt-3 text-xs text-zinc-400">Discord 계정만 있으면 바로 참여 가능</p>
         </FadeUp>
       </div>
     </section>
@@ -192,6 +192,224 @@ function StatsBar({ stats }: { stats: LandingStats }) {
   );
 }
 
+/** Mock UI 미리보기 — 포스트 피드 */
+function MockPosts() {
+  return (
+    <div className="mt-4 space-y-2">
+      {[
+        { name: 'alice', title: 'React 19의 새로운 기능 정리', comments: 3, views: 12 },
+        { name: 'bob', title: 'Docker 멀티스테이지 빌드 최적화', comments: 1, views: 8 },
+      ].map((p) => (
+        <div
+          key={p.name}
+          className="flex items-center gap-2.5 rounded-lg bg-white/[0.03] px-3 py-2"
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={`https://api.dicebear.com/9.x/fun-emoji/svg?seed=${p.name}`}
+            alt=""
+            width={24}
+            height={24}
+            className="rounded-full shrink-0"
+          />
+          <div className="min-w-0 flex-1">
+            <p className="text-xs text-white truncate">{p.title}</p>
+            <div className="flex items-center gap-2 text-[10px] text-zinc-500">
+              <span>{p.name}</span>
+              <span>💬 {p.comments}</span>
+              <span>👀 {p.views}</span>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Mock UI 미리보기 — 랭킹 & 활동 점수 */
+function MockRanking() {
+  const ranks = [
+    { rank: 1, name: 'alice', score: 420, medal: 'bg-amber-400' },
+    { rank: 2, name: 'bob', score: 385, medal: 'bg-slate-300' },
+    { rank: 3, name: 'charlie', score: 310, medal: 'bg-orange-400' },
+  ];
+  return (
+    <div className="mt-4 space-y-1.5">
+      {ranks.map((r) => (
+        <div
+          key={r.rank}
+          className="flex items-center gap-2.5 rounded-lg bg-white/[0.03] px-3 py-2"
+        >
+          <span
+            className={`h-5 w-5 rounded-full ${r.medal} flex items-center justify-center text-[10px] font-bold text-black`}
+          >
+            {r.rank}
+          </span>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={`https://api.dicebear.com/9.x/fun-emoji/svg?seed=${r.name}`}
+            alt=""
+            width={22}
+            height={22}
+            className="rounded-full"
+          />
+          <span className="text-xs text-white flex-1">{r.name}</span>
+          <span className="text-xs font-semibold text-blue-400 tabular-nums">{r.score}pt</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Mock UI 미리보기 — 활동 점수 */
+function MockScoreProgress() {
+  const items = [
+    { emoji: '📝', label: '블로그', earned: 10, cap: 10, full: true },
+    { emoji: '💬', label: '댓글', earned: 6, cap: 10, full: false },
+    { emoji: '📋', label: '게시판', earned: 3, cap: 5, full: false },
+    { emoji: '👀', label: '조회', earned: 10, cap: 10, full: true },
+  ];
+  return (
+    <div className="mt-4">
+      <div className="rounded-lg bg-white/[0.03] p-3 space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-[10px] text-zinc-500">오늘의 활동</span>
+          <span className="text-xs font-semibold text-blue-400">+29pt</span>
+        </div>
+        <div className="grid grid-cols-2 gap-1.5">
+          {items.map((item) => (
+            <div
+              key={item.label}
+              className="flex items-center gap-1.5 rounded bg-white/[0.02] px-2 py-1.5"
+            >
+              <span className="text-xs">{item.emoji}</span>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center justify-between">
+                  <span className="text-[10px] text-zinc-400">{item.label}</span>
+                  <span className="text-[9px] text-zinc-500">
+                    {item.earned}/{item.cap}
+                  </span>
+                </div>
+                <div className="mt-0.5 h-1 rounded-full bg-white/10 overflow-hidden">
+                  <div
+                    className={`h-full rounded-full ${item.full ? 'bg-emerald-400' : 'bg-blue-400'}`}
+                    style={{ width: `${(item.earned / item.cap) * 100}%` }}
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Mock UI 미리보기 — 커뮤니티 게시판 */
+function MockBoard() {
+  return (
+    <div className="mt-4 space-y-2">
+      <div className="rounded-lg bg-white/[0.03] p-3 space-y-2">
+        <div className="flex items-center gap-2">
+          <span className="rounded-full bg-blue-500/20 px-2 py-0.5 text-[10px] font-medium text-blue-400">
+            지식공유
+          </span>
+          <span className="text-xs text-white">Next.js 15 → 16 마이그레이션 팁</span>
+        </div>
+        <div className="flex items-center gap-2 ml-0.5">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src="https://api.dicebear.com/9.x/fun-emoji/svg?seed=dave"
+            alt=""
+            width={18}
+            height={18}
+            className="rounded-full"
+          />
+          <p className="text-[10px] text-zinc-400">오 저도 이거 때문에 삽질했는데...</p>
+        </div>
+      </div>
+      <div className="rounded-lg bg-white/[0.03] p-3">
+        <div className="flex items-center gap-2">
+          <span className="rounded-full bg-amber-500/20 px-2 py-0.5 text-[10px] font-medium text-amber-400">
+            일상
+          </span>
+          <span className="text-xs text-white">큐스팅 4기 시작 회식 🍻</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Mock UI 미리보기 — 스터디원 */
+function MockMembers() {
+  const ppl = [
+    { name: 'eve', part: 'FE', score: 280 },
+    { name: 'frank', part: 'BE', score: 195 },
+    { name: 'grace', part: 'AI', score: 150 },
+  ];
+  return (
+    <div className="mt-4">
+      <div className="flex gap-2">
+        {ppl.map((m) => (
+          <div
+            key={m.name}
+            className="flex-1 flex flex-col items-center gap-1.5 rounded-lg bg-white/[0.03] py-3 px-2"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={`https://api.dicebear.com/9.x/fun-emoji/svg?seed=${m.name}`}
+              alt=""
+              width={28}
+              height={28}
+              className="rounded-full"
+            />
+            <span className="text-[11px] text-white">{m.name}</span>
+            <span className="rounded-full bg-blue-500/15 px-1.5 py-0.5 text-[9px] font-medium text-blue-400">
+              {m.part}
+            </span>
+            <span className="text-[10px] text-zinc-500">{m.score}pt</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Mock UI 미리보기 — 대시보드 */
+function MockDashboard() {
+  return (
+    <div className="mt-4 space-y-2">
+      <div className="rounded-lg bg-white/[0.03] px-3 py-2">
+        <p className="text-xs text-white">☀️ 좋은 아침이에요, alice님</p>
+        <p className="text-[10px] text-zinc-500 mt-0.5">
+          ✍️ 완벽한 글은 없어요. 일단 쓰기 시작하면 그게 최고의 글이에요.
+        </p>
+      </div>
+      <div className="rounded-lg bg-white/[0.03] p-3 space-y-2.5">
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-medium text-white">3회차</span>
+          <span className="text-sm font-bold text-blue-400">D-5</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] text-zinc-500">나의 출석</span>
+          <span className="rounded-full bg-emerald-500/20 px-2 py-0.5 text-[10px] font-medium text-emerald-400">
+            ✓ 제출 완료
+          </span>
+        </div>
+        <div className="space-y-1">
+          <div className="flex items-center justify-between">
+            <span className="text-[10px] text-zinc-500">제출률</span>
+            <span className="text-[10px] font-medium text-white">75%</span>
+          </div>
+          <div className="h-1.5 rounded-full bg-white/10 overflow-hidden">
+            <div className="h-full w-3/4 rounded-full bg-gradient-to-r from-blue-500 to-blue-400" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function FeaturesBento() {
   return (
     <section className="px-6 py-24 sm:py-32">
@@ -199,35 +417,64 @@ function FeaturesBento() {
         {/* Section header */}
         <FadeUp>
           <div className="mb-14 text-center">
-            <h2 className="text-3xl font-bold tracking-tight text-white">
-              필요한 기능, 전부 갖췄습니다
-            </h2>
-            <p className="mt-3 text-base text-zinc-400">반복적인 스터디 운영 업무를 자동화하세요</p>
+            <h2 className="text-3xl font-bold tracking-tight text-white">이런 것들을 함께 해요</h2>
+            <p className="mt-3 text-base text-zinc-400">
+              글쓰기에만 집중하세요. 나머지는 알아서 돌아가요.
+            </p>
           </div>
         </FadeUp>
 
         <StaggerContainer className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {[
-            { icon: Rss, title: 'RSS 자동 수집', desc: '블로그 글 발행 시 자동 감지 및 수집' },
+            {
+              icon: TrendingUp,
+              title: '나만의 대시보드',
+              desc: '내 현황을 한눈에 확인',
+              mock: <MockDashboard />,
+            },
             {
               icon: Trophy,
               title: '랭킹 & 활동 점수',
-              desc: '글 작성·댓글·출석 등 활동 기반 점수 시스템',
+              desc: '글 쓰고, 댓글 달고, 점수 쌓기',
+              mock: <MockRanking />,
             },
-            { icon: CalendarCheck, title: '출석 자동화', desc: '2주 1회차, 지각·결석 자동 판정' },
+            {
+              icon: FileText,
+              title: '포스트 피드',
+              desc: '스터디원들의 글을 모아서',
+              mock: <MockPosts />,
+            },
+            {
+              icon: CalendarCheck,
+              title: '활동 점수',
+              desc: '쓰고, 읽고, 댓글 달면 점수 적립',
+              mock: <MockScoreProgress />,
+            },
             {
               icon: MessageSquare,
-              title: '커뮤니티 게시판',
-              desc: 'Tiptap 에디터, 댓글, 비밀글 지원',
+              title: '자유 게시판',
+              desc: '후기, 건의, 지식 공유',
+              mock: <MockBoard />,
             },
-            { icon: Banknote, title: '벌금 관리', desc: '자동 부과, DM 알림, 납부 확인' },
-            { icon: Newspaper, title: '큐레이션', desc: '관심 키워드 기반 아티클·컨퍼런스 추천' },
-          ].map(({ icon: Icon, title, desc }) => (
+            {
+              icon: Rss,
+              title: '함께하는 스터디원',
+              desc: '다양한 분야의 사람들과',
+              mock: <MockMembers />,
+            },
+          ].map(({ icon: Icon, title, desc, mock }) => (
             <StaggerItem key={title}>
-              <div className="bento-card rounded-2xl p-6">
-                <Icon className="h-8 w-8 text-blue-400" strokeWidth={1.5} />
-                <h3 className="mt-4 mb-2 text-base font-semibold text-white">{title}</h3>
-                <p className="text-sm leading-relaxed text-zinc-400">{desc}</p>
+              <div className="bento-card rounded-2xl p-5 flex flex-col">
+                <div className="flex items-center gap-3">
+                  <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-blue-500/10 border border-blue-500/20">
+                    <Icon className="h-4.5 w-4.5 text-blue-400" strokeWidth={1.5} />
+                  </div>
+                  <div>
+                    <h3 className="text-sm font-semibold text-white">{title}</h3>
+                    <p className="text-[11px] text-zinc-500">{desc}</p>
+                  </div>
+                </div>
+                {mock}
               </div>
             </StaggerItem>
           ))}
@@ -324,11 +571,16 @@ function AvatarMarquee() {
 function FinalCTA() {
   return (
     <section className="relative overflow-hidden px-6 py-24 sm:py-32 text-center">
-      <div className="landing-glow-bottom absolute inset-0 pointer-events-none" aria-hidden="true" />
+      <div
+        className="landing-glow-bottom absolute inset-0 pointer-events-none"
+        aria-hidden="true"
+      />
 
       <div className="relative z-10 mx-auto max-w-2xl">
         <FadeUp delay={0}>
-          <h2 className="text-3xl font-bold tracking-tight gradient-text">지금 바로 시작하세요.</h2>
+          <h2 className="text-3xl font-bold tracking-tight gradient-text">
+            함께 글쓰기, 시작해볼까요?
+          </h2>
         </FadeUp>
 
         <FadeUp delay={0.1}>
@@ -337,7 +589,7 @@ function FinalCTA() {
               href="/login"
               className="glow-button btn-gradient inline-flex items-center gap-2 rounded-xl px-8 py-3.5 text-sm font-semibold text-white"
             >
-              Discord로 시작하기
+              Discord로 참여하기
             </Link>
           </div>
         </FadeUp>


### PR DESCRIPTION
## Summary
- 포스트 댓글에 **비밀댓글(isSecret)** 기능 추가 (스키마/API/UI, 게시판과 동일)
- 대시보드 현재 회차 카드에 **나의 출석 상태 칩** 표시
- 포스트 상세 페이지(`/posts/[id]`) 댓글 시스템 **전면 개편** (답글/수정/삭제/트리구조)
- 랜딩 페이지 **mock UI 미리보기** + 커뮤니티 톤 전환
- 전역 **autoFocus 제거** (PWA/모바일 키보드 UX)
- 대시보드 API **쿼리 병렬화** (Promise.all, ~30ms 절감)
- 제출률에 **LATE 포함** (SUBMITTED + LATE)
- 보안: 댓글 **sanitizeDescription** 적용 + **5000자 제한** + isSecret PATCH 본인만 변경
- 접근성: textarea **aria-label**, placeholder **엘립시스(…)**, marquee **reduced-motion**
- 문서 최신화 (CLAUDE.md, README, ARCHITECTURE, schema-summary)

## Changes
| 영역 | 파일 | 변경 |
|------|------|------|
| Schema | `schema.ts` | `postComments.is_secret` 컬럼 추가 |
| API | `posts/[id]/comments/route.ts` | 비밀댓글 마스킹/생성/답글제한/푸시마스킹 |
| API | `posts/[id]/comments/[commentId]/route.ts` | isSecret PATCH (본인만) + sanitize + 5000자 |
| API | `dashboard/route.ts` | myAttendanceStatus 추가 + Promise.all 병렬화 + LATE 포함 |
| UI | `posts/[id]/page.tsx` | 댓글 전면 개편 (MemberAvatar, 비밀댓글, 답글, AlertDialog) |
| UI | `posts/page.tsx` | 비밀댓글 토글/뱃지/마스킹 추가 |
| UI | `dashboard/page.tsx` | 출석 상태 칩 + IIFE→derived variable |
| UI | `landing-client.tsx` | mock UI 미리보기 6개 + 커뮤니티 톤 |
| UX | 6 files | autoFocus 제거 |
| A11y | CSS + TSX | marquee reduced-motion, aria-label, placeholder … |
| Docs | 4 files | CLAUDE.md, README, ARCHITECTURE, schema-summary |

## Test plan
- [ ] 대시보드: 출석 칩 표시 확인 (SUBMITTED/LATE/PENDING/ABSENT)
- [ ] 포스트 댓글: 비밀댓글 작성 → 다른 유저에게 마스킹 확인
- [ ] 포스트 댓글: 비밀댓글 답글 → 자동 비밀 처리 확인
- [ ] 포스트 상세(`/posts/[id]`): 답글/수정/삭제/트리구조 확인
- [ ] 푸시 알림: 비밀댓글 시 내용 마스킹 확인
- [ ] 랜딩 페이지: mock UI 카드 6개 렌더링 확인
- [ ] PWA 모바일: 입력 필드 포커스 안 잡히는 것 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)