### PR TITLE
feat(web/bot): 새 글 등록 시 FCM 푸시 알림 발송

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ SENTRY_DSN=https://your-dsn@o123.ingest.us.sentry.io/456
 BOT_API_SECRET=your_bot_api_secret_here
 BOT_API_URL=http://localhost:3001
 
+# Internal API (bot → web push notification)
+INTERNAL_API_KEY=your_internal_api_key_here
+WEB_URL=https://your-web-app.vercel.app
+
 # Application
 APP_URL=http://localhost:3000
 NODE_ENV=development

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,8 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 - **Discord 알림**: 웹에서 직접 Discord REST API 호출 시 `discord-notify.ts` 유틸 사용, 사용자 입력은 `escapeDiscordMarkdown()` 적용, `allowed_mentions: { parse: [] }` 필수
 - **댓글 길이**: 최대 5000자 제한 (API에서 검증)
 - **이미지 업로드**: Cloudflare R2 (`board-images/{userId}/{uuid}.{ext}`), 5MB 제한, rate limit 20회/분/유저
-- **포스트 수동등록**: 2단계 UX (URL→미리보기→편집→등록), OG HTML 엔티티 자동 디코딩, Discord 알림 토글
+- **포스트 수동등록**: 2단계 UX (URL→미리보기→편집→등록), OG HTML 엔티티 자동 디코딩, Discord 알림 토글, 푸시 알림은 Discord 토글과 무관하게 항상 발송
+- **새 글 푸시 알림**: 수동 등록 + RSS 수집 모두 지원. 대상: active/OB/dormant (작성자 본인 제외), 알림 타입 `new_post`. 봇→웹 내부 API(`/api/internal/new-post-push`, Bearer 인증) 경유
 - **포스트 수정**: 본인 또는 관리자만 제목/설명 수정 가능 (`PATCH /api/posts/[id]`)
 - **공지 알림**: 게시판 공지 작성 시 FCM 푸시 + Discord 공지채널(`notice_channel_id`) `@everyone` + 웹 딥링크 버튼
 - **벌금 DM**: 계좌 정보 포함 (3333333114501 카카오뱅크), 납부완료 시 관리자 채널 알림
@@ -98,7 +99,7 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 | `packages/bot/src/lib/sentry.ts` | 봇 Sentry SDK 초기화 (PII 스크러빙, DB URL/토큰 마스킹) |
 | `packages/bot/src/bot.ts` | Discord 클라이언트 초기화 (이벤트 핸들러만) |
 | `packages/bot/src/job-queue.ts` | pg-boss 싱글톤 (시작/종료/조회) |
-| `packages/bot/src/scheduler-registry.ts` | 잡 등록 + RSS→Post→Notification 파이프라인 |
+| `packages/bot/src/scheduler-registry.ts` | 잡 등록 + RSS→Post→Notification→Push 파이프라인 |
 | `packages/bot/src/services/score.service.ts` | 활동 점수 계산/부여 (봇: blog_post만) |
 | `packages/web/src/lib/score.ts` | 웹 활동 점수 부여 (board_post, post_comment, board_comment, post_view) |
 | `packages/web/src/lib/score-config.ts` | 활동 점수 타입별 메타데이터 (Single Source of Truth: 라벨, 이모지, 배점, 뱃지 컬러) |
@@ -106,7 +107,7 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 | `packages/web/src/lib/board-auth.ts` | 게시판 인증 헬퍼 (`getBoardAuth`) |
 | `packages/web/src/lib/board-config.ts` | 게시판 카테고리/뱃지 설정 |
 | `packages/web/src/lib/api-error.ts` | API 표준 응답/에러 헬퍼 (`successResponse`, `Errors`, `withCache`) |
-| `packages/web/src/lib/sanitize.ts` | 입력 새니타이즈 (`sanitizeDescription`, `sanitizeTiptapContent`, `getTodayKST`) |
+| `packages/web/src/lib/sanitize.ts` | 입력 새니타이즈 (`sanitizeDescription`, `sanitizeTiptapContent`, `decodeHtmlEntities`, `getTodayKST`) |
 | `packages/web/src/app/not-found.tsx` | 커스텀 404 페이지 |
 | `packages/web/src/app/(user)/error.tsx` | 사용자 에러 바운더리 |
 | `packages/web/src/app/(admin)/error.tsx` | 관리자 에러 바운더리 |
@@ -130,6 +131,7 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 | `packages/web/src/components/settings/push-notification-settings.tsx` | 알림 설정 UI (타입별 토글 + 테스트 전송) |
 | `packages/web/src/app/api/push/test/route.ts` | 테스트 푸시 알림 API (레이트 리밋 5/min) |
 | `packages/web/src/app/api/notification-preferences/route.ts` | 알림 타입별 설정 CRUD API |
+| `packages/web/src/app/api/internal/new-post-push/route.ts` | 새 글 푸시 알림 내부 API (봇→웹, Bearer 인증, rate limit 20/min) |
 | `packages/web/src/app/api/firebase-sw/route.ts` | FCM 서비스 워커 동적 서빙 (rewrite: `/firebase-messaging-sw.js` → `/api/firebase-sw`) |
 | `packages/bot/src/scripts/rss-collect.ts` | 수동 RSS 수집 스크립트 (봇 없이 독립 실행) |
 | `packages/bot/src/scripts/setup-channels.ts` | 디스코드 채널 일괄 생성 스크립트 |
@@ -245,6 +247,8 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 - `SENTRY_AUTH_TOKEN` (소스맵 업로드, Vercel/CI에서만 설정)
 - `FIREBASE_PROJECT_ID`, `FIREBASE_PRIVATE_KEY`, `FIREBASE_CLIENT_EMAIL` 등 (Firebase Admin, 서버용)
 - `NEXT_PUBLIC_FIREBASE_*` (Firebase 클라이언트, `API_KEY`/`AUTH_DOMAIN`/`PROJECT_ID`/`MESSAGING_SENDER_ID`/`APP_ID`/`VAPID_KEY`)
+- `INTERNAL_API_KEY` (봇→웹 내부 API 인증, 웹+봇 공유)
+- `WEB_URL` (봇에서 웹 API 호출 시 base URL, 봇 전용)
 
 **env 파일 위치** (2곳):
 - `.env.local` — 루트 (shared/bot용)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Blog Study Admin - 시스템 아키텍처
 
-> 최종 업데이트: 2026-03-18 (v11)
+> 최종 업데이트: 2026-03-23 (v12)
 
 블로그 글쓰기 스터디 운영 자동화 플랫폼. 웹 대시보드에서 모든 관리/유저 기능을 제공하고, Discord 봇은 스케줄러(RSS 수집/출석/벌금/큐레이션)와 이벤트 핸들러만 담당한다.
 
@@ -53,7 +53,7 @@ graph TB
         BANNER["Notice Banner<br/>글로벌 공지 배너"]
         PWA["PWA<br/>manifest.json<br/>홈 화면 추가"]
         FCM["FCM Push<br/>firebase-admin · firebase/messaging<br/>서비스 워커"]
-        API["API Routes<br/>/api/auth · /api/posts<br/>/api/admin · /api/board<br/>/api/push · /api/notification-preferences"]
+        API["API Routes<br/>/api/auth · /api/posts<br/>/api/admin · /api/board<br/>/api/push · /api/notification-preferences<br/>/api/internal (봇→웹 내부 API)"]
         SUPA_CLIENT["Supabase SSR Client<br/>@supabase/ssr"]
         SENTRY_WEB["Sentry SDK<br/>에러 모니터링 + PII 스크러빙"]
     end
@@ -70,6 +70,7 @@ graph TB
     Bot -->|service_role key| TABLES
     API -->|POST /api/trigger/*| BOT_API
     BOT_API --> SCH
+    BOT_API -->|POST /api/internal/new-post-push| API
     API -->|Discord REST API| CH_ADMIN
 
     Web -->|HTTPS| DB
@@ -218,6 +219,7 @@ flowchart TD
     D --> E["출석 상태 업데이트"]
     E --> F["활동 점수 부여 (봇: blog_post)"]
     F --> G["Discord 채널 알림"]
+    G --> H["FCM 푸시 알림<br/>(웹 내부 API 호출, fire-and-forget)"]
 ```
 
 ### 큐레이션 추천 흐름
@@ -451,7 +453,7 @@ erDiagram
 - **Pull-to-Refresh**: 커스텀 터치 제스처 기반 새로고침 (`PullToRefresh` + `usePullToRefresh`), Safari PWA 최적화, 다이얼로그 열림 시 `data-scroll-locked` 가드로 비활성화
 - **PWA**: `manifest.json` + 커스텀 로고 아이콘 (SVG/192/512, maskable) → 홈 화면 추가 지원
 - **OG 이미지**: `opengraph-image.tsx` Edge Runtime 동적 생성 (1200×630, `next/og` ImageResponse). 다크 테마 + K 로고 + 히어로 카피 + Mock UI 카드 (랭킹/포스트). `layout.tsx`에 `openGraph`/`twitter` 메타데이터 + `og:url`
-- **FCM 푸시**: Firebase Cloud Messaging 서비스 워커 (API route `/api/firebase-sw` → rewrite `/firebase-messaging-sw.js`) → 백그라운드 알림. 타입별(댓글/답글/공지) 개별 설정, 테스트 알림 전송 지원. 푸시/점수 등 백그라운드 작업은 `after()` from `next/server` 사용
+- **FCM 푸시**: Firebase Cloud Messaging 서비스 워커 (API route `/api/firebase-sw` → rewrite `/firebase-messaging-sw.js`) → 백그라운드 알림. 타입별(댓글/답글/공지/새글) 개별 설정, 테스트 알림 전송 지원. 새 글 알림은 수동 등록(`after()`) + RSS 수집(봇→웹 내부 API) 모두 지원. 푸시/점수 등 백그라운드 작업은 `after()` from `next/server` 사용
 
 ## 스케줄러 (pg-boss)
 
@@ -479,6 +481,7 @@ erDiagram
 | **SQL Injection** | Drizzle ORM 파라미터화 쿼리 (raw SQL 사용 안 함) | 전체 API Routes |
 | **CSRF** | Supabase Auth 쿠키 `SameSite=Lax` | Supabase 기본 설정 |
 | **입력 검증** | description 새니타이즈 (제어 문자/제로 너비 유니코드 제거, 300자 제한) | `lib/sanitize.ts` |
+| **내부 API 인증** | Bearer 토큰 (`INTERNAL_API_KEY`, timing-safe 비교) + rate limit 20/min + UUID/길이 검증 | `api/internal/new-post-push/` |
 
 ### 에러 처리
 

--- a/docs/superpowers/plans/26-03-23-new-post-push-notification.md
+++ b/docs/superpowers/plans/26-03-23-new-post-push-notification.md
@@ -1,0 +1,385 @@
+# 새 글 등록 푸시 알림 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 새 글 등록(수동 + RSS) 시 작성자 본인을 제외한 전원(active/OB/dormant)에게 FCM 푸시 알림 발송
+
+**Architecture:** shared 스키마에 `new_post` 알림 타입 추가 → 웹에 내부 API 엔드포인트 생성 (봇→웹 통신용) → 수동 등록은 직접 `sendPushToMembers` 호출, RSS는 봇이 내부 API 호출 → 알림 설정 UI에 토글 추가
+
+**Tech Stack:** Next.js (API route, `after()`), Drizzle ORM, FCM (`sendPushToMembers`), discord.js (봇)
+
+**Spec:** `docs/superpowers/specs/26-03-23-new-post-push-notification-design.md`
+
+---
+
+## File Structure
+
+| 파일 | 역할 | 변경 |
+|------|------|------|
+| `packages/shared/src/db/schema.ts` | NotificationType enum | `NEW_POST` 추가 |
+| `packages/web/src/lib/sanitize.ts` | 새니타이즈 유틸 | `decodeHtmlEntities()` 추가 |
+| `packages/web/src/app/api/internal/new-post-push/route.ts` | 내부 푸시 API | 신규 생성 |
+| `packages/web/src/app/api/posts/manual/route.ts` | 수동 등록 | 별도 `after()` 블록 추가 |
+| `packages/bot/src/scheduler-registry.ts` | RSS 수집 | 웹 내부 API 호출 추가 |
+| `packages/web/src/components/settings/push-notification-settings.tsx` | 알림 설정 UI | `new_post` 토글 추가 |
+| `packages/web/src/app/api/push/test/route.ts` | 테스트 푸시 | `new_post` 메시지 추가 |
+| `.env.example` | 환경변수 문서 | `INTERNAL_API_KEY`, `WEB_URL` 추가 |
+
+---
+
+### Task 1: shared 스키마에 NotificationType 추가
+
+**Files:**
+- Modify: `packages/shared/src/db/schema.ts:524-530`
+
+- [ ] **Step 1: `NotificationType`에 `NEW_POST` 추가**
+
+```typescript
+// packages/shared/src/db/schema.ts (line 524-530)
+export const NotificationType = {
+  BOARD_COMMENT: 'board_comment',
+  BOARD_REPLY: 'board_reply',
+  POST_COMMENT: 'post_comment',
+  POST_REPLY: 'post_reply',
+  BOARD_NOTICE: 'board_notice',
+  NEW_POST: 'new_post',
+} as const;
+```
+
+- [ ] **Step 2: shared 패키지 리빌드**
+
+Run: `pnpm --filter @blog-study/shared build`
+Expected: 빌드 성공
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add packages/shared/src/db/schema.ts
+git commit -m "feat(shared): NotificationType에 NEW_POST 추가"
+```
+
+---
+
+### Task 2: HTML 엔티티 디코더 추가
+
+**Files:**
+- Modify: `packages/web/src/lib/sanitize.ts`
+
+- [ ] **Step 1: `decodeHtmlEntities()` 함수 추가**
+
+`sanitize.ts` 파일 끝에 추가:
+
+```typescript
+/**
+ * HTML 엔티티를 일반 문자로 디코딩 (RSS 제목에 사용)
+ */
+export function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'")
+    .replace(/&#x27;/g, "'")
+    .replace(/&#(\d+);/g, (_, num) => String.fromCharCode(Number(num)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+}
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add packages/web/src/lib/sanitize.ts
+git commit -m "feat(web): HTML 엔티티 디코더 추가 (decodeHtmlEntities)"
+```
+
+---
+
+### Task 3: 내부 푸시 API 엔드포인트 생성
+
+**Files:**
+- Create: `packages/web/src/app/api/internal/new-post-push/route.ts`
+
+- [ ] **Step 1: API 라우트 생성**
+
+```typescript
+import { NextRequest } from 'next/server';
+import { inArray, ne, and } from 'drizzle-orm';
+import { getDb } from '@/lib/db';
+import { db as sharedDb } from '@blog-study/shared';
+import { sendPushToMembers } from '@/lib/push';
+import { decodeHtmlEntities } from '@/lib/sanitize';
+import { errorResponse, Errors, successResponse } from '@/lib/api-error';
+
+const { members, MemberStatus } = sharedDb;
+
+export async function POST(request: NextRequest) {
+  try {
+    // 내부 API 인증
+    const authHeader = request.headers.get('authorization');
+    const expectedKey = process.env.INTERNAL_API_KEY;
+    if (!expectedKey || authHeader !== `Bearer ${expectedKey}`) {
+      return Errors.unauthorized('Invalid API key').toResponse();
+    }
+
+    const body = await request.json();
+    const { postId, authorMemberId, authorName, postTitle } = body;
+
+    if (!postId || !authorMemberId || !authorName || !postTitle) {
+      return Errors.badRequest('postId, authorMemberId, authorName, postTitle은 필수입니다.').toResponse();
+    }
+
+    const database = getDb();
+
+    // active + OB + dormant 멤버 조회 (작성자 제외)
+    const targetMembers = await database
+      .select({ id: members.id })
+      .from(members)
+      .where(
+        and(
+          inArray(members.status, [MemberStatus.ACTIVE, MemberStatus.OB, MemberStatus.DORMANT]),
+          ne(members.id, authorMemberId)
+        )
+      );
+
+    if (targetMembers.length === 0) {
+      return successResponse({ success: 0, failed: 0 }, '발송 대상 없음');
+    }
+
+    const safeTitle = decodeHtmlEntities(postTitle).slice(0, 100);
+
+    const result = await sendPushToMembers(
+      targetMembers.map((m) => m.id),
+      {
+        title: '📝 새 글이 등록되었어요',
+        body: `${authorName}님이 새 글을 등록했어요: ${safeTitle}`,
+        clickUrl: `/posts/${postId}`,
+        data: { type: 'new_post' },
+      }
+    );
+
+    return successResponse(result);
+  } catch (error) {
+    console.error('[internal/new-post-push] Error:', error);
+    return errorResponse(error);
+  }
+}
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add packages/web/src/app/api/internal/new-post-push/route.ts
+git commit -m "feat(web): 새 글 푸시 알림 내부 API 엔드포인트 추가"
+```
+
+---
+
+### Task 4: 수동 등록에 푸시 알림 추가
+
+**Files:**
+- Modify: `packages/web/src/app/api/posts/manual/route.ts`
+
+- [ ] **Step 1: import 추가**
+
+기존 import 블록에 추가:
+
+```typescript
+import { sendPushToMembers } from '@/lib/push';
+import { inArray } from 'drizzle-orm';
+```
+
+참고: `eq`, `and`, `sql`은 이미 import됨. `inArray`만 추가 필요.
+
+- [ ] **Step 2: Discord `after()` 블록 뒤에 별도 푸시 `after()` 블록 추가**
+
+기존 코드 (line 354) `});` (Discord after 블록 종료) 이후, `return successResponse(...)` (line 356) 이전에 추가:
+
+```typescript
+    // 푸시 알림 (Discord 토글과 무관하게 항상 발송)
+    if (newPost) {
+      after(async () => {
+        try {
+          const database3 = db();
+          const allMembers = await database3
+            .select({ id: members.id })
+            .from(members)
+            .where(inArray(members.status, ['active', 'ob', 'dormant']));
+
+          const targetIds = allMembers
+            .map((m) => m.id)
+            .filter((id) => id !== member.id);
+
+          if (targetIds.length > 0) {
+            await sendPushToMembers(targetIds, {
+              title: '📝 새 글이 등록되었어요',
+              body: `${member.name}님이 새 글을 등록했어요: ${title!.slice(0, 100)}`,
+              clickUrl: `/posts/${newPost!.id}`,
+              data: { type: 'new_post' },
+            });
+          }
+        } catch (e) {
+          console.error('[manual-post] 푸시 알림 전송 실패:', e);
+        }
+      });
+    }
+```
+
+- [ ] **Step 3: 타입 체크**
+
+Run: `pnpm typecheck`
+Expected: 에러 없음
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add packages/web/src/app/api/posts/manual/route.ts
+git commit -m "feat(web): 수동 포스트 등록 시 푸시 알림 발송"
+```
+
+---
+
+### Task 5: RSS 수집에 푸시 알림 호출 추가
+
+**Files:**
+- Modify: `packages/bot/src/scheduler-registry.ts`
+
+- [ ] **Step 1: RSS 콜백에서 `sendPostNotification` 호출 뒤에 푸시 API 호출 추가**
+
+기존 코드 (line ~137, `notificationService.sendPostNotification(...)` 이후)에 추가:
+
+```typescript
+      // 푸시 알림 (웹 내부 API 호출)
+      try {
+        const webUrl = process.env.WEB_URL;
+        const apiKey = process.env.INTERNAL_API_KEY;
+        if (webUrl && apiKey) {
+          const pushRes = await fetch(`${webUrl}/api/internal/new-post-push`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${apiKey}`,
+            },
+            body: JSON.stringify({
+              postId: result.post.id,
+              authorMemberId: member.id,
+              authorName: member.name,
+              postTitle: item.title,
+            }),
+          });
+          if (!pushRes.ok) {
+            logger.warn({ status: pushRes.status }, '📢 [알림] 푸시 알림 API 응답 실패');
+          }
+        }
+      } catch (e) {
+        logger.error({ error: e }, '📢 [알림] 푸시 알림 전송 실패');
+      }
+```
+
+- [ ] **Step 2: 타입 체크**
+
+Run: `pnpm typecheck`
+Expected: 에러 없음
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add packages/bot/src/scheduler-registry.ts
+git commit -m "feat(bot): RSS 새 글 감지 시 웹 푸시 알림 API 호출"
+```
+
+---
+
+### Task 6: 알림 설정 UI에 토글 추가
+
+**Files:**
+- Modify: `packages/web/src/components/settings/push-notification-settings.tsx`
+
+- [ ] **Step 1: `FileText` import 추가**
+
+기존 import (line 4):
+```typescript
+import { Bell, Megaphone, MessageCircle, MessageSquare, SendHorizonal } from 'lucide-react';
+```
+변경:
+```typescript
+import { Bell, FileText, Megaphone, MessageCircle, MessageSquare, SendHorizonal } from 'lucide-react';
+```
+
+- [ ] **Step 2: `NOTIFICATION_LABELS`에 `new_post` 추가**
+
+기존 `board_notice` 항목 (line 41) 뒤에 추가:
+
+```typescript
+  new_post: {
+    label: '새 글 알림',
+    icon: FileText,
+    description: '스터디원이 새 글을 등록할 때',
+  },
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add packages/web/src/components/settings/push-notification-settings.tsx
+git commit -m "feat(web): 알림 설정에 새 글 알림 토글 추가"
+```
+
+---
+
+### Task 7: 테스트 푸시 메시지 추가
+
+**Files:**
+- Modify: `packages/web/src/app/api/push/test/route.ts`
+
+- [ ] **Step 1: `TEST_MESSAGES`에 `new_post` 추가**
+
+기존 `board_notice` 항목 (line 26) 뒤에 추가:
+
+```typescript
+  new_post: {
+    title: '📝 새 글 알림 테스트',
+    body: '스터디원이 새 글을 등록했습니다.',
+  },
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add packages/web/src/app/api/push/test/route.ts
+git commit -m "feat(web): 테스트 푸시에 새 글 알림 타입 추가"
+```
+
+---
+
+### Task 8: 환경변수 문서화 + 빌드 검증
+
+**Files:**
+- Modify: `.env.example`
+
+- [ ] **Step 1: `.env.example`에 새 환경변수 추가**
+
+파일 끝에 추가:
+
+```
+# Internal API (bot → web push notification)
+INTERNAL_API_KEY=
+WEB_URL=
+```
+
+- [ ] **Step 2: 전체 빌드 검증**
+
+Run: `pnpm build`
+Expected: shared, bot, web 모두 빌드 성공
+
+- [ ] **Step 3: 전체 린트 + 타입 체크**
+
+Run: `pnpm lint && pnpm typecheck`
+Expected: 에러 없음
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add .env.example
+git commit -m "docs: INTERNAL_API_KEY, WEB_URL 환경변수 추가"
+```

--- a/docs/superpowers/specs/26-03-23-new-post-push-notification-design.md
+++ b/docs/superpowers/specs/26-03-23-new-post-push-notification-design.md
@@ -1,0 +1,172 @@
+# 새 글 등록 푸시 알림
+
+새 글이 등록(수동 + RSS)되면, 알림을 허용한 멤버 전원에게 FCM 푸시 알림을 발송한다. 작성자 본인은 제외.
+
+## 설계 결정
+
+- **푸시 대상**: active + OB + dormant 전원 (작성자 본인 제외). `new_post` 알림 설정이 꺼져 있으면 제외 (기존 `sendPushToMembers` 로직).
+- **Discord 토글과 독립**: 수동 등록 시 `notifyDiscord` 토글과 무관하게 푸시는 항상 발송. 별도 `after()` 블록으로 분리.
+- **인앱 알림 기록 없음**: FCM 푸시만 발송, DB에 알림 레코드 저장하지 않음.
+- **배포 원자성**: shared `NotificationType` 추가 + 웹 UI 라벨은 동시 배포 필수 (라벨 없으면 raw string 노출).
+
+## 변경 포인트
+
+### 1. NotificationType 추가 (shared)
+
+`packages/shared/src/db/schema.ts`의 `NotificationType`에 추가:
+
+```ts
+NEW_POST: 'new_post',
+```
+
+DB 마이그레이션 불필요 — `notification_preferences.type`은 `varchar(30)`이고, 새 타입은 레코드가 없으면 기본값 `true`로 처리됨 (기존 GET API 로직).
+
+### 2. 내부 API 엔드포인트
+
+`POST /api/internal/new-post-push`
+
+**인증**: `Authorization: Bearer {INTERNAL_API_KEY}` 헤더. 환경변수 `INTERNAL_API_KEY`를 봇과 웹이 공유.
+
+**Request body**:
+```json
+{
+  "postId": "uuid",
+  "authorMemberId": "uuid",
+  "authorName": "닉네임",
+  "postTitle": "포스트 제목"
+}
+```
+
+**로직**:
+1. `members` 테이블에서 active + OB + dormant 멤버 ID 목록 조회
+2. `authorMemberId` 제외
+3. `postTitle` 새니타이즈 — HTML 엔티티 제거 (`&amp;` → `&` 등). RSS 경유 시 인코딩된 제목이 올 수 있음
+4. `sendPushToMembers(memberIds, payload)` 호출
+   - `payload.data.type = 'new_post'` → 알림 선호도 자동 필터링 (기존 로직)
+   - `title`: `📝 새 글이 등록되었어요`
+   - `body`: `{authorName}님이 새 글을 등록했어요: {postTitle}` (postTitle 100자 제한)
+   - `clickUrl`: `/posts/{postId}`
+
+**실패 처리**: `WEB_URL` 또는 `INTERNAL_API_KEY` 미설정 시 fetch 실패 → catch에서 로그만 남기고 RSS 파이프라인은 정상 진행.
+
+**Response**: `{ success: true, data: { success: N, failed: N } }`
+
+### 3. 수동 등록에서 호출 (web)
+
+`packages/web/src/app/api/posts/manual/route.ts`
+
+기존 Discord 알림 `after()` 블록과 **별도 `after()` 블록**에서 `sendPushToMembers()` 호출. `shouldNotify` 플래그와 무관하게 항상 실행.
+
+```ts
+// Discord 알림 after() 블록 바깥, newPost가 있을 때
+if (newPost) {
+  after(async () => {
+    try {
+      const database3 = db();
+      const allMembers = await database3
+        .select({ id: members.id })
+        .from(members)
+        .where(inArray(members.status, ['active', 'ob', 'dormant']));
+
+      const targetIds = allMembers
+        .map(m => m.id)
+        .filter(id => id !== member.id);
+
+      if (targetIds.length > 0) {
+        await sendPushToMembers(targetIds, {
+          title: '📝 새 글이 등록되었어요',
+          body: `${member.name}님이 새 글을 등록했어요: ${title!.slice(0, 100)}`,
+          clickUrl: `/posts/${newPost!.id}`,
+          data: { type: 'new_post' },
+        });
+      }
+    } catch (e) {
+      console.error('[manual-post] 푸시 알림 전송 실패:', e);
+    }
+  });
+}
+```
+
+### 4. RSS 수집에서 호출 (bot → web API)
+
+`packages/bot/src/scheduler-registry.ts`
+
+RSS로 새 포스트 감지 후, `result.isNew`일 때 웹 내부 API 호출:
+
+```ts
+if (result.isNew) {
+  // 기존 Discord 알림
+  await notificationService.sendPostNotification(...);
+
+  // 푸시 알림 (웹 내부 API 호출)
+  try {
+    const webUrl = process.env.WEB_URL;
+    const apiKey = process.env.INTERNAL_API_KEY;
+    if (webUrl && apiKey) {
+      await fetch(`${webUrl}/api/internal/new-post-push`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          postId: result.post.id,
+          authorMemberId: result.post.memberId,
+          authorName: member.name,
+          postTitle: result.post.title,
+        }),
+      });
+    }
+  } catch (e) {
+    logger.error({ error: e }, '푸시 알림 전송 실패');
+  }
+}
+```
+
+### 5. 알림 설정 UI
+
+`packages/web/src/components/settings/push-notification-settings.tsx`의 `NOTIFICATION_LABELS`에 추가:
+
+```ts
+new_post: {
+  label: '새 글 알림',
+  icon: FileText,
+  description: '스터디원이 새 글을 등록할 때',
+},
+```
+
+### 6. 테스트 푸시
+
+`packages/web/src/app/api/push/test/route.ts`의 `TEST_MESSAGES`에 추가:
+
+```ts
+new_post: {
+  title: '📝 새 글 알림 테스트',
+  body: '스터디원이 새 글을 등록했습니다.',
+},
+```
+
+### 7. 환경변수
+
+| 변수 | 위치 | 용도 |
+|------|------|------|
+| `INTERNAL_API_KEY` | 웹 `.env.local` + 봇 `.env.local` | 내부 API 인증 |
+| `WEB_URL` | 봇 `.env.local` | 웹 서버 주소 (예: `https://kusting-web.vercel.app`) |
+
+`.env.example`에도 추가 필요.
+
+### 8. shared 패키지 리빌드
+
+`NotificationType` 변경 후 `pnpm --filter @blog-study/shared build` 필수.
+
+## 파일 변경 목록
+
+| 파일 | 변경 |
+|------|------|
+| `packages/shared/src/db/schema.ts` | `NotificationType`에 `NEW_POST` 추가 |
+| `packages/web/src/app/api/internal/new-post-push/route.ts` | 신규: 내부 푸시 API |
+| `packages/web/src/app/api/posts/manual/route.ts` | 별도 `after()` 블록에 `sendPushToMembers` 추가 |
+| `packages/bot/src/scheduler-registry.ts` | RSS 새 글 시 웹 내부 API 호출 추가 |
+| `packages/web/src/components/settings/push-notification-settings.tsx` | `new_post` 토글 + `FileText` import 추가 |
+| `packages/web/src/app/api/push/test/route.ts` | `new_post` 테스트 메시지 추가 |
+| `.env.example` | `INTERNAL_API_KEY`, `WEB_URL` 추가 |

--- a/packages/bot/src/scheduler-registry.ts
+++ b/packages/bot/src/scheduler-registry.ts
@@ -138,6 +138,31 @@ export async function registerAllJobs(boss: PgBoss, client: Client): Promise<voi
           post: result.post,
           roundNumber: currentRound?.roundNumber ?? null,
         });
+
+        // 푸시 알림 (웹 내부 API 호출, fire-and-forget — RSS 루프 블로킹 방지)
+        const webUrl = process.env.WEB_URL;
+        const apiKey = process.env.INTERNAL_API_KEY;
+        if (webUrl && apiKey) {
+          fetch(`${webUrl}/api/internal/new-post-push`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${apiKey}`,
+            },
+            body: JSON.stringify({
+              postId: result.post.id,
+              authorMemberId: member.id,
+              authorName: member.name,
+              postTitle: item.title,
+            }),
+          })
+            .then((res) => {
+              if (!res.ok) logger.warn({ status: res.status }, '📢 [알림] 푸시 알림 API 응답 실패');
+            })
+            .catch((e) => {
+              logger.error({ error: e }, '📢 [알림] 푸시 알림 전송 실패');
+            });
+        }
       }
     }
   });

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -527,6 +527,7 @@ export const NotificationType = {
   POST_COMMENT: 'post_comment',
   POST_REPLY: 'post_reply',
   BOARD_NOTICE: 'board_notice',
+  NEW_POST: 'new_post',
 } as const;
 
 export type NotificationTypeType = (typeof NotificationType)[keyof typeof NotificationType];

--- a/packages/web/src/app/api/internal/new-post-push/route.ts
+++ b/packages/web/src/app/api/internal/new-post-push/route.ts
@@ -1,0 +1,108 @@
+import { timingSafeEqual } from 'crypto';
+import { NextRequest } from 'next/server';
+import { and, inArray, ne } from 'drizzle-orm';
+import { getDb } from '@/lib/db';
+import { db as sharedDb } from '@blog-study/shared';
+import { sendPushToMembers } from '@/lib/push';
+import { decodeHtmlEntities } from '@/lib/sanitize';
+import { errorResponse, Errors, successResponse } from '@/lib/api-error';
+
+const { members, MemberStatus } = sharedDb;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Rate limit: 20 requests/minute
+const rateLimitMap = new Map<string, number[]>();
+const RATE_LIMIT_WINDOW = 60_000;
+const RATE_LIMIT_MAX = 20;
+
+function checkRateLimit(): boolean {
+  const key = 'internal-push';
+  const now = Date.now();
+  const timestamps = rateLimitMap.get(key) ?? [];
+  const recent = timestamps.filter((t) => now - t < RATE_LIMIT_WINDOW);
+  if (recent.length >= RATE_LIMIT_MAX) return false;
+  recent.push(now);
+  rateLimitMap.set(key, recent);
+  return true;
+}
+
+function safeCompare(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    // Rate limit
+    if (!checkRateLimit()) {
+      return Errors.badRequest('Rate limit exceeded').toResponse();
+    }
+
+    // 내부 API 인증 (timing-safe comparison)
+    const authHeader = request.headers.get('authorization');
+    const expectedKey = process.env.INTERNAL_API_KEY;
+    const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : '';
+    if (!expectedKey || !token || !safeCompare(token, expectedKey)) {
+      return Errors.unauthorized('Invalid API key').toResponse();
+    }
+
+    const body = await request.json();
+    const { postId, authorMemberId, authorName, postTitle } = body;
+
+    // 타입 검증
+    if (
+      typeof postId !== 'string' ||
+      typeof authorMemberId !== 'string' ||
+      typeof authorName !== 'string' ||
+      typeof postTitle !== 'string'
+    ) {
+      return Errors.badRequest('All fields must be strings').toResponse();
+    }
+
+    // UUID 형식 검증
+    if (!UUID_RE.test(postId) || !UUID_RE.test(authorMemberId)) {
+      return Errors.badRequest('Invalid ID format').toResponse();
+    }
+
+    // 길이 제한 (regex 처리 전 방어)
+    if (authorName.length > 100 || postTitle.length > 2000) {
+      return Errors.badRequest('authorName 또는 postTitle이 너무 깁니다.').toResponse();
+    }
+
+    const database = getDb();
+
+    // active + OB + dormant 멤버 조회 (작성자 제외)
+    const targetMembers = await database
+      .select({ id: members.id })
+      .from(members)
+      .where(
+        and(
+          inArray(members.status, [MemberStatus.ACTIVE, MemberStatus.OB, MemberStatus.DORMANT]),
+          ne(members.id, authorMemberId)
+        )
+      );
+
+    if (targetMembers.length === 0) {
+      return successResponse({ success: 0, failed: 0 }, '발송 대상 없음');
+    }
+
+    const safeName = authorName.replace(/[<>"'&]/g, '').slice(0, 50);
+    const safeTitle = decodeHtmlEntities(postTitle).slice(0, 100);
+
+    const result = await sendPushToMembers(
+      targetMembers.map((m) => m.id),
+      {
+        title: '📝 새 글이 등록되었어요',
+        body: `${safeName}님이 새 글을 등록했어요: ${safeTitle}`,
+        clickUrl: `/posts/${postId}`,
+        data: { type: 'new_post' },
+      }
+    );
+
+    return successResponse(result);
+  } catch (error) {
+    console.error('[internal/new-post-push] Error:', error);
+    return errorResponse(error);
+  }
+}

--- a/packages/web/src/app/api/posts/manual/route.ts
+++ b/packages/web/src/app/api/posts/manual/route.ts
@@ -1,11 +1,13 @@
 import { after, NextRequest, NextResponse } from 'next/server';
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, inArray, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { createClient } from '@/lib/supabase/server';
 import { errorResponse, Errors, successResponse } from '@/lib/api-error';
 import { isSafeUrl } from '@/lib/rss-detect';
 import { sendDiscordChannelMessage } from '@/lib/discord-notify';
+import { sendPushToMembers } from '@/lib/push';
+import { decodeHtmlEntities } from '@/lib/sanitize';
 
 const {
   posts,
@@ -349,6 +351,32 @@ export async function POST(request: NextRequest) {
           });
         } catch (e) {
           console.error('[manual-post] Discord 알림 전송 실패:', e);
+        }
+      });
+    }
+
+    // 푸시 알림 (Discord 토글과 무관하게 항상 발송)
+    if (newPost) {
+      after(async () => {
+        try {
+          const database3 = db();
+          const allMembers = await database3
+            .select({ id: members.id })
+            .from(members)
+            .where(inArray(members.status, ['active', 'ob', 'dormant']));
+
+          const targetIds = allMembers.map((m) => m.id).filter((id) => id !== member.id);
+
+          if (targetIds.length > 0) {
+            await sendPushToMembers(targetIds, {
+              title: '📝 새 글이 등록되었어요',
+              body: `${member.name}님이 새 글을 등록했어요: ${decodeHtmlEntities(title!).slice(0, 100)}`,
+              clickUrl: `/posts/${newPost!.id}`,
+              data: { type: 'new_post' },
+            });
+          }
+        } catch (e) {
+          console.error('[manual-post] 푸시 알림 전송 실패:', e);
         }
       });
     }

--- a/packages/web/src/app/api/push/test/route.ts
+++ b/packages/web/src/app/api/push/test/route.ts
@@ -24,6 +24,10 @@ const TEST_MESSAGES: Record<string, { title: string; body: string }> = {
     title: '📢 공지사항 테스트',
     body: '새로운 공지사항이 게시되었습니다.',
   },
+  new_post: {
+    title: '📝 새 글 알림 테스트',
+    body: '스터디원이 새 글을 등록했습니다.',
+  },
 };
 
 // 유저별 레이트 리밋 (분당 5회)

--- a/packages/web/src/components/settings/push-notification-settings.tsx
+++ b/packages/web/src/components/settings/push-notification-settings.tsx
@@ -1,7 +1,14 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Bell, Megaphone, MessageCircle, MessageSquare, SendHorizonal } from 'lucide-react';
+import {
+  Bell,
+  FileText,
+  Megaphone,
+  MessageCircle,
+  MessageSquare,
+  SendHorizonal,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { toast } from 'sonner';
@@ -39,6 +46,7 @@ const NOTIFICATION_LABELS: Record<
     description: '내 댓글에 답글이 달릴 때',
   },
   board_notice: { label: '공지사항', icon: Megaphone, description: '새 공지사항이 게시될 때' },
+  new_post: { label: '새 글 알림', icon: FileText, description: '스터디원이 새 글을 등록할 때' },
 };
 
 export function PushNotificationSettings() {

--- a/packages/web/src/lib/sanitize.ts
+++ b/packages/web/src/lib/sanitize.ts
@@ -52,6 +52,29 @@ export function sanitizeTiptapContent(content: any): any {
 }
 
 /**
+ * HTML 엔티티를 일반 문자로 디코딩 (RSS 제목에 사용)
+ */
+export function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'")
+    .replace(/&#x27;/g, "'")
+    .replace(/&#(\d+);/g, (match, num) => {
+      const cp = Number(num);
+      if (cp < 0x20 && cp !== 0x09 && cp !== 0x0a && cp !== 0x0d) return '';
+      try { return String.fromCodePoint(cp); } catch { return match; }
+    })
+    .replace(/&#x([0-9a-fA-F]+);/g, (match, hex) => {
+      const cp = parseInt(hex, 16);
+      if (cp < 0x20 && cp !== 0x09 && cp !== 0x0a && cp !== 0x0d) return '';
+      try { return String.fromCodePoint(cp); } catch { return match; }
+    });
+}
+
+/**
  * KST (UTC+9) 기준 오늘 날짜 문자열 (YYYY-MM-DD)
  */
 export function getTodayKST(): string {


### PR DESCRIPTION
## Summary
새 글이 등록(수동 + RSS)되면, 알림을 허용한 active/OB/dormant 멤버 전원에게 FCM 푸시 알림을 발송한다. 작성자 본인은 제외.

## Changes
| 파일 | 변경 |
|------|------|
| `packages/shared/src/db/schema.ts` | `NotificationType`에 `NEW_POST: 'new_post'` 추가 |
| `packages/web/src/lib/sanitize.ts` | `decodeHtmlEntities()` 추가 (RSS 제목 HTML 엔티티 디코딩, `fromCodePoint` + 제어문자 필터) |
| `packages/web/src/app/api/internal/new-post-push/route.ts` | **신규** — 봇→웹 내부 푸시 API (Bearer 인증, timing-safe 비교, rate limit 20/min, UUID/길이 검증) |
| `packages/web/src/app/api/posts/manual/route.ts` | 별도 `after()` 블록으로 푸시 발송 (Discord 토글 무관, `decodeHtmlEntities` 적용) |
| `packages/bot/src/scheduler-registry.ts` | RSS 새 글 시 웹 내부 API fire-and-forget 호출 (루프 블로킹 방지) |
| `packages/web/src/components/settings/push-notification-settings.tsx` | `new_post` 토글 + `FileText` 아이콘 추가 |
| `packages/web/src/app/api/push/test/route.ts` | `new_post` 테스트 메시지 추가 |
| `.env.example` | `INTERNAL_API_KEY`, `WEB_URL` 추가 |
| `CLAUDE.md` | 새 글 푸시 알림 관련 문서 최신화 |
| `docs/ARCHITECTURE.md` | 데이터 흐름, 보안 레이어, FCM 설명 업데이트 |

## Design Decisions
| 결정 | 이유 |
|------|------|
| 봇→웹 내부 API 방식 (A안) | 푸시 로직을 웹에 집중, Firebase 의존성 봇에 추가 불필요, 확장성 |
| Discord 토글과 푸시 분리 | 사용자가 Discord 알림은 끄되 푸시는 받고 싶을 수 있음 |
| fire-and-forget (봇→웹) | RSS 폴링 루프 블로킹 방지 |
| timing-safe 비교 + rate limit | 내부 API이지만 Vercel에 퍼블릭 노출되므로 보안 강화 |
| active + OB + dormant 전원 대상 | 웹 접근 가능한 모든 멤버가 알림 수신 가능하도록 |

## Test Plan
- [ ] 수동 등록 시 본인 제외 전원에게 푸시 알림 수신 확인
- [ ] RSS 수집 시 봇→웹 내부 API 호출 및 푸시 발송 확인
- [ ] 알림 설정에서 '새 글 알림' 토글 표시 및 on/off 동작 확인
- [ ] 테스트 푸시 '새 글 알림' 전송 확인
- [ ] `INTERNAL_API_KEY` 미설정 시 봇 graceful skip 확인
- [ ] 클릭 시 `/posts/{id}` 포스트 상세로 이동 확인

## 배포 전 필요
- Vercel에 `INTERNAL_API_KEY` 환경변수 추가
- 봇 EC2에 `INTERNAL_API_KEY` + `WEB_URL` 환경변수 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)