### PR TITLE
chore(bot): RSS 수집 시작일을 3/23으로 변경

### DIFF
--- a/packages/bot/src/scheduler-registry.ts
+++ b/packages/bot/src/scheduler-registry.ts
@@ -67,8 +67,8 @@ export async function registerAllJobs(boss: PgBoss, client: Client): Promise<voi
   const attendanceService = getAttendanceService();
   const fineService = getFineService();
 
-  // 2025-07-01 이후 발행된 글만 수집
-  const POST_CUTOFF_DATE = new Date('2026-03-15T00:00:00+09:00');
+  // 2026-03-23 이후 발행된 글만 수집
+  const POST_CUTOFF_DATE = new Date('2026-03-23T00:00:00+09:00');
 
   rssPoller.setOnNewPostCallback(async (member, items) => {
     const currentRound = await getCurrentRound().catch(() => null);


### PR DESCRIPTION
## Summary
- RSS 수집 cutoff 날짜를 `2026-03-15` → `2026-03-23`으로 변경
- 주석도 실제 값에 맞게 수정

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `packages/bot/src/scheduler-registry.ts` | `POST_CUTOFF_DATE`를 3/23 KST로 변경, 주석 업데이트 |

## Test Plan
- [x] 봇 빌드 정상 확인
- [x] RSS 수집 시 3/23 이전 글 필터링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)