### PR TITLE
feat: 랭킹 관리자 제외 + 프로필 페이지 UX 개선

### DIFF
--- a/packages/bot/src/schedulers/weekly-ranking.ts
+++ b/packages/bot/src/schedulers/weekly-ranking.ts
@@ -86,15 +86,24 @@ async function getMemberRankings(): Promise<MemberRanking[]> {
     rank: 0,
   }));
 
-  rankings.sort((a, b) =>
+  // 관리자 + config 제외 대상을 랭킹에서 제외
+  const adminIds = (process.env.ADMIN_DISCORD_IDS || '').split(',').map((id) => id.trim()).filter(Boolean);
+  const configExcluded = await getConfigValue('ranking_excluded_ids');
+  const configExcludedIds = configExcluded
+    ? configExcluded.split(',').map((id) => id.trim()).filter(Boolean)
+    : [];
+  const excludedIds = new Set([...adminIds, ...configExcludedIds]);
+  const filtered = rankings.filter((r) => !excludedIds.has(r.discordId));
+
+  filtered.sort((a, b) =>
     b.totalScore - a.totalScore || b.postCount - a.postCount
   );
 
-  rankings.forEach((ranking, index) => {
+  filtered.forEach((ranking, index) => {
     ranking.rank = index + 1;
   });
 
-  return rankings;
+  return filtered;
 }
 
 /**

--- a/packages/web/src/app/(user)/profile/page.tsx
+++ b/packages/web/src/app/(user)/profile/page.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { PageError, ProfileSkeleton } from '@/components/ui/page-state';
 import { PartBadge } from '@/components/ui/part-badge';
+import { usePushNotification } from '@/hooks/use-push-notification';
 
 interface UserInfo {
   id: string;
@@ -92,6 +93,20 @@ export default function ProfilePage() {
   const [withdrawOpen, setWithdrawOpen] = useState(false);
   const [withdrawing, setWithdrawing] = useState(false);
   const [withdrawError, setWithdrawError] = useState<string | null>(null);
+  const { permission, requestPermission, isSupported } = usePushNotification();
+  const [pushDismissed, setPushDismissed] = useState(false);
+  const [pushLoading, setPushLoading] = useState(false);
+  const showPushPrompt = isSupported && permission !== 'granted' && !pushDismissed;
+
+  const handleEnablePush = async () => {
+    setPushLoading(true);
+    const success = await requestPermission();
+    setPushLoading(false);
+    if (success) {
+      setPushDismissed(true);
+      router.push('/profile/notifications');
+    }
+  };
 
   const fetchProfile = useCallback(async () => {
     try {
@@ -161,11 +176,48 @@ export default function ProfilePage() {
   return (
     <div className="space-y-6">
       {/* Page Header */}
-      <div className="space-y-0.5">
-        <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
-          Profile
-        </p>
-        <h1 className="text-xl font-semibold tracking-tight">내 프로필</h1>
+      <div className="flex items-end justify-between">
+        <div className="flex items-center gap-2.5">
+          <div className="space-y-0.5">
+            <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+              Profile
+            </p>
+            <h1 className="text-xl font-semibold tracking-tight">내 프로필</h1>
+          </div>
+          {/* Push Notification Prompt Bubble */}
+          {showPushPrompt && (
+            <div className="relative animate-in fade-in slide-in-from-bottom-2 duration-500 ml-1">
+              <div className="rounded-xl border border-blue-200/60 dark:border-blue-800/40 bg-blue-50 dark:bg-blue-950/40 px-3.5 py-2.5 shadow-sm">
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="relative flex h-5 w-5 items-center justify-center">
+                    <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-400 opacity-40" />
+                    <Bell className="relative h-3.5 w-3.5 text-blue-500" />
+                  </span>
+                  <p className="text-xs font-medium text-blue-900 dark:text-blue-100">
+                    공지, 댓글, 새 포스트 알림을 받아보세요!
+                  </p>
+                </div>
+                <div className="ml-7">
+                  <button
+                    onClick={handleEnablePush}
+                    disabled={pushLoading}
+                    className="rounded-md bg-blue-500 px-2.5 py-1 text-[11px] font-semibold text-white hover:bg-blue-600 transition-colors disabled:opacity-50"
+                  >
+                    {pushLoading ? '켜는 중...' : '알림 켜기'}
+                  </button>
+                </div>
+              </div>
+              {/* Tail */}
+              <div className="absolute -left-1.5 top-4 w-0 h-0 border-t-[5px] border-t-transparent border-r-[7px] border-r-blue-200/60 dark:border-r-blue-800/40 border-b-[5px] border-b-transparent" />
+              <div className="absolute -left-1 top-4 w-0 h-0 border-t-[5px] border-t-transparent border-r-[7px] border-r-blue-50 dark:border-r-blue-950/40 border-b-[5px] border-b-transparent" />
+            </div>
+          )}
+        </div>
+        {data?.member?.onboardingCompleted && (
+          <Button size="sm" onClick={() => router.push('/profile/edit')}>
+            프로필 수정
+          </Button>
+        )}
       </div>
 
       {/* Account Info */}
@@ -445,67 +497,61 @@ export default function ProfilePage() {
             </CardContent>
           </Card>
 
-          {/* Edit Profile & Withdraw Buttons */}
+          {/* Withdraw Button */}
           {data.member.onboardingCompleted && (
-            <div className="flex items-center justify-between">
-              <AlertDialog open={withdrawOpen} onOpenChange={setWithdrawOpen}>
-                <AlertDialogTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="gap-1.5 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+            <AlertDialog open={withdrawOpen} onOpenChange={setWithdrawOpen}>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="gap-1.5 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+                >
+                  <LogOut className="h-3.5 w-3.5" />
+                  탈퇴하기
+                </Button>
+              </AlertDialogTrigger>
+
+              <AlertDialogContent className="max-w-sm">
+                <AlertDialogHeader>
+                  <AlertDialogTitle className="text-base">
+                    정말 탈퇴하시겠습니까?
+                  </AlertDialogTitle>
+                  <AlertDialogDescription className="text-sm text-muted-foreground">
+                    탈퇴하면 스터디 활동이 중단되며, 다시 참가하려면 관리자 승인이 필요합니다.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+
+                {withdrawError && (
+                  <p className="text-xs text-destructive bg-destructive/10 rounded-md px-3 py-2 border border-destructive/20">
+                    {withdrawError}
+                  </p>
+                )}
+
+                <AlertDialogFooter>
+                  <AlertDialogCancel
+                    disabled={withdrawing}
+                    className="h-9 text-sm"
+                    onClick={() => setWithdrawError(null)}
                   >
-                    <LogOut className="h-3.5 w-3.5" />
-                    탈퇴하기
-                  </Button>
-                </AlertDialogTrigger>
-
-                <AlertDialogContent className="max-w-sm">
-                  <AlertDialogHeader>
-                    <AlertDialogTitle className="text-base">
-                      정말 탈퇴하시겠습니까?
-                    </AlertDialogTitle>
-                    <AlertDialogDescription className="text-sm text-muted-foreground">
-                      탈퇴하면 스터디 활동이 중단되며, 다시 참가하려면 관리자 승인이 필요합니다.
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-
-                  {withdrawError && (
-                    <p className="text-xs text-destructive bg-destructive/10 rounded-md px-3 py-2 border border-destructive/20">
-                      {withdrawError}
-                    </p>
-                  )}
-
-                  <AlertDialogFooter>
-                    <AlertDialogCancel
-                      disabled={withdrawing}
-                      className="h-9 text-sm"
-                      onClick={() => setWithdrawError(null)}
-                    >
-                      취소
-                    </AlertDialogCancel>
-                    <AlertDialogAction
-                      onClick={handleWithdraw}
-                      disabled={withdrawing}
-                      className="h-9 text-sm bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
-                    >
-                      {withdrawing ? (
-                        <span className="flex items-center gap-1.5">
-                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                          처리 중...
-                        </span>
-                      ) : (
-                        '탈퇴하기'
-                      )}
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
-
-              <Button size="sm" onClick={() => router.push('/profile/edit')}>
-                프로필 수정
-              </Button>
-            </div>
+                    취소
+                  </AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={handleWithdraw}
+                    disabled={withdrawing}
+                    className="h-9 text-sm bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+                  >
+                    {withdrawing ? (
+                      <span className="flex items-center gap-1.5">
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        처리 중...
+                      </span>
+                    ) : (
+                      '탈퇴하기'
+                    )}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           )}
         </>
       )}

--- a/packages/web/src/app/api/ranking/route.ts
+++ b/packages/web/src/app/api/ranking/route.ts
@@ -4,8 +4,9 @@ import { db } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
 import { errorResponse, Errors, successResponse, withCache } from '@/lib/api-error';
 import { createClient } from '@/lib/supabase/server';
+import { getAdminDiscordIds } from '@/lib/admin';
 
-const { members, posts, attendance, rounds, activityScores, MemberStatus, AttendanceStatus } =
+const { members, posts, attendance, rounds, activityScores, config, MemberStatus, AttendanceStatus } =
   sharedDb;
 
 const VALID_SORT_KEYS = ['score', 'posts', 'activity'] as const;
@@ -140,6 +141,7 @@ export async function GET(request: NextRequest) {
         id: members.id,
         name: members.name,
         nickname: members.nickname,
+        discordId: members.discordId,
         discordUsername: members.discordUsername,
         profileImageUrl: members.profileImageUrl,
         resolution: members.resolution,
@@ -149,6 +151,21 @@ export async function GET(request: NextRequest) {
       .leftJoin(posts, eq(members.id, posts.memberId))
       .where(inArray(members.status, [MemberStatus.ACTIVE, MemberStatus.OB, MemberStatus.DORMANT]))
       .groupBy(members.id);
+
+    // 관리자 + config 제외 대상을 랭킹에서 제외
+    const adminDiscordIds = await getAdminDiscordIds();
+    const [excludedRow] = await database
+      .select({ value: config.value })
+      .from(config)
+      .where(eq(config.key, 'ranking_excluded_ids'))
+      .limit(1);
+    const configExcludedIds = excludedRow
+      ? excludedRow.value.split(',').map((id) => id.trim()).filter(Boolean)
+      : [];
+    const excludedDiscordIds = new Set([...adminDiscordIds, ...configExcludedIds]);
+    const filteredMembersWithPosts = membersWithPosts.filter(
+      (member) => !excludedDiscordIds.has(member.discordId)
+    );
 
     // Get current round post counts
     const currentRoundPostCounts = new Map<string, number>();
@@ -295,7 +312,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Combine all data
-    const rankings = membersWithPosts.map((member) => {
+    const rankings = filteredMembersWithPosts.map((member) => {
       const stats = attendanceMap.get(member.id) || { totalRounds: 0, submittedRounds: 0 };
       const attendanceRate =
         stats.totalRounds > 0 ? (stats.submittedRounds / stats.totalRounds) * 100 : 0;


### PR DESCRIPTION
## Summary
- 웹/봇 랭킹에서 관리자 및 지정 멤버 제외 (config 테이블 기반)
- 프로필 수정 버튼 위치 개선 + 푸시 알림 유도 말풍선 추가

## Changes

### 랭킹 필터링
| 파일 | 변경 |
|------|------|
| `packages/web/src/app/api/ranking/route.ts` | 관리자 + `ranking_excluded_ids` config 기반 필터링 추가 |
| `packages/bot/src/schedulers/weekly-ranking.ts` | env `ADMIN_DISCORD_IDS` + config `ranking_excluded_ids` 기반 필터링 추가 |

### 프로필 UX 개선
| 파일 | 변경 |
|------|------|
| `packages/web/src/app/(user)/profile/page.tsx` | 프로필 수정 버튼 헤더 우측 이동, 푸시 알림 유도 말풍선 추가 |

## Design Decisions
| 결정 | 이유 |
|------|------|
| config 테이블(`ranking_excluded_ids`) 사용 | 하드코딩 없이 DB에서 제외 대상 관리, 코드 변경/배포 불필요 |
| 관리자 제외는 기존 `ADMIN_DISCORD_IDS` + `admin_discord_ids` config 활용 | 이미 존재하는 인프라 재사용 |
| 푸시 유도를 `Notification.permission` 기반으로 체크 | 기기별 독립 동작, 불필요한 DB 호출 없음 |
| 알림 켜기 성공 시 상세 설정 페이지 이동 | 타입별 알림 세부 설정 유도 |

## Test Plan
- [ ] 웹 랭킹 페이지에서 관리자 멤버가 표시되지 않는지 확인
- [ ] config `ranking_excluded_ids`에 등록된 멤버가 랭킹에서 제외되는지 확인
- [ ] 봇 주간 랭킹 Discord 메시지에서 관리자/제외 멤버 미표시 확인
- [ ] 프로필 페이지에서 "프로필 수정" 버튼이 헤더 우측에 위치하는지 확인
- [ ] 푸시 알림 미허용 브라우저에서 말풍선이 표시되는지 확인
- [ ] "알림 켜기" 버튼 클릭 → 권한 허용 → 알림 설정 페이지 이동 확인
- [ ] 이미 알림 허용된 브라우저에서 말풍선이 표시되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)