### PR TITLE
feat(web): 게시글당 투표 여러 개 생성 가능하도록 제한 해제

### DIFF
--- a/packages/web/src/components/board/poll-editor.tsx
+++ b/packages/web/src/components/board/poll-editor.tsx
@@ -2,16 +2,12 @@
 
 import { useState } from 'react';
 import { toast } from 'sonner';
-import { Plus, Trash2, BarChart3, Calendar, Clock, Edit2, Check, Lock } from 'lucide-react';
+import { BarChart3, Calendar, Check, Clock, Edit2, Lock, Plus, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Calendar as CalendarComponent } from '@/components/ui/calendar';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 
@@ -60,14 +56,9 @@ export function PollEditor({ polls, onPollsChange }: PollEditorProps) {
   const [dateOptions, setDateOptions] = useState<Date[]>([]);
   const [datePickerOpen, setDatePickerOpen] = useState(false);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [formOpen, setFormOpen] = useState(false);
 
   const handleAddPoll = () => {
-    // Check if poll already exists
-    if (polls.length >= 1) {
-      toast.error('게시글당 투표는 1개만 생성할 수 있습니다.');
-      return;
-    }
-
     // Validation
     if (!newPoll.question?.trim()) {
       toast.error('질문을 입력해주세요.');
@@ -89,7 +80,7 @@ export function PollEditor({ polls, onPollsChange }: PollEditorProps) {
       // Format dates as strings
       finalOptions = dateOptions
         .sort((a, b) => a.getTime() - b.getTime())
-        .map(date => format(date, 'yyyy-MM-dd'));
+        .map((date) => format(date, 'yyyy-MM-dd'));
     } else {
       const validOptions = options.filter((opt) => opt.trim());
       if (validOptions.length < 2) {
@@ -125,6 +116,7 @@ export function PollEditor({ polls, onPollsChange }: PollEditorProps) {
     });
     setOptions(['', '']);
     setDateOptions([]);
+    setFormOpen(false);
   };
 
   const handleRemovePoll = (index: number) => {
@@ -145,12 +137,14 @@ export function PollEditor({ polls, onPollsChange }: PollEditorProps) {
 
     // Set options based on poll type
     if (poll.pollType === 'date') {
-      setDateOptions(poll.options.map(dateStr => {
-        const parts = dateStr.split('-').map(Number);
-        const [year, month, day] = parts;
-        if (!year || !month || !day) return new Date();
-        return new Date(year, month - 1, day);
-      }));
+      setDateOptions(
+        poll.options.map((dateStr) => {
+          const parts = dateStr.split('-').map(Number);
+          const [year, month, day] = parts;
+          if (!year || !month || !day) return new Date();
+          return new Date(year, month - 1, day);
+        })
+      );
     } else {
       setOptions(poll.options);
     }
@@ -181,7 +175,7 @@ export function PollEditor({ polls, onPollsChange }: PollEditorProps) {
       }
       finalOptions = dateOptions
         .sort((a, b) => a.getTime() - b.getTime())
-        .map(date => format(date, 'yyyy-MM-dd'));
+        .map((date) => format(date, 'yyyy-MM-dd'));
     } else {
       const validOptions = options.filter((opt) => opt.trim());
       if (validOptions.length < 2) {
@@ -218,6 +212,7 @@ export function PollEditor({ polls, onPollsChange }: PollEditorProps) {
     setOptions(['', '']);
     setDateOptions([]);
     setEditingIndex(null);
+    setFormOpen(false);
   };
 
   const handleCancelEdit = () => {
@@ -230,6 +225,7 @@ export function PollEditor({ polls, onPollsChange }: PollEditorProps) {
     setOptions(['', '']);
     setDateOptions([]);
     setEditingIndex(null);
+    setFormOpen(false);
   };
 
   const handleOptionChange = (index: number, value: string) => {
@@ -255,7 +251,7 @@ export function PollEditor({ polls, onPollsChange }: PollEditorProps) {
       {/* Existing polls */}
       {polls.length > 0 && editingIndex === null && (
         <div className="space-y-3">
-          <Label className="text-sm font-medium">투표</Label>
+          <Label className="text-sm font-medium">투표 ({polls.length}개)</Label>
           {polls.map((poll, index) => (
             <div
               key={index}
@@ -290,325 +286,339 @@ export function PollEditor({ polls, onPollsChange }: PollEditorProps) {
               </div>
             </div>
           ))}
+
+          {/* Add more polls button */}
+          {!formOpen && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setFormOpen(true)}
+              className="w-full"
+            >
+              <Plus className="mr-2 h-4 w-4" />
+              투표 추가
+            </Button>
+          )}
         </div>
       )}
 
-      {/* New poll form - show if no poll exists OR editing */}
-      {(polls.length === 0 || editingIndex !== null) && (
+      {/* New poll form - show if no poll exists, editing, or form opened */}
+      {(polls.length === 0 || editingIndex !== null || formOpen) && (
         <div className="rounded-lg border border-dashed border-border/60 bg-muted/10 p-4">
-        <div className="space-y-4">
-          <div className="flex items-center justify-between">
-            <Label className="text-sm font-medium">
-              {editingIndex !== null ? '투표 수정' : '새 투표 만들기'}
-            </Label>
-          </div>
-
-          {/* Question */}
-          <div className="space-y-1.5">
-            <Label htmlFor="poll-question" className="text-sm font-medium">
-              투표 질문
-            </Label>
-            <Input
-              id="poll-question"
-              placeholder="예: 이번 주말에 맛집갈 사람?"
-              value={newPoll.question || ''}
-              onChange={(e) => setNewPoll({ ...newPoll, question: e.target.value })}
-              className="text-sm"
-            />
-          </div>
-
-          {/* Poll type */}
-          <div className="space-y-1.5">
-            <Label className="text-sm font-medium">투표 유형</Label>
-            <div className="flex gap-2">
-              <Button
-                type="button"
-                variant={newPoll.pollType === 'text' ? 'default' : 'outline'}
-                onClick={() => setNewPoll({ ...newPoll, pollType: 'text' })}
-                className="flex-1"
-              >
-                텍스트 투표
-              </Button>
-              <Button
-                type="button"
-                variant={newPoll.pollType === 'date' ? 'default' : 'outline'}
-                onClick={() => setNewPoll({ ...newPoll, pollType: 'date' })}
-                className="flex-1"
-              >
-                날짜 투표
-              </Button>
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <Label className="text-sm font-medium">
+                {editingIndex !== null ? '투표 수정' : '새 투표 만들기'}
+              </Label>
             </div>
-          </div>
 
-          {/* Poll options */}
-          <div className="space-y-3">
-            <Label className="text-xs font-medium">투표 옵션</Label>
-            <div className="flex flex-wrap gap-2">
-              <Button
-                type="button"
-                variant={newPoll.allowMultiple ? 'default' : 'outline'}
-                size="sm"
-                onClick={() => setNewPoll({ ...newPoll, allowMultiple: !newPoll.allowMultiple })}
-                className="h-8 px-3 text-xs"
-              >
-                <Check className="mr-1.5 h-3.5 w-3.5" />
-                복수 선택
-              </Button>
-              <Button
-                type="button"
-                variant={newPoll.isAnonymous ? 'default' : 'outline'}
-                size="sm"
-                onClick={() => setNewPoll({ ...newPoll, isAnonymous: !newPoll.isAnonymous })}
-                className="h-8 px-3 text-xs"
-              >
-                <Lock className="mr-1.5 h-3.5 w-3.5" />
-                익명
-              </Button>
+            {/* Question */}
+            <div className="space-y-1.5">
+              <Label htmlFor="poll-question" className="text-sm font-medium">
+                투표 질문
+              </Label>
+              <Input
+                id="poll-question"
+                placeholder="예: 이번 주말에 맛집갈 사람?"
+                value={newPoll.question || ''}
+                onChange={(e) => setNewPoll({ ...newPoll, question: e.target.value })}
+                className="text-sm"
+              />
             </div>
-          </div>
 
-          {/* Expiry */}
-          <div className="space-y-1.5">
-            <Label className="text-sm font-medium">마감시간</Label>
-            <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
-              <PopoverTrigger asChild>
+            {/* Poll type */}
+            <div className="space-y-1.5">
+              <Label className="text-sm font-medium">투표 유형</Label>
+              <div className="flex gap-2">
                 <Button
-                  variant="outline"
-                  className="w-full justify-start text-left font-normal"
+                  type="button"
+                  variant={newPoll.pollType === 'text' ? 'default' : 'outline'}
+                  onClick={() => setNewPoll({ ...newPoll, pollType: 'text' })}
+                  className="flex-1"
                 >
-                  <Calendar className="mr-2 h-4 w-4" />
-                  {newPoll.expiresAt
-                    ? format(new Date(newPoll.expiresAt), 'yyyy년 MM월 dd일 HH:mm', { locale: ko })
-                    : '마감 시간 설정'}
+                  텍스트 투표
                 </Button>
-              </PopoverTrigger>
-              <PopoverContent className="w-auto p-4" align="start">
-                <div className="space-y-4">
-                  {/* Date picker */}
-                  <div>
-                    <Label className="text-xs text-muted-foreground mb-2">날짜</Label>
-                    <CalendarComponent
-                      mode="single"
-                      selected={newPoll.expiresAt ? new Date(newPoll.expiresAt) : undefined}
-                      onSelect={(date) => {
-                        if (date) {
-                          // Preserve the time from current expiresAt
-                          const currentExpiresAt = newPoll.expiresAt
-                            ? new Date(newPoll.expiresAt)
-                            : new Date();
-                          date.setHours(currentExpiresAt.getHours(), currentExpiresAt.getMinutes());
-                          setNewPoll({
-                            ...newPoll,
-                            expiresAt: date.toISOString(),
-                          });
-                        }
-                      }}
-                      disabled={(date) => date < new Date(new Date().setHours(0, 0, 0, 0))}
-                      initialFocus
-                      className="rounded-md border"
-                      classNames={{
-                        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
-                        month: "space-y-4",
-                        caption: "flex justify-center pt-1 relative items-center",
-                        caption_label: "text-sm font-medium",
-                        nav: "space-x-1 flex items-center",
-                        nav_button: "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100",
-                        nav_button_previous: "absolute left-1",
-                        nav_button_next: "absolute right-1",
-                        table: "w-full border-collapse space-y-1",
-                        head_row: "flex",
-                        head_cell: "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
-                        row: "flex w-full mt-2",
-                        cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
-                        day: "h-9 w-9 p-0 font-normal aria-selected:opacity-100 hover:bg-accent hover:text-accent-foreground rounded-md transition-colors",
-                        day_range_end: "day-range-end",
-                        day_selected: "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
-                        day_today: "bg-accent text-accent-foreground",
-                        day_outside: "day-outside text-muted-foreground opacity-50",
-                        day_disabled: "text-muted-foreground opacity-50",
-                        day_range_middle: "aria-selected:bg-accent aria-selected:text-accent-foreground",
-                        day_hidden: "invisible",
-                      }}
-                    />
-                  </div>
+                <Button
+                  type="button"
+                  variant={newPoll.pollType === 'date' ? 'default' : 'outline'}
+                  onClick={() => setNewPoll({ ...newPoll, pollType: 'date' })}
+                  className="flex-1"
+                >
+                  날짜 투표
+                </Button>
+              </div>
+            </div>
 
-                  {/* Time picker */}
-                  <div>
-                    <Label className="text-xs text-muted-foreground mb-2">시간</Label>
-                    <div className="flex items-center gap-2">
-                      <Clock className="h-4 w-4 text-muted-foreground" />
-                      <Input
-                        type="time"
-                        value={
-                          newPoll.expiresAt
-                            ? format(new Date(newPoll.expiresAt), 'HH:mm')
-                            : ''
-                        }
-                        onChange={(e) => {
-                          const [hours, minutes] = e.target.value.split(':').map(Number);
-                          if (newPoll.expiresAt) {
-                            const date = new Date(newPoll.expiresAt);
-                            date.setHours(hours || 0, minutes || 0);
+            {/* Poll options */}
+            <div className="space-y-3">
+              <Label className="text-xs font-medium">투표 옵션</Label>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  variant={newPoll.allowMultiple ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => setNewPoll({ ...newPoll, allowMultiple: !newPoll.allowMultiple })}
+                  className="h-8 px-3 text-xs"
+                >
+                  <Check className="mr-1.5 h-3.5 w-3.5" />
+                  복수 선택
+                </Button>
+                <Button
+                  type="button"
+                  variant={newPoll.isAnonymous ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => setNewPoll({ ...newPoll, isAnonymous: !newPoll.isAnonymous })}
+                  className="h-8 px-3 text-xs"
+                >
+                  <Lock className="mr-1.5 h-3.5 w-3.5" />
+                  익명
+                </Button>
+              </div>
+            </div>
+
+            {/* Expiry */}
+            <div className="space-y-1.5">
+              <Label className="text-sm font-medium">마감시간</Label>
+              <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
+                <PopoverTrigger asChild>
+                  <Button variant="outline" className="w-full justify-start text-left font-normal">
+                    <Calendar className="mr-2 h-4 w-4" />
+                    {newPoll.expiresAt
+                      ? format(new Date(newPoll.expiresAt), 'yyyy년 MM월 dd일 HH:mm', {
+                          locale: ko,
+                        })
+                      : '마감 시간 설정'}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-4" align="start">
+                  <div className="space-y-4">
+                    {/* Date picker */}
+                    <div>
+                      <Label className="text-xs text-muted-foreground mb-2">날짜</Label>
+                      <CalendarComponent
+                        mode="single"
+                        selected={newPoll.expiresAt ? new Date(newPoll.expiresAt) : undefined}
+                        onSelect={(date) => {
+                          if (date) {
+                            // Preserve the time from current expiresAt
+                            const currentExpiresAt = newPoll.expiresAt
+                              ? new Date(newPoll.expiresAt)
+                              : new Date();
+                            date.setHours(
+                              currentExpiresAt.getHours(),
+                              currentExpiresAt.getMinutes()
+                            );
                             setNewPoll({
                               ...newPoll,
                               expiresAt: date.toISOString(),
                             });
                           }
                         }}
-                        className="flex-1"
+                        disabled={(date) => date < new Date(new Date().setHours(0, 0, 0, 0))}
+                        initialFocus
+                        className="rounded-md border"
+                        classNames={{
+                          months: 'flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0',
+                          month: 'space-y-4',
+                          caption: 'flex justify-center pt-1 relative items-center',
+                          caption_label: 'text-sm font-medium',
+                          nav: 'space-x-1 flex items-center',
+                          nav_button: 'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100',
+                          nav_button_previous: 'absolute left-1',
+                          nav_button_next: 'absolute right-1',
+                          table: 'w-full border-collapse space-y-1',
+                          head_row: 'flex',
+                          head_cell:
+                            'text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]',
+                          row: 'flex w-full mt-2',
+                          cell: 'h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20',
+                          day: 'h-9 w-9 p-0 font-normal aria-selected:opacity-100 hover:bg-accent hover:text-accent-foreground rounded-md transition-colors',
+                          day_range_end: 'day-range-end',
+                          day_selected:
+                            'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground',
+                          day_today: 'bg-accent text-accent-foreground',
+                          day_outside: 'day-outside text-muted-foreground opacity-50',
+                          day_disabled: 'text-muted-foreground opacity-50',
+                          day_range_middle:
+                            'aria-selected:bg-accent aria-selected:text-accent-foreground',
+                          day_hidden: 'invisible',
+                        }}
                       />
                     </div>
-                  </div>
-                </div>
-              </PopoverContent>
-            </Popover>
-          </div>
 
-          {/* Options or Date Picker */}
-          {newPoll.pollType === 'date' ? (
-            <div className="space-y-2">
-              <Label className="text-sm font-medium">
-                날짜 선택 (최소 2개)
-              </Label>
-              <Popover open={datePickerOpen} onOpenChange={setDatePickerOpen}>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start text-left font-normal"
-                  >
-                    <Calendar className="mr-2 h-4 w-4" />
-                    {dateOptions.length > 0
-                      ? `${dateOptions.length}개 날짜 선택됨`
-                      : '날짜 선택'}
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-auto p-0" align="start">
-                  <div className="p-3">
-                    <CalendarComponent
-                      mode="multiple"
-                      selected={dateOptions}
-                      onSelect={(dates) => {
-                        if (dates) {
-                          setDateOptions(dates as Date[]);
-                        }
-                      }}
-                      disabled={(date) => date < new Date(new Date().setHours(0, 0, 0, 0))}
-                      initialFocus
-                      className="rounded-md border"
-                      classNames={{
-                        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
-                        month: "space-y-4",
-                        caption: "flex justify-center pt-1 relative items-center",
-                        caption_label: "text-sm font-medium",
-                        nav: "space-x-1 flex items-center",
-                        nav_button: "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100",
-                        nav_button_previous: "absolute left-1",
-                        nav_button_next: "absolute right-1",
-                        table: "w-full border-collapse space-y-1",
-                        head_row: "flex",
-                        head_cell: "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
-                        row: "flex w-full mt-2",
-                        cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
-                        day: "h-9 w-9 p-0 font-normal aria-selected:opacity-100 hover:bg-accent hover:text-accent-foreground rounded-md transition-colors",
-                        day_range_end: "day-range-end",
-                        day_selected: "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
-                        day_today: "bg-accent text-accent-foreground",
-                        day_outside: "day-outside text-muted-foreground opacity-50",
-                        day_disabled: "text-muted-foreground opacity-50",
-                        day_range_middle: "aria-selected:bg-accent aria-selected:text-accent-foreground",
-                        day_hidden: "invisible",
-                      }}
-                    />
+                    {/* Time picker */}
+                    <div>
+                      <Label className="text-xs text-muted-foreground mb-2">시간</Label>
+                      <div className="flex items-center gap-2">
+                        <Clock className="h-4 w-4 text-muted-foreground" />
+                        <Input
+                          type="time"
+                          value={
+                            newPoll.expiresAt ? format(new Date(newPoll.expiresAt), 'HH:mm') : ''
+                          }
+                          onChange={(e) => {
+                            const [hours, minutes] = e.target.value.split(':').map(Number);
+                            if (newPoll.expiresAt) {
+                              const date = new Date(newPoll.expiresAt);
+                              date.setHours(hours || 0, minutes || 0);
+                              setNewPoll({
+                                ...newPoll,
+                                expiresAt: date.toISOString(),
+                              });
+                            }
+                          }}
+                          className="flex-1"
+                        />
+                      </div>
+                    </div>
                   </div>
                 </PopoverContent>
               </Popover>
-
-              {/* Selected dates */}
-              {dateOptions.length > 0 && (
-                <div className="flex flex-wrap gap-2 p-3 bg-muted/30 rounded-lg">
-                  {dateOptions
-                    .sort((a, b) => a.getTime() - b.getTime())
-                    .map((date, index) => (
-                      <div
-                        key={index}
-                        className="flex items-center gap-1 px-2 py-1 bg-background border rounded-md text-sm"
-                      >
-                        <span>{format(date, 'MM월 dd일 (E)', { locale: ko })}</span>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setDateOptions(dateOptions.filter((_, i) => i !== index));
-                          }}
-                          className="ml-1 text-muted-foreground hover:text-destructive"
-                        >
-                          ×
-                        </button>
-                      </div>
-                    ))}
-                </div>
-              )}
             </div>
-          ) : (
-            <div className="space-y-2">
-              <Label className="text-sm font-medium">
-                선택지 (최소 2개)
-              </Label>
-              {options.map((option, index) => (
-                <div key={index} className="flex gap-2">
-                  <Input
-                    placeholder={`선택지 ${index + 1}`}
-                    value={option}
-                    onChange={(e) => handleOptionChange(index, e.target.value)}
-                    className="flex-1 text-sm"
-                  />
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => handleRemoveOption(index)}
-                    disabled={options.length <= 2}
-                    className="h-9 w-9 shrink-0"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                </div>
-              ))}
+
+            {/* Options or Date Picker */}
+            {newPoll.pollType === 'date' ? (
+              <div className="space-y-2">
+                <Label className="text-sm font-medium">날짜 선택 (최소 2개)</Label>
+                <Popover open={datePickerOpen} onOpenChange={setDatePickerOpen}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="outline"
+                      className="w-full justify-start text-left font-normal"
+                    >
+                      <Calendar className="mr-2 h-4 w-4" />
+                      {dateOptions.length > 0 ? `${dateOptions.length}개 날짜 선택됨` : '날짜 선택'}
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-auto p-0" align="start">
+                    <div className="p-3">
+                      <CalendarComponent
+                        mode="multiple"
+                        selected={dateOptions}
+                        onSelect={(dates) => {
+                          if (dates) {
+                            setDateOptions(dates as Date[]);
+                          }
+                        }}
+                        disabled={(date) => date < new Date(new Date().setHours(0, 0, 0, 0))}
+                        initialFocus
+                        className="rounded-md border"
+                        classNames={{
+                          months: 'flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0',
+                          month: 'space-y-4',
+                          caption: 'flex justify-center pt-1 relative items-center',
+                          caption_label: 'text-sm font-medium',
+                          nav: 'space-x-1 flex items-center',
+                          nav_button: 'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100',
+                          nav_button_previous: 'absolute left-1',
+                          nav_button_next: 'absolute right-1',
+                          table: 'w-full border-collapse space-y-1',
+                          head_row: 'flex',
+                          head_cell:
+                            'text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]',
+                          row: 'flex w-full mt-2',
+                          cell: 'h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20',
+                          day: 'h-9 w-9 p-0 font-normal aria-selected:opacity-100 hover:bg-accent hover:text-accent-foreground rounded-md transition-colors',
+                          day_range_end: 'day-range-end',
+                          day_selected:
+                            'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground',
+                          day_today: 'bg-accent text-accent-foreground',
+                          day_outside: 'day-outside text-muted-foreground opacity-50',
+                          day_disabled: 'text-muted-foreground opacity-50',
+                          day_range_middle:
+                            'aria-selected:bg-accent aria-selected:text-accent-foreground',
+                          day_hidden: 'invisible',
+                        }}
+                      />
+                    </div>
+                  </PopoverContent>
+                </Popover>
+
+                {/* Selected dates */}
+                {dateOptions.length > 0 && (
+                  <div className="flex flex-wrap gap-2 p-3 bg-muted/30 rounded-lg">
+                    {dateOptions
+                      .sort((a, b) => a.getTime() - b.getTime())
+                      .map((date, index) => (
+                        <div
+                          key={index}
+                          className="flex items-center gap-1 px-2 py-1 bg-background border rounded-md text-sm"
+                        >
+                          <span>{format(date, 'MM월 dd일 (E)', { locale: ko })}</span>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setDateOptions(dateOptions.filter((_, i) => i !== index));
+                            }}
+                            className="ml-1 text-muted-foreground hover:text-destructive"
+                          >
+                            ×
+                          </button>
+                        </div>
+                      ))}
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <Label className="text-sm font-medium">선택지 (최소 2개)</Label>
+                {options.map((option, index) => (
+                  <div key={index} className="flex gap-2">
+                    <Input
+                      placeholder={`선택지 ${index + 1}`}
+                      value={option}
+                      onChange={(e) => handleOptionChange(index, e.target.value)}
+                      className="flex-1 text-sm"
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleRemoveOption(index)}
+                      disabled={options.length <= 2}
+                      className="h-9 w-9 shrink-0"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ))}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleAddOption}
+                  className="w-full"
+                >
+                  <Plus className="mr-2 h-4 w-4" />
+                  선택지 추가
+                </Button>
+              </div>
+            )}
+
+            {/* Add/Update poll button */}
+            <div className="flex gap-2">
+              {(editingIndex !== null || formOpen) && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleCancelEdit}
+                  className="flex-1"
+                >
+                  취소
+                </Button>
+              )}
               <Button
                 type="button"
-                variant="outline"
-                size="sm"
-                onClick={handleAddOption}
-                className="w-full"
+                onClick={editingIndex !== null ? handleUpdatePoll : handleAddPoll}
+                className="flex-1 bg-sky-500 text-white hover:bg-sky-600"
               >
                 <Plus className="mr-2 h-4 w-4" />
-                선택지 추가
+                {editingIndex !== null ? '저장' : '투표 추가'}
               </Button>
             </div>
-          )}
-
-          {/* Add/Update poll button */}
-          <div className="flex gap-2">
-            {editingIndex !== null && (
-              <Button
-                type="button"
-                variant="outline"
-                onClick={handleCancelEdit}
-                className="flex-1"
-              >
-                취소
-              </Button>
-            )}
-            <Button
-              type="button"
-              onClick={editingIndex !== null ? handleUpdatePoll : handleAddPoll}
-              className="flex-1 bg-sky-500 text-white hover:bg-sky-600"
-            >
-              <Plus className="mr-2 h-4 w-4" />
-              {editingIndex !== null ? '저장' : '투표 추가'}
-            </Button>
           </div>
         </div>
-      </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- 게시글에 투표를 1개만 생성할 수 있던 제한을 제거하여 여러 개의 투표를 자유롭게 추가 가능하도록 변경

## Changes
| 파일 | 변경 내용 |
|------|-----------|
| `packages/web/src/components/board/poll-editor.tsx` | `polls.length >= 1` 제한 제거, `formOpen` 상태 추가로 투표 추가 폼 토글 구현, 투표 개수 라벨 표시 |

## Design Decisions
| 결정 | 이유 |
|------|------|
| 프론트엔드만 수정 | DB 스키마와 API는 이미 배열(다중 투표)을 지원하고 있어 백엔드 변경 불필요 |
| 최대 개수 제한 없음 | 사용자 요청에 따라 무제한 허용 |
| `formOpen` 토글 방식 | 투표가 이미 있을 때 폼이 항상 열려있으면 UX가 지저분하므로 버튼 클릭으로 열기/닫기 |

## Test Plan
- [x] 게시글 작성 시 투표 2개 이상 추가 가능 확인
- [x] 투표 추가 후 "투표 추가" 버튼으로 추가 폼 재오픈 확인
- [x] 기존 투표 수정/삭제 동작 정상 확인
- [x] 투표 추가 폼에서 취소 시 폼 닫힘 확인
- [x] 게시글 상세에서 여러 투표 표시 정상 확인
- [x] 게시글 목록에서 pollCount 뱃지 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)