### PR TITLE
style(web): PC 공지 배너 콘텐츠 영역 내부로 이동

### DIFF
--- a/packages/web/src/components/layout/main-layout.tsx
+++ b/packages/web/src/components/layout/main-layout.tsx
@@ -28,10 +28,12 @@ function MainContent({
   children,
   showSidebar,
   collapsed,
+  isAdmin,
 }: {
   children: React.ReactNode;
   showSidebar: boolean;
   collapsed: boolean;
+  isAdmin: boolean;
 }) {
   return (
     <main
@@ -45,9 +47,12 @@ function MainContent({
     >
       <div
         data-ptr-scroll="true"
-        className="w-full h-full overflow-y-auto px-4 sm:px-6 lg:px-8 py-6 max-w-7xl mx-auto"
+        className="w-full h-full overflow-y-auto"
       >
-        {children}
+        {!isAdmin && <NoticeBanner />}
+        <div className="px-4 sm:px-6 lg:px-8 py-6 max-w-7xl mx-auto">
+          {children}
+        </div>
       </div>
     </main>
   );
@@ -95,7 +100,6 @@ export function MainLayout({
         본문으로 바로가기
       </a>
       <Header user={user} isAdmin={isAdmin} onLogout={handleLogout} />
-      {!isAdmin && <NoticeBanner />}
       <PullToRefresh>
         <div className="flex flex-1 min-h-0 overflow-hidden">
           {showSidebar && (
@@ -105,7 +109,7 @@ export function MainLayout({
               onToggleCollapsed={handleToggleCollapsed}
             />
           )}
-          <MainContent showSidebar={showSidebar} collapsed={collapsed}>
+          <MainContent showSidebar={showSidebar} collapsed={collapsed} isAdmin={isAdmin}>
             {children}
           </MainContent>
         </div>


### PR DESCRIPTION
## Summary
- PC에서 공지 배너가 사이드바+콘텐츠 전체 너비에 걸쳐 애매하게 표시되던 레이아웃을 수정
- 태블릿/모바일과 동일하게 OVERVIEW 위 콘텐츠 영역 내부에 배치

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `packages/web/src/components/layout/main-layout.tsx` | `NoticeBanner`를 `MainLayout` 루트에서 `MainContent` 내부로 이동, `isAdmin` prop 전달 |

## Design Decisions
| 결정 | 이유 |
|------|------|
| `NoticeBanner`를 `MainContent` 스크롤 영역 안에 배치 | 사이드바와 분리하여 콘텐츠 영역에만 표시, 모바일/태블릿 뷰와 일관성 유지 |
| 스크롤 컨테이너와 패딩 컨테이너 분리 | 배너는 콘텐츠 max-width와 무관하게 전체 너비, children은 기존 패딩 유지 |

## Test Plan
- [ ] PC(lg 이상)에서 공지 배너가 OVERVIEW 바로 위에 표시되는지 확인
- [ ] 태블릿/모바일에서 기존과 동일하게 동작하는지 확인
- [ ] 배너 접기/닫기 동작 정상 확인
- [ ] 관리자 모드에서 배너 미표시 확인
- [ ] 다크모드에서 배너 스타일 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)