### PR TITLE
feat(web): 스터디원 OB/휴면 표시 + 포스트 삭제 기능

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,8 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 - **백그라운드 작업**: API route에서 푸시 알림/점수 부여 등 fire-and-forget 작업은 `after()` from `next/server` 사용 (Vercel 서버리스 종료 방지)
 - **비밀댓글 알림**: 비밀댓글(`isSecret`)의 푸시 알림은 내용 마스킹 (`'비밀 댓글이 달렸습니다.'`), 포스트/게시판 댓글 모두 적용
 - **비밀댓글 isSecret 토글**: PATCH 시 본인만 변경 가능 (관리자도 타인 비밀 상태 변경 불가)
+- **포스트 삭제**: 본인 또는 관리자만 가능, 트랜잭션으로 댓글/조회기록/활동점수(blog_post) 일괄 삭제
+- **스터디원 목록**: active + dormant + ob 모두 표시, 상태 칩으로 구분 (OB: 황금 파스텔, 휴면: secondary)
 
 ## 핵심 파일 위치
 
@@ -107,6 +109,7 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 | `packages/web/src/app/(admin)/admin/bot-operations/page.tsx` | 봇 수동 실행 대시보드 (관리자 전용) |
 | `packages/web/src/app/api/admin/bot-operations/[operationId]/route.ts` | 봇 작업 트리거 프록시 (web → bot HTTP API, 30s 타임아웃) |
 | `packages/web/src/app/(admin)/admin/rounds/page.tsx` | 회차 관리 페이지 (CRUD + 현재 회차 설정) |
+| `packages/web/src/app/api/posts/[id]/route.ts` | 포스트 삭제 API (본인/관리자, 댓글+조회+점수 일괄 삭제) |
 | `packages/web/src/app/api/profile/withdraw/route.ts` | 유저 자체 탈퇴 API |
 | `packages/web/src/lib/firebase/admin.ts` | Firebase Admin SDK (lazy 초기화, `getAdminMessaging()`) |
 | `packages/web/src/lib/firebase/client.ts` | Firebase 클라이언트 (FCM 토큰 요청, 포그라운드 메시지) |
@@ -152,7 +155,7 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 | `pending_approval` | 차단 (`/pending`) | 제외 | 온보딩 후 기본 상태 |
 | `active` | 허용 | 대상 | 관리자 승인 시 전환 |
 | `inactive` | 차단 (`/inactive`) | 제외 | |
-| `dormant` | 허용 | 제외 | 1회 사용 가능 |
+| `dormant` | 허용 | 제외 | 관리자가 반복 전환 가능 (1회 제한 해제됨) |
 | `ob` | 허용 | 제외 | 관리자 승인 시 선택 가능 |
 | `withdrawn` | 차단 | 제외 | soft delete |
 

--- a/packages/web/src/app/(user)/members/page.tsx
+++ b/packages/web/src/app/(user)/members/page.tsx
@@ -7,9 +7,11 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { PART_OPTIONS } from '@/lib/part-config';
-import { getDefaultAvatar } from '@/lib/utils';
+import { cn, getDefaultAvatar } from '@/lib/utils';
 import { MembersListSkeleton, PageError } from '@/components/ui/page-state';
 import { PartBadge } from '@/components/ui/part-badge';
+import { Badge } from '@/components/ui/badge';
+import { MEMBER_STATUS_CONFIG } from '@/lib/member-config';
 
 interface Member {
   id: string;
@@ -43,7 +45,7 @@ export default function MembersPage() {
   useEffect(() => {
     const fetchMembers = async () => {
       try {
-        const response = await fetch('/api/members?status=active');
+        const response = await fetch('/api/members?status=active,dormant,ob');
         if (!response.ok) {
           throw new Error('Failed to fetch members');
         }
@@ -146,7 +148,20 @@ export default function MembersPage() {
                       </AvatarFallback>
                     </Avatar>
                     <div className="min-w-0 flex-1">
-                      <p className="truncate text-sm font-semibold">{member.nickname}</p>
+                      <div className="flex items-center gap-1.5">
+                        <p className="truncate text-sm font-semibold">{member.nickname}</p>
+                        {member.status !== 'active' && (
+                          <Badge
+                            variant={member.status === 'ob' ? 'outline' : (MEMBER_STATUS_CONFIG[member.status]?.variant ?? 'secondary')}
+                            className={cn(
+                              'h-4 px-1.5 text-[10px] font-medium shrink-0',
+                              member.status === 'ob' && 'border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
+                            )}
+                          >
+                            {MEMBER_STATUS_CONFIG[member.status]?.label ?? member.status}
+                          </Badge>
+                        )}
+                      </div>
                       <div className="flex items-center gap-1.5">
                         <p className="truncate text-xs text-muted-foreground">
                           @{member.discordUsername.replace(/#0$/, '')}

--- a/packages/web/src/app/(user)/posts/page.tsx
+++ b/packages/web/src/app/(user)/posts/page.tsx
@@ -117,6 +117,8 @@ interface Post {
 
 interface PostsData {
   posts: Post[];
+  currentMemberId: string | null;
+  isAdmin: boolean;
   pagination: {
     page: number;
     pageSize: number;
@@ -802,11 +804,15 @@ function PostCard({
   post,
   onView,
   onCommentCountChange,
+  onDelete,
+  canDelete,
   rank,
 }: {
   post: Post;
   onView: (id: string) => void;
   onCommentCountChange: (postId: string, delta: number) => void;
+  onDelete: (postId: string) => void;
+  canDelete: boolean;
   rank?: number; // 1, 2, 3 for medal styling
 }) {
   const authorName = post.memberNickname || post.memberDiscordUsername;
@@ -819,6 +825,8 @@ function PostCard({
   const [newCommentSecret, setNewCommentSecret] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [showComments, setShowComments] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   const fetchComments = useCallback(async () => {
     try {
@@ -837,6 +845,25 @@ function PostCard({
       fetchComments();
     }
   }, [showComments, commentsLoaded, fetchComments]);
+
+  const handleDeletePost = async () => {
+    setDeleting(true);
+    try {
+      const res = await fetch(`/api/posts/${post.id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const result = await res.json();
+        toast.error(result.error?.message || '삭제에 실패했습니다.');
+        return;
+      }
+      toast.success('포스트가 삭제되었습니다.');
+      setDeleteOpen(false);
+      onDelete(post.id);
+    } catch {
+      toast.error('서버 오류가 발생했습니다.');
+    } finally {
+      setDeleting(false);
+    }
+  };
 
   const handleSubmitComment = async () => {
     if (!newComment.trim()) return;
@@ -988,7 +1015,51 @@ function PostCard({
             <MessageCircle className="h-3.5 w-3.5" />
             <span className="tabular-nums">{post.commentCount}</span>
           </button>
+
+          {canDelete && (
+            <button
+              onClick={() => setDeleteOpen(true)}
+              aria-label="포스트 삭제"
+              className="ml-auto flex items-center gap-1 rounded-md p-1.5 text-xs text-destructive hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          )}
         </div>
+
+        {/* 삭제 확인 다이얼로그 */}
+        <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+          <AlertDialogContent className="max-w-sm">
+            <AlertDialogHeader>
+              <AlertDialogTitle className="text-base">포스트를 삭제하시겠습니까?</AlertDialogTitle>
+              <AlertDialogDescription className="text-sm text-muted-foreground">
+                삭제된 포스트는 복구할 수 없습니다. 댓글, 조회 기록, 활동 점수도 함께 삭제됩니다.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={deleting} className="h-9 text-sm">
+                취소
+              </AlertDialogCancel>
+              <AlertDialogAction
+                onClick={(e) => {
+                  e.preventDefault(); // Radix auto-close 방지 — deleting 스피너 표시 위해 수동 제어
+                  handleDeletePost();
+                }}
+                disabled={deleting}
+                className="h-9 text-sm bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+              >
+                {deleting ? (
+                  <span className="flex items-center gap-1.5">
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    삭제 중...
+                  </span>
+                ) : (
+                  '삭제하기'
+                )}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
 
         {/* Comments section (게시판 스타일) */}
         {showComments && (
@@ -1097,6 +1168,8 @@ function PostsContent() {
 
   const [tab, setTab] = useState<TabType>(initialTab);
   const [posts, setPosts] = useState<Post[]>([]);
+  const [currentMemberId, setCurrentMemberId] = useState<string | null>(null);
+  const [isAdmin, setIsAdmin] = useState(false);
   const [totalCount, setTotalCount] = useState(0);
   const [hasMore, setHasMore] = useState(false);
   const [page, setPage] = useState(1);
@@ -1145,6 +1218,9 @@ function PostsContent() {
         if (!response.ok) throw new Error('Failed to fetch posts');
         const result = await response.json();
         const data = result.data as PostsData;
+
+        setCurrentMemberId(data.currentMemberId);
+        setIsAdmin(data.isAdmin);
 
         if (append) {
           setPosts((prev) => {
@@ -1216,6 +1292,11 @@ function PostsContent() {
         p.id === postId ? { ...p, commentCount: Math.max(0, p.commentCount + delta) } : p
       )
     );
+  };
+
+  const handleDeletePost = (postId: string) => {
+    setPosts((prev) => prev.filter((p) => p.id !== postId));
+    setTotalCount((prev) => prev - 1);
   };
 
   const resetDialog = () => {
@@ -1515,6 +1596,8 @@ function PostsContent() {
                 post={post}
                 onView={trackPostView}
                 onCommentCountChange={handleCommentCountChange}
+                onDelete={handleDeletePost}
+                canDelete={isAdmin || post.memberId === currentMemberId}
                 rank={tab === 'popular' ? index + 1 : undefined}
               />
             ))}

--- a/packages/web/src/app/api/admin/members/[id]/route.ts
+++ b/packages/web/src/app/api/admin/members/[id]/route.ts
@@ -127,16 +127,8 @@ export const PUT = withAdminAuth(async (request: NextRequest, _adminAuth) => {
     if (blogUrl !== undefined) updateData.blogUrl = blogUrl.trim();
     if (rssUrl !== undefined) updateData.rssUrl = rssUrl?.trim() || null;
     if (status !== undefined) {
-      // 휴면 전환 시 전용 로직
+      // 휴면 전환 시 전용 로직 (1회 제한 해제됨 — 관리자가 필요에 따라 반복 전환 가능)
       if (status === MemberStatus.DORMANT) {
-        // 이미 휴면을 사용한 멤버는 재사용 불가 (1회 제한)
-        if (existingMember.dormantUsed) {
-          return NextResponse.json(
-            { message: '이미 휴면을 사용한 멤버입니다. (1회 제한)' },
-            { status: 400 }
-          );
-        }
-
         // 현재 회차 조회
         const [currentRound] = await database
           .select()

--- a/packages/web/src/app/api/members/route.ts
+++ b/packages/web/src/app/api/members/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server';
-import { count, eq, sql } from 'drizzle-orm';
+import { count, eq, inArray, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { createClient } from '@/lib/supabase/server';
@@ -7,7 +7,7 @@ import { errorResponse, Errors, successResponse, withCache } from '@/lib/api-err
 
 const { members, posts, attendance, AttendanceStatus } = sharedDb;
 
-const ALLOWED_STATUSES = ['active', 'dormant'];
+const ALLOWED_STATUSES = ['active', 'dormant', 'ob'];
 
 /**
  * GET /api/members
@@ -25,16 +25,21 @@ export async function GET(request: NextRequest) {
     }
 
     const { searchParams } = new URL(request.url);
-    const status = searchParams.get('status') || 'active';
+    const statusParam = searchParams.get('status') || 'active';
 
-    if (!ALLOWED_STATUSES.includes(status)) {
+    // 쉼표 구분으로 복수 상태 지원: ?status=active,dormant,ob
+    const statuses = statusParam.split(',').map((s) => s.trim()).filter(Boolean);
+    if (statuses.some((s) => !ALLOWED_STATUSES.includes(s))) {
       return Errors.badRequest('유효하지 않은 상태입니다.').toResponse();
     }
 
     const database = db();
 
-    // Get members by status
-    const membersList = await database.select().from(members).where(eq(members.status, status));
+    // Get members by status(es)
+    const membersList = await database
+      .select()
+      .from(members)
+      .where(statuses.length === 1 ? eq(members.status, statuses[0]!) : inArray(members.status, statuses));
 
     // Get post counts for all members
     const postCounts = await database

--- a/packages/web/src/app/api/posts/[id]/route.ts
+++ b/packages/web/src/app/api/posts/[id]/route.ts
@@ -1,0 +1,99 @@
+import { eq, and, like } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { db as sharedDb } from '@blog-study/shared';
+import { createClient } from '@/lib/supabase/server';
+import { errorResponse, Errors, successResponse } from '@/lib/api-error';
+import { isAdminDiscordId } from '@/lib/admin';
+
+const { posts, members, postComments, postViews, activityScores, ActivityScoreType } = sharedDb;
+
+/**
+ * DELETE /api/posts/[id]
+ * 포스트 삭제 (본인 또는 관리자만)
+ * - 관련 댓글, 조회 기록, 활동 점수(blog_post) 함께 삭제
+ */
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: postId } = await params;
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return Errors.unauthorized().toResponse();
+    }
+
+    const discordIdentity = user.identities?.find((i) => i.provider === 'discord');
+    const discordId = discordIdentity?.id as string | undefined;
+    if (!discordId) {
+      return Errors.unauthorized('Discord 계정 정보를 찾을 수 없습니다.').toResponse();
+    }
+
+    const database = db();
+
+    // 포스트 조회
+    const [post] = await database
+      .select({
+        id: posts.id,
+        memberId: posts.memberId,
+        title: posts.title,
+        url: posts.url,
+      })
+      .from(posts)
+      .where(eq(posts.id, postId))
+      .limit(1);
+
+    if (!post) {
+      return Errors.notFound('포스트를 찾을 수 없습니다.').toResponse();
+    }
+
+    // 권한 체크: 본인 또는 관리자
+    const [member] = await database
+      .select({ id: members.id, discordId: members.discordId })
+      .from(members)
+      .where(eq(members.id, post.memberId))
+      .limit(1);
+
+    const isOwner = member?.discordId === discordId;
+    const isAdmin = await isAdminDiscordId(discordId);
+
+    if (!isOwner && !isAdmin) {
+      return Errors.forbidden('삭제 권한이 없습니다.').toResponse();
+    }
+
+    // 트랜잭션으로 일괄 삭제
+    await database.transaction(async (tx) => {
+      // 1. 댓글 삭제
+      await tx.delete(postComments).where(eq(postComments.postId, postId));
+
+      // 2. 조회 기록 삭제
+      await tx.delete(postViews).where(eq(postViews.postId, postId));
+
+      // 3. blog_post 점수 회수
+      // 봇: "블로그 포스트: {title(특수문자 제거, 200자)}", 수동: "블로그 포스트: {title(200자)}"
+      // LIKE로 제목 앞 50자 prefix 매칭 (봇/수동 포맷 차이 대응)
+      const titlePrefix = post.title.replace(/[%_\\]/g, '\\$&').slice(0, 50);
+      await tx
+        .delete(activityScores)
+        .where(
+          and(
+            eq(activityScores.memberId, post.memberId),
+            eq(activityScores.type, ActivityScoreType.BLOG_POST),
+            like(activityScores.description, `블로그 포스트: ${titlePrefix}%`)
+          )
+        );
+
+      // 4. 포스트 삭제
+      await tx.delete(posts).where(eq(posts.id, postId));
+    });
+
+    return successResponse({ deleted: true });
+  } catch (error) {
+    console.error('Post delete error:', error);
+    return errorResponse(error);
+  }
+}

--- a/packages/web/src/app/api/posts/route.ts
+++ b/packages/web/src/app/api/posts/route.ts
@@ -10,6 +10,7 @@ import {
   successResponse,
 } from '@/lib/api-error';
 import { createClient } from '@/lib/supabase/server';
+import { isAdminDiscordId } from '@/lib/admin';
 
 const { posts, members, rounds, postViews } = sharedDb;
 
@@ -28,6 +29,10 @@ export async function GET(request: NextRequest) {
     if (authError || !user) {
       return Errors.unauthorized().toResponse();
     }
+
+    // 현재 유저의 discordId → memberId 조회
+    const discordIdentity = user.identities?.find((i) => i.provider === 'discord');
+    const currentDiscordId = discordIdentity?.id as string | undefined;
 
     const { searchParams } = new URL(request.url);
     const { page, pageSize, offset } = parsePagination(searchParams);
@@ -179,6 +184,19 @@ export async function GET(request: NextRequest) {
       }
     }
 
+    // 현재 유저의 memberId + 관리자 여부 조회
+    let currentMemberId: string | null = null;
+    let isAdmin = false;
+    if (currentDiscordId) {
+      const [currentMember] = await database
+        .select({ id: members.id })
+        .from(members)
+        .where(eq(members.discordId, currentDiscordId))
+        .limit(1);
+      currentMemberId = currentMember?.id ?? null;
+      isAdmin = await isAdminDiscordId(currentDiscordId);
+    }
+
     return successResponse({
       posts: postsResult.map((post) => ({
         id: post.id,
@@ -199,6 +217,8 @@ export async function GET(request: NextRequest) {
         viewers: (viewersMap.get(post.id) ?? []).slice(0, 3),
         totalViewers: viewCountMap.get(post.id) ?? 0,
       })),
+      currentMemberId,
+      isAdmin,
       pagination: createPaginationMeta(page, pageSize, totalCount),
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- 스터디원 목록에 active/dormant/ob 전체 표시, 상태 칩 추가 (OB: 황금 파스텔, 휴면: secondary)
- 포스트 삭제 API (`DELETE /api/posts/[id]`) — 본인/관리자만 가능, 트랜잭션으로 댓글+조회기록+활동점수(blog_post) 일괄 삭제
- 포스트 카드에 빨간 휴지통 버튼 (hover 없이 항상 노출, 본인/관리자만)
- 관리자 휴면 전환 1회 제한 해제

## Changed Files
| 파일 | 변경 |
|------|------|
| `api/members/route.ts` | 복수 상태 쿼리 지원 (`?status=active,dormant,ob`) |
| `(user)/members/page.tsx` | 상태 칩 UI (OB 황금, 휴면 secondary) |
| `api/posts/[id]/route.ts` | **NEW** 포스트 삭제 API |
| `api/posts/route.ts` | `currentMemberId`, `isAdmin` 응답 추가 |
| `(user)/posts/page.tsx` | 삭제 버튼 + 확인 다이얼로그 |
| `api/admin/members/[id]/route.ts` | 휴면 1회 제한 해제 |
| `CLAUDE.md` | 문서 최신화 |

## Test plan
- [ ] 스터디원 목록에서 OB/휴면 멤버가 상태 칩과 함께 표시되는지 확인
- [ ] 내 포스트에 빨간 휴지통 버튼이 보이는지 확인
- [ ] 타인 포스트에는 휴지통 버튼이 안 보이는지 확인
- [ ] 관리자 계정으로 타인 포스트 삭제 가능한지 확인
- [ ] 포스트 삭제 시 댓글/조회기록/활동점수가 함께 삭제되는지 확인
- [ ] 관리자 페이지에서 멤버 휴면 전환이 반복 가능한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)