### PR TITLE
feat: 게시판/포스트 이모지 리액션 기능 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,8 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 - **비밀댓글 알림**: 비밀댓글(`isSecret`)의 푸시 알림은 내용 마스킹 (`'비밀 댓글이 달렸습니다.'`), 포스트/게시판 댓글 모두 적용
 - **비밀댓글 isSecret 토글**: PATCH 시 본인만 변경 가능 (관리자도 타인 비밀 상태 변경 불가)
 - **포스트 삭제**: 본인 또는 관리자만 가능, 트랜잭션으로 댓글/조회기록/활동점수(blog_post) 일괄 삭제
+- **이모지 리액션**: 게시판 글 + 포스트에 고정 6종 이모지 (👍👀🔥💡😂✅) 토글, `ReactionBar` 공용 컴포넌트 (`apiPath` prop으로 board/posts 구분), 호버(PC)/클릭(모바일) 시 닉네임 팝오버, 복수 선택 가능, 활동 점수/알림 없음
+- **인기글 점수**: `댓글×3 + 조회수×2 + 리액션×1`
 - **스터디원 목록**: active + dormant + ob 모두 표시, 상태 칩으로 구분 (OB: 황금 파스텔, 휴면: secondary)
 
 ## 핵심 파일 위치
@@ -104,6 +106,7 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 | `packages/web/src/lib/score.ts` | 웹 활동 점수 부여 (board_post, post_comment, board_comment, post_view) |
 | `packages/web/src/lib/score-config.ts` | 활동 점수 타입별 메타데이터 (Single Source of Truth: 라벨, 이모지, 배점, 뱃지 컬러) |
 | `packages/web/src/app/(user)/profile/activity/page.tsx` | 활동 내역 페이지 (타입별 필터, 무한 로드) |
+| `packages/web/src/components/board/reaction-bar.tsx` | 이모지 리액션 바 공용 컴포넌트 (`apiPath` prop) |
 | `packages/web/src/lib/board-auth.ts` | 게시판 인증 헬퍼 (`getBoardAuth`) |
 | `packages/web/src/lib/board-config.ts` | 게시판 카테고리/뱃지 설정 |
 | `packages/web/src/lib/api-error.ts` | API 표준 응답/에러 헬퍼 (`successResponse`, `Errors`, `withCache`) |

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -499,6 +499,35 @@ export const boardPollVotes = pgTable(
   })
 );
 
+// ── Board Post Reactions ──────────────────────────────────────────────────
+
+export const REACTION_EMOJIS = ['👍', '👀', '🔥', '💡', '😂', '✅'] as const;
+export type ReactionEmoji = (typeof REACTION_EMOJIS)[number];
+
+export const boardPostReactions = pgTable(
+  'board_post_reactions',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    postId: uuid('post_id')
+      .notNull()
+      .references(() => boardPosts.id, { onDelete: 'cascade' }),
+    memberId: uuid('member_id')
+      .notNull()
+      .references(() => members.id, { onDelete: 'cascade' }),
+    emoji: varchar('emoji', { length: 10 }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  },
+  (table) => ({
+    postIdIdx: index('idx_board_post_reactions_post_id').on(table.postId),
+    memberIdIdx: index('idx_board_post_reactions_member_id').on(table.memberId),
+    uniqueReaction: unique('unique_post_member_emoji').on(
+      table.postId,
+      table.memberId,
+      table.emoji
+    ),
+  })
+);
+
 // ── FCM Tokens ─────────────────────────────────────────────────────────────
 
 export const fcmTokens = pgTable(
@@ -565,6 +594,7 @@ export const membersRelations = relations(members, ({ many }) => ({
   boardComments: many(boardComments),
   fcmTokens: many(fcmTokens),
   notificationPreferences: many(notificationPreferences),
+  boardPostReactions: many(boardPostReactions),
 }));
 
 export const fcmTokensRelations = relations(fcmTokens, ({ one }) => ({
@@ -669,6 +699,7 @@ export const boardPostsRelations = relations(boardPosts, ({ one, many }) => ({
   }),
   comments: many(boardComments),
   polls: many(boardPolls),
+  reactions: many(boardPostReactions),
 }));
 
 export const boardCommentsRelations = relations(boardComments, ({ one, many }) => ({
@@ -716,6 +747,17 @@ export const boardPollVotesRelations = relations(boardPollVotes, ({ one }) => ({
   }),
   member: one(members, {
     fields: [boardPollVotes.memberId],
+    references: [members.id],
+  }),
+}));
+
+export const boardPostReactionsRelations = relations(boardPostReactions, ({ one }) => ({
+  post: one(boardPosts, {
+    fields: [boardPostReactions.postId],
+    references: [boardPosts.id],
+  }),
+  member: one(members, {
+    fields: [boardPostReactions.memberId],
     references: [members.id],
   }),
 }));
@@ -774,6 +816,9 @@ export type NewBoardPollOption = typeof boardPollOptions.$inferInsert;
 
 export type BoardPollVote = typeof boardPollVotes.$inferSelect;
 export type NewBoardPollVote = typeof boardPollVotes.$inferInsert;
+
+export type BoardPostReaction = typeof boardPostReactions.$inferSelect;
+export type NewBoardPostReaction = typeof boardPostReactions.$inferInsert;
 
 export type FcmToken = typeof fcmTokens.$inferSelect;
 export type NewFcmToken = typeof fcmTokens.$inferInsert;

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -528,6 +528,32 @@ export const boardPostReactions = pgTable(
   })
 );
 
+// ── Post Reactions ────────────────────────────────────────────────────────
+
+export const postReactions = pgTable(
+  'post_reactions',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    postId: uuid('post_id')
+      .notNull()
+      .references(() => posts.id, { onDelete: 'cascade' }),
+    memberId: uuid('member_id')
+      .notNull()
+      .references(() => members.id, { onDelete: 'cascade' }),
+    emoji: varchar('emoji', { length: 10 }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  },
+  (table) => ({
+    postIdIdx: index('idx_post_reactions_post_id').on(table.postId),
+    memberIdIdx: index('idx_post_reactions_member_id').on(table.memberId),
+    uniqueReaction: unique('unique_post_reaction').on(
+      table.postId,
+      table.memberId,
+      table.emoji
+    ),
+  })
+);
+
 // ── FCM Tokens ─────────────────────────────────────────────────────────────
 
 export const fcmTokens = pgTable(
@@ -595,6 +621,7 @@ export const membersRelations = relations(members, ({ many }) => ({
   fcmTokens: many(fcmTokens),
   notificationPreferences: many(notificationPreferences),
   boardPostReactions: many(boardPostReactions),
+  postReactions: many(postReactions),
 }));
 
 export const fcmTokensRelations = relations(fcmTokens, ({ one }) => ({
@@ -628,6 +655,7 @@ export const postsRelations = relations(posts, ({ one, many }) => ({
   }),
   views: many(postViews),
   comments: many(postComments),
+  reactions: many(postReactions),
 }));
 
 export const attendanceRelations = relations(attendance, ({ one }) => ({
@@ -758,6 +786,17 @@ export const boardPostReactionsRelations = relations(boardPostReactions, ({ one 
   }),
   member: one(members, {
     fields: [boardPostReactions.memberId],
+    references: [members.id],
+  }),
+}));
+
+export const postReactionsRelations = relations(postReactions, ({ one }) => ({
+  post: one(posts, {
+    fields: [postReactions.postId],
+    references: [posts.id],
+  }),
+  member: one(members, {
+    fields: [postReactions.memberId],
     references: [members.id],
   }),
 }));

--- a/packages/web/src/app/(user)/board/[id]/page.tsx
+++ b/packages/web/src/app/(user)/board/[id]/page.tsx
@@ -9,6 +9,7 @@ import { type Poll, PollDisplay } from '@/components/board/poll-display';
 import { type Comment, CommentTree } from '@/components/board/comment-tree';
 import { CommentForm } from '@/components/board/comment-form';
 import { DeletePostDialog } from '@/components/board/delete-post-dialog';
+import { ReactionBar } from '@/components/board/reaction-bar';
 import { categoryBadgeConfig } from '@/lib/board-config';
 import { MemberAvatar } from '@/components/ui/member-avatar';
 import { Button } from '@/components/ui/button';
@@ -88,6 +89,9 @@ export default function BoardDetailPage() {
   const [post, setPost] = useState<Post | null>(null);
   const [comments, setComments] = useState<Comment[]>([]);
   const [polls, setPolls] = useState<Poll[]>([]);
+  const [reactions, setReactions] = useState<
+    Record<string, { count: number; members: { id: string; nickname: string }[]; reacted: boolean }>
+  >({});
   const [currentUser, setCurrentUser] = useState<CurrentUser>({
     memberId: null,
     isAdmin: false,
@@ -145,6 +149,7 @@ export default function BoardDetailPage() {
 
       setPost(postResult.data.post);
       setComments(postResult.data.comments);
+      setReactions(postResult.data.reactions || {});
 
       // Fetch polls (non-critical)
       if (pollsRes.ok) {
@@ -169,9 +174,22 @@ export default function BoardDetailPage() {
       if (!res.ok) return;
       const result = await res.json();
       setComments(result.data.comments);
+      setReactions(result.data.reactions || {});
       setPost((prev) => (prev ? { ...prev, commentCount: result.data.post.commentCount } : prev));
     } catch {
       // Fail silently — user can manually refresh
+    }
+  }, [postId]);
+
+  // Refresh reactions
+  const refreshReactions = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/board/${postId}`);
+      if (!res.ok) return;
+      const result = await res.json();
+      setReactions(result.data.reactions || {});
+    } catch {
+      // Fail silently
     }
   }, [postId]);
 
@@ -319,6 +337,15 @@ export default function BoardDetailPage() {
         {/* Post content */}
         <div className="px-6 py-6">
           <TiptapRenderer content={post.content} />
+        </div>
+
+        {/* Reactions */}
+        <div className="px-6 pb-5">
+          <ReactionBar
+            postId={postId}
+            reactions={reactions}
+            onUpdate={refreshReactions}
+          />
         </div>
       </div>
 

--- a/packages/web/src/app/(user)/posts/[id]/page.tsx
+++ b/packages/web/src/app/(user)/posts/[id]/page.tsx
@@ -34,6 +34,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
+import { ReactionBar } from '@/components/board/reaction-bar';
 import { cn, getDefaultAvatar } from '@/lib/utils';
 
 // ─────────────────────────────────────────────
@@ -613,6 +614,9 @@ export default function PostDetailPage() {
 
   const [comments, setComments] = useState<Comment[]>([]);
   const [commentCount, setCommentCount] = useState(0);
+  const [reactions, setReactions] = useState<
+    Record<string, { count: number; members: { id: string; nickname: string }[]; reacted: boolean }>
+  >({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [newComment, setNewComment] = useState('');
@@ -672,7 +676,19 @@ export default function PostDetailPage() {
     }
     fetchPostInfo();
     fetchComments();
+    fetchReactions();
   }, [postId, fetchComments]);
+
+  const fetchReactions = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/posts/${postId}/reactions`);
+      if (!res.ok) return;
+      const result = await res.json();
+      setReactions(result.data.reactions || {});
+    } catch {
+      // Non-critical
+    }
+  }, [postId]);
 
   const handleSubmitComment = async () => {
     if (!newComment.trim()) return;
@@ -772,6 +788,15 @@ export default function PostDetailPage() {
           </CardContent>
         </Card>
       )}
+
+      {/* Reactions */}
+      <div className="px-1">
+        <ReactionBar
+          postId={postId}
+          reactions={reactions}
+          onUpdate={fetchReactions}
+        />
+      </div>
 
       {/* Comments section */}
       <Card className="border-border/60 shadow-none">

--- a/packages/web/src/app/(user)/posts/[id]/page.tsx
+++ b/packages/web/src/app/(user)/posts/[id]/page.tsx
@@ -649,6 +649,17 @@ export default function PostDetailPage() {
     }
   }, [postId]);
 
+  const fetchReactions = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/posts/${postId}/reactions`);
+      if (!res.ok) return;
+      const result = await res.json();
+      setReactions(result.data.reactions || {});
+    } catch {
+      // Non-critical
+    }
+  }, [postId]);
+
   useEffect(() => {
     async function fetchPostInfo() {
       try {
@@ -677,18 +688,7 @@ export default function PostDetailPage() {
     fetchPostInfo();
     fetchComments();
     fetchReactions();
-  }, [postId, fetchComments]);
-
-  const fetchReactions = useCallback(async () => {
-    try {
-      const res = await fetch(`/api/posts/${postId}/reactions`);
-      if (!res.ok) return;
-      const result = await res.json();
-      setReactions(result.data.reactions || {});
-    } catch {
-      // Non-critical
-    }
-  }, [postId]);
+  }, [postId, fetchComments, fetchReactions]);
 
   const handleSubmitComment = async () => {
     if (!newComment.trim()) return;
@@ -793,6 +793,7 @@ export default function PostDetailPage() {
       <div className="px-1">
         <ReactionBar
           postId={postId}
+          apiPath="posts"
           reactions={reactions}
           onUpdate={fetchReactions}
         />

--- a/packages/web/src/app/(user)/posts/page.tsx
+++ b/packages/web/src/app/(user)/posts/page.tsx
@@ -20,6 +20,7 @@ import {
   Plus,
   Reply,
   Search,
+  SmilePlus,
   Trash2,
   TrendingUp,
   X,
@@ -32,6 +33,7 @@ import { Switch } from '@/components/ui/switch';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Textarea } from '@/components/ui/textarea';
 import { PartBadge } from '@/components/ui/part-badge';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { MemberAvatar } from '@/components/ui/member-avatar';
 import { PageError, PostsListSkeleton } from '@/components/ui/page-state';
 import {
@@ -113,6 +115,7 @@ interface Post {
   viewCount: number;
   viewers: Viewer[];
   totalViewers: number;
+  reactionCount: number;
 }
 
 interface PostsData {
@@ -800,6 +803,79 @@ function PostThumbnail({
   );
 }
 
+// ─────────────────────────────────────────────
+// ReactionChip (이모지 카운트 + 호버/클릭 시 닉네임)
+// ─────────────────────────────────────────────
+
+function ReactionChip({
+  emoji,
+  count,
+  reacted,
+  members,
+  loading,
+  onToggle,
+}: {
+  emoji: string;
+  count: number;
+  reacted: boolean;
+  members: { id: string; nickname: string }[];
+  loading: boolean;
+  onToggle: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <div
+          className="inline-flex"
+          onMouseEnter={() => setOpen(true)}
+          onMouseLeave={() => setOpen(false)}
+        >
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggle();
+            }}
+            disabled={loading}
+            className={cn(
+              'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium transition-colors select-none',
+              reacted
+                ? 'border-sky-300 bg-sky-50 text-sky-700 dark:border-sky-700 dark:bg-sky-950/40 dark:text-sky-300'
+                : 'border-border/60 bg-muted/40 text-muted-foreground hover:bg-muted/70',
+              loading && 'opacity-50',
+            )}
+          >
+            <span className="text-sm leading-none">{emoji}</span>
+            <span className="tabular-nums">{count}</span>
+          </button>
+        </div>
+      </PopoverTrigger>
+      <PopoverContent
+        side="top"
+        className="w-auto max-w-48 p-2"
+        sideOffset={6}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onPointerDownOutside={() => setOpen(false)}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+      >
+        <div className="space-y-0.5">
+          {members.map((m) => (
+            <p key={m.id} className="text-xs text-popover-foreground truncate">
+              {m.nickname}
+            </p>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+// ─────────────────────────────────────────────
+// PostCard with inline comments
+// ─────────────────────────────────────────────
+
 function PostCard({
   post,
   onView,
@@ -835,6 +911,50 @@ function PostCard({
   const [editTitle, setEditTitle] = useState(post.title);
   const [editDescription, setEditDescription] = useState(post.description || '');
   const [editing, setEditing] = useState(false);
+  const [reactions, setReactions] = useState<
+    Record<string, { count: number; members: { id: string; nickname: string }[]; reacted: boolean }>
+  >({});
+  const [reactionPickerOpen, setReactionPickerOpen] = useState(false);
+  const [reactionLoading, setReactionLoading] = useState<string | null>(null);
+
+  const REACTION_EMOJIS = ['👍', '👀', '🔥', '💡', '😂', '✅'] as const;
+
+  const fetchReactions = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/posts/${post.id}/reactions`);
+      if (!res.ok) return;
+      const result = await res.json();
+      setReactions(result.data.reactions || {});
+    } catch { /* non-critical */ }
+  }, [post.id]);
+
+  useEffect(() => {
+    fetchReactions();
+  }, [fetchReactions]);
+
+  const toggleReaction = useCallback(async (emoji: string) => {
+    if (reactionLoading) return;
+    setReactionLoading(emoji);
+    setReactionPickerOpen(false);
+    try {
+      const res = await fetch(`/api/posts/${post.id}/reactions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ emoji }),
+      });
+      if (!res.ok) {
+        toast.error('리액션 처리에 실패했습니다.');
+        return;
+      }
+      fetchReactions();
+    } catch {
+      toast.error('리액션 처리에 실패했습니다.');
+    } finally {
+      setReactionLoading(null);
+    }
+  }, [post.id, reactionLoading, fetchReactions]);
+
+  const activeEmojis = REACTION_EMOJIS.filter((e) => (reactions[e]?.count ?? 0) > 0);
 
   const handleEditSubmit = async () => {
     if (!editTitle.trim()) return;
@@ -1010,7 +1130,7 @@ function PostCard({
           })()}
 
         {/* Footer: viewers + comments toggle */}
-        <div className="flex items-center gap-3 px-4 pb-3 pt-1">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2 px-4 pb-3 pt-1">
           <div className="flex items-center gap-1.5">
             {post.viewers.length > 0 ? (
               <div className="flex -space-x-1.5">
@@ -1050,6 +1170,58 @@ function PostCard({
             <MessageCircle className="h-3.5 w-3.5" />
             <span className="tabular-nums">{post.commentCount}</span>
           </button>
+
+
+          {/* Reactions — 이모지별 카운트, 호버/클릭 시 닉네임 */}
+          {activeEmojis.map((emoji) => {
+            const r = reactions[emoji]!;
+            return (
+              <ReactionChip
+                key={emoji}
+                emoji={emoji}
+                count={r.count}
+                reacted={r.reacted}
+                members={r.members}
+                loading={reactionLoading === emoji}
+                onToggle={() => toggleReaction(emoji)}
+              />
+            );
+          })}
+          {/* 리액션 추가 버튼 */}
+          <Popover open={reactionPickerOpen} onOpenChange={setReactionPickerOpen}>
+            <PopoverTrigger asChild>
+              <button
+                className="flex items-center text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+                aria-label="리액션 추가"
+              >
+                <SmilePlus className="h-3.5 w-3.5" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent
+              side="top"
+              className="w-auto p-1.5"
+              sideOffset={6}
+              onOpenAutoFocus={(e) => e.preventDefault()}
+            >
+              <div className="flex items-center gap-0.5">
+                {REACTION_EMOJIS.map((emoji) => (
+                  <button
+                    key={emoji}
+                    type="button"
+                    onClick={() => toggleReaction(emoji)}
+                    disabled={reactionLoading === emoji}
+                    className={cn(
+                      'h-8 w-8 rounded-md text-base flex items-center justify-center hover:bg-muted/80 transition-colors',
+                      reactions[emoji]?.reacted && 'bg-sky-50 dark:bg-sky-950/40',
+                      reactionLoading === emoji && 'opacity-50',
+                    )}
+                  >
+                    {emoji}
+                  </button>
+                ))}
+              </div>
+            </PopoverContent>
+          </Popover>
 
           <div className="ml-auto flex items-center gap-0.5">
             {canEdit && (

--- a/packages/web/src/app/(user)/posts/page.tsx
+++ b/packages/web/src/app/(user)/posts/page.tsx
@@ -58,6 +58,9 @@ import {
 import { cn, getDefaultAvatar } from '@/lib/utils';
 import { getPartStyle, PART_OPTIONS } from '@/lib/part-config';
 
+// Synced with REACTION_EMOJIS in packages/shared/src/db/schema.ts (server validates)
+const REACTION_EMOJIS = ['👍', '👀', '🔥', '💡', '😂', '✅'] as const;
+
 // ─────────────────────────────────────────────
 // Types
 // ─────────────────────────────────────────────
@@ -916,8 +919,6 @@ function PostCard({
   >({});
   const [reactionPickerOpen, setReactionPickerOpen] = useState(false);
   const [reactionLoading, setReactionLoading] = useState<string | null>(null);
-
-  const REACTION_EMOJIS = ['👍', '👀', '🔥', '💡', '😂', '✅'] as const;
 
   const fetchReactions = useCallback(async () => {
     try {

--- a/packages/web/src/app/api/board/[id]/reactions/route.ts
+++ b/packages/web/src/app/api/board/[id]/reactions/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest } from 'next/server';
 import { and, eq } from 'drizzle-orm';
 import { getDb } from '@/lib/db';
-import { db as sharedDb, REACTION_EMOJIS, type ReactionEmoji } from '@blog-study/shared';
+import { db as sharedDb } from '@blog-study/shared';
+
+const { REACTION_EMOJIS } = sharedDb;
+type ReactionEmoji = (typeof REACTION_EMOJIS)[number];
 import { getBoardAuth } from '@/lib/board-auth';
 import { errorResponse, Errors, successResponse } from '@/lib/api-error';
 

--- a/packages/web/src/app/api/board/[id]/reactions/route.ts
+++ b/packages/web/src/app/api/board/[id]/reactions/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest } from 'next/server';
+import { and, eq } from 'drizzle-orm';
+import { getDb } from '@/lib/db';
+import { db as sharedDb, REACTION_EMOJIS, type ReactionEmoji } from '@blog-study/shared';
+import { getBoardAuth } from '@/lib/board-auth';
+import { errorResponse, Errors, successResponse } from '@/lib/api-error';
+
+const { boardPostReactions, boardPosts } = sharedDb;
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await getBoardAuth();
+    if (!auth) return Errors.unauthorized().toResponse();
+
+    const { id: postId } = await params;
+    const body = await request.json();
+    const { emoji } = body as { emoji: string };
+
+    // Validate emoji
+    if (!emoji || !REACTION_EMOJIS.includes(emoji as ReactionEmoji)) {
+      return Errors.badRequest('유효하지 않은 이모지입니다.').toResponse();
+    }
+
+    const database = getDb();
+
+    // Check post exists
+    const [post] = await database
+      .select({ id: boardPosts.id })
+      .from(boardPosts)
+      .where(eq(boardPosts.id, postId))
+      .limit(1);
+
+    if (!post) return Errors.notFound('게시글을 찾을 수 없습니다.').toResponse();
+
+    // Toggle: check if already reacted
+    const [existing] = await database
+      .select({ id: boardPostReactions.id })
+      .from(boardPostReactions)
+      .where(
+        and(
+          eq(boardPostReactions.postId, postId),
+          eq(boardPostReactions.memberId, auth.memberId),
+          eq(boardPostReactions.emoji, emoji)
+        )
+      )
+      .limit(1);
+
+    if (existing) {
+      // Remove reaction
+      await database
+        .delete(boardPostReactions)
+        .where(eq(boardPostReactions.id, existing.id));
+      return successResponse({ action: 'removed', emoji });
+    } else {
+      // Add reaction
+      await database
+        .insert(boardPostReactions)
+        .values({ postId, memberId: auth.memberId, emoji });
+      return successResponse({ action: 'added', emoji }, undefined, 201);
+    }
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/packages/web/src/app/api/board/[id]/reactions/route.ts
+++ b/packages/web/src/app/api/board/[id]/reactions/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest } from 'next/server';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import { getDb } from '@/lib/db';
 import { db as sharedDb } from '@blog-study/shared';
+import { getBoardAuth } from '@/lib/board-auth';
+import { errorResponse, Errors, successResponse } from '@/lib/api-error';
 
 const { REACTION_EMOJIS } = sharedDb;
 type ReactionEmoji = (typeof REACTION_EMOJIS)[number];
-import { getBoardAuth } from '@/lib/board-auth';
-import { errorResponse, Errors, successResponse } from '@/lib/api-error';
 
 const { boardPostReactions, boardPosts } = sharedDb;
 
@@ -33,37 +33,43 @@ export async function POST(
     const [post] = await database
       .select({ id: boardPosts.id })
       .from(boardPosts)
-      .where(eq(boardPosts.id, postId))
+      .where(and(eq(boardPosts.id, postId), isNull(boardPosts.deletedAt)))
       .limit(1);
 
     if (!post) return Errors.notFound('게시글을 찾을 수 없습니다.').toResponse();
 
-    // Toggle: check if already reacted
-    const [existing] = await database
-      .select({ id: boardPostReactions.id })
-      .from(boardPostReactions)
-      .where(
-        and(
-          eq(boardPostReactions.postId, postId),
-          eq(boardPostReactions.memberId, auth.memberId),
-          eq(boardPostReactions.emoji, emoji)
+    // Toggle in transaction to avoid race condition
+    const action = await database.transaction(async (tx) => {
+      const [existing] = await tx
+        .select({ id: boardPostReactions.id })
+        .from(boardPostReactions)
+        .where(
+          and(
+            eq(boardPostReactions.postId, postId),
+            eq(boardPostReactions.memberId, auth.memberId),
+            eq(boardPostReactions.emoji, emoji)
+          )
         )
-      )
-      .limit(1);
+        .limit(1);
 
-    if (existing) {
-      // Remove reaction
-      await database
-        .delete(boardPostReactions)
-        .where(eq(boardPostReactions.id, existing.id));
-      return successResponse({ action: 'removed', emoji });
-    } else {
-      // Add reaction
-      await database
-        .insert(boardPostReactions)
-        .values({ postId, memberId: auth.memberId, emoji });
-      return successResponse({ action: 'added', emoji }, undefined, 201);
-    }
+      if (existing) {
+        await tx
+          .delete(boardPostReactions)
+          .where(eq(boardPostReactions.id, existing.id));
+        return 'removed' as const;
+      } else {
+        await tx
+          .insert(boardPostReactions)
+          .values({ postId, memberId: auth.memberId, emoji });
+        return 'added' as const;
+      }
+    });
+
+    return successResponse(
+      { action, emoji },
+      undefined,
+      action === 'added' ? 201 : 200
+    );
   } catch (error) {
     return errorResponse(error);
   }

--- a/packages/web/src/app/api/board/[id]/route.ts
+++ b/packages/web/src/app/api/board/[id]/route.ts
@@ -8,7 +8,7 @@ import { getAdminDiscordIds } from '@/lib/admin';
 import { isValidCategory } from '@/lib/board-config';
 import { sanitizeTiptapContent } from '@/lib/sanitize';
 
-const { boardPosts, boardComments, members } = sharedDb;
+const { boardPosts, boardComments, members, boardPostReactions } = sharedDb;
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -111,12 +111,39 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
       };
     });
 
+    // Reactions
+    const reactionsRaw = await database
+      .select({
+        emoji: boardPostReactions.emoji,
+        memberId: boardPostReactions.memberId,
+        memberName: members.nickname,
+      })
+      .from(boardPostReactions)
+      .innerJoin(members, eq(boardPostReactions.memberId, members.id))
+      .where(eq(boardPostReactions.postId, id));
+
+    // Group by emoji
+    const reactions: Record<
+      string,
+      { count: number; members: { id: string; nickname: string }[]; reacted: boolean }
+    > = {};
+    for (const row of reactionsRaw) {
+      if (!reactions[row.emoji]) {
+        reactions[row.emoji] = { count: 0, members: [], reacted: false };
+      }
+      reactions[row.emoji].count++;
+      reactions[row.emoji].members.push({ id: row.memberId, nickname: row.memberName });
+      if (row.memberId === auth.memberId) {
+        reactions[row.emoji].reacted = true;
+      }
+    }
+
     const postWithAdmin = {
       ...post,
       memberIsAdmin: adminDiscordIds.includes(post.memberDiscordId),
     };
 
-    return successResponse({ post: postWithAdmin, comments: maskedComments });
+    return successResponse({ post: postWithAdmin, comments: maskedComments, reactions });
   } catch (error) {
     return errorResponse(error);
   }

--- a/packages/web/src/app/api/board/[id]/route.ts
+++ b/packages/web/src/app/api/board/[id]/route.ts
@@ -131,10 +131,11 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
       if (!reactions[row.emoji]) {
         reactions[row.emoji] = { count: 0, members: [], reacted: false };
       }
-      reactions[row.emoji].count++;
-      reactions[row.emoji].members.push({ id: row.memberId, nickname: row.memberName });
+      const entry = reactions[row.emoji]!;
+      entry.count++;
+      entry.members.push({ id: row.memberId, nickname: row.memberName });
       if (row.memberId === auth.memberId) {
-        reactions[row.emoji].reacted = true;
+        entry.reacted = true;
       }
     }
 

--- a/packages/web/src/app/api/posts/[id]/reactions/route.ts
+++ b/packages/web/src/app/api/posts/[id]/reactions/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest } from 'next/server';
+import { and, eq } from 'drizzle-orm';
+import { getDb } from '@/lib/db';
+import { db as sharedDb } from '@blog-study/shared';
+import { getBoardAuth } from '@/lib/board-auth';
+import { errorResponse, Errors, successResponse } from '@/lib/api-error';
+
+const { REACTION_EMOJIS } = sharedDb;
+type ReactionEmoji = (typeof REACTION_EMOJIS)[number];
+
+const { postReactions, posts, members } = sharedDb;
+
+/**
+ * GET /api/posts/[id]/reactions
+ * 포스트 리액션 조회
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await getBoardAuth();
+    if (!auth) return Errors.unauthorized().toResponse();
+
+    const { id: postId } = await params;
+    const database = getDb();
+
+    const reactionsRaw = await database
+      .select({
+        emoji: postReactions.emoji,
+        memberId: postReactions.memberId,
+        memberName: members.nickname,
+      })
+      .from(postReactions)
+      .innerJoin(members, eq(postReactions.memberId, members.id))
+      .where(eq(postReactions.postId, postId));
+
+    const reactions: Record<
+      string,
+      { count: number; members: { id: string; nickname: string }[]; reacted: boolean }
+    > = {};
+    for (const row of reactionsRaw) {
+      if (!reactions[row.emoji]) {
+        reactions[row.emoji] = { count: 0, members: [], reacted: false };
+      }
+      const r = reactions[row.emoji]!;
+      r.count++;
+      r.members.push({ id: row.memberId, nickname: row.memberName ?? '' });
+      if (row.memberId === auth.memberId) {
+        r.reacted = true;
+      }
+    }
+
+    return successResponse({ reactions });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+/**
+ * POST /api/posts/[id]/reactions
+ * 포스트 리액션 토글
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await getBoardAuth();
+    if (!auth) return Errors.unauthorized().toResponse();
+
+    const { id: postId } = await params;
+    const body = await request.json();
+    const { emoji } = body as { emoji: string };
+
+    if (!emoji || !REACTION_EMOJIS.includes(emoji as ReactionEmoji)) {
+      return Errors.badRequest('유효하지 않은 이모지입니다.').toResponse();
+    }
+
+    const database = getDb();
+
+    const [post] = await database
+      .select({ id: posts.id })
+      .from(posts)
+      .where(eq(posts.id, postId))
+      .limit(1);
+
+    if (!post) return Errors.notFound('포스트를 찾을 수 없습니다.').toResponse();
+
+    const action = await database.transaction(async (tx) => {
+      const [existing] = await tx
+        .select({ id: postReactions.id })
+        .from(postReactions)
+        .where(
+          and(
+            eq(postReactions.postId, postId),
+            eq(postReactions.memberId, auth.memberId),
+            eq(postReactions.emoji, emoji)
+          )
+        )
+        .limit(1);
+
+      if (existing) {
+        await tx
+          .delete(postReactions)
+          .where(eq(postReactions.id, existing.id));
+        return 'removed' as const;
+      } else {
+        await tx
+          .insert(postReactions)
+          .values({ postId, memberId: auth.memberId, emoji });
+        return 'added' as const;
+      }
+    });
+
+    return successResponse(
+      { action, emoji },
+      undefined,
+      action === 'added' ? 201 : 200
+    );
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/packages/web/src/app/api/posts/route.ts
+++ b/packages/web/src/app/api/posts/route.ts
@@ -12,7 +12,7 @@ import {
 import { createClient } from '@/lib/supabase/server';
 import { isAdminDiscordId } from '@/lib/admin';
 
-const { posts, members, rounds, postViews } = sharedDb;
+const { posts, members, rounds, postViews, postReactions } = sharedDb;
 
 /**
  * GET /api/posts
@@ -94,7 +94,8 @@ export async function GET(request: NextRequest) {
     const totalCount = totalCountResult[0]?.count ?? 0;
 
     // 정렬 기준: 인기순은 score desc → 동점 시 댓글 많은 순 → 최신순
-    const popularScore = sql`COALESCE(${posts.commentCount}, 0) * 3 + (SELECT COUNT(*) FROM post_views pv WHERE pv.post_id = ${posts.id})`;
+    // 가중치: 댓글 3, 조회수 2, 리액션 1
+    const popularScore = sql`COALESCE(${posts.commentCount}, 0) * 3 + (SELECT COUNT(*) FROM post_views pv WHERE pv.post_id = ${posts.id}) * 2 + (SELECT COUNT(*) FROM post_reactions pr WHERE pr.post_id = ${posts.id})`;
 
     // Get paginated posts with member and round info
     const postsQuery = database
@@ -140,6 +141,7 @@ export async function GET(request: NextRequest) {
       }[]
     >();
     let viewCountMap = new Map<string, number>();
+    let reactionCountMap = new Map<string, number>();
 
     if (postIds.length > 0) {
       // Get view counts per post
@@ -153,6 +155,18 @@ export async function GET(request: NextRequest) {
         .groupBy(postViews.postId);
 
       viewCountMap = new Map(viewCounts.map((v) => [v.postId, v.count]));
+
+      // Get reaction counts per post
+      const reactionCounts = await database
+        .select({
+          postId: postReactions.postId,
+          count: count(),
+        })
+        .from(postReactions)
+        .where(inArray(postReactions.postId, postIds))
+        .groupBy(postReactions.postId);
+
+      reactionCountMap = new Map(reactionCounts.map((r) => [r.postId, r.count]));
 
       // Get recent viewers per post with member info (Drizzle query)
       const allViewers = await database
@@ -216,6 +230,7 @@ export async function GET(request: NextRequest) {
         viewCount: viewCountMap.get(post.id) ?? 0,
         viewers: (viewersMap.get(post.id) ?? []).slice(0, 3),
         totalViewers: viewCountMap.get(post.id) ?? 0,
+        reactionCount: reactionCountMap.get(post.id) ?? 0,
       })),
       currentMemberId,
       isAdmin,

--- a/packages/web/src/components/board/reaction-bar.tsx
+++ b/packages/web/src/components/board/reaction-bar.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import { Plus } from 'lucide-react';
+import { toast } from 'sonner';
+import { cn } from '@/lib/utils';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+
+// ─────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────
+
+const EMOJIS = ['\u{1F44D}', '\u{1F440}', '\u{1F525}', '\u{1F4A1}', '\u{1F602}', '\u2705'] as const;
+
+const LONG_PRESS_MS = 500;
+
+// ─────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────
+
+interface ReactionData {
+  count: number;
+  members: { id: string; nickname: string }[];
+  reacted: boolean;
+}
+
+interface ReactionBarProps {
+  postId: string;
+  reactions: Record<string, ReactionData>;
+  onUpdate: () => void;
+}
+
+// ─────────────────────────────────────────────
+// MemberPopover (hover on desktop, long-press on mobile)
+// ─────────────────────────────────────────────
+
+function MemberPopover({
+  members,
+  children,
+}: {
+  members: { id: string; nickname: string }[];
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const didLongPress = useRef(false);
+
+  const clearTimer = useCallback(() => {
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  }, []);
+
+  const handlePointerDown = useCallback(() => {
+    didLongPress.current = false;
+    longPressTimer.current = setTimeout(() => {
+      didLongPress.current = true;
+      setOpen(true);
+    }, LONG_PRESS_MS);
+  }, []);
+
+  const handlePointerUp = useCallback(() => {
+    clearTimer();
+  }, [clearTimer]);
+
+  const handlePointerCancel = useCallback(() => {
+    clearTimer();
+  }, [clearTimer]);
+
+  // Prevent click after long-press on mobile
+  const handleClick = useCallback((e: React.MouseEvent) => {
+    if (didLongPress.current) {
+      e.preventDefault();
+      e.stopPropagation();
+      didLongPress.current = false;
+    }
+  }, []);
+
+  if (members.length === 0) return <>{children}</>;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <div
+          className="inline-flex"
+          // Desktop hover
+          onMouseEnter={() => setOpen(true)}
+          onMouseLeave={() => setOpen(false)}
+          // Mobile long-press
+          onPointerDown={handlePointerDown}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerCancel}
+          onClickCapture={handleClick}
+        >
+          {children}
+        </div>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-auto max-w-56 p-2.5"
+        side="top"
+        sideOffset={6}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onPointerDownOutside={() => setOpen(false)}
+        // Keep open on hover (desktop)
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+      >
+        <div className="space-y-0.5">
+          {members.map((m) => (
+            <p key={m.id} className="text-xs text-popover-foreground truncate">
+              {m.nickname}
+            </p>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+// ─────────────────────────────────────────────
+// ReactionBar
+// ─────────────────────────────────────────────
+
+export function ReactionBar({ postId, reactions, onUpdate }: ReactionBarProps) {
+  const [loading, setLoading] = useState<string | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const toggle = useCallback(
+    async (emoji: string) => {
+      if (loading) return;
+      setLoading(emoji);
+      try {
+        const res = await fetch(`/api/board/${postId}/reactions`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ emoji }),
+        });
+        if (!res.ok) {
+          const data = await res.json().catch(() => null);
+          toast.error(data?.message || '리액션 처리에 실패했습니다.');
+          return;
+        }
+        onUpdate();
+      } catch {
+        toast.error('리액션 처리에 실패했습니다.');
+      } finally {
+        setLoading(null);
+      }
+    },
+    [postId, loading, onUpdate],
+  );
+
+  const handlePickerSelect = useCallback(
+    (emoji: string) => {
+      setPickerOpen(false);
+      toggle(emoji);
+    },
+    [toggle],
+  );
+
+  // Active reactions (count > 0)
+  const activeEmojis = EMOJIS.filter((e) => (reactions[e]?.count ?? 0) > 0);
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {activeEmojis.map((emoji) => {
+        const r = reactions[emoji]!;
+        return (
+          <MemberPopover key={emoji} members={r.members}>
+            <button
+              type="button"
+              disabled={loading === emoji}
+              onClick={() => toggle(emoji)}
+              className={cn(
+                'inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors select-none',
+                r.reacted
+                  ? 'border-sky-300 bg-sky-50 text-sky-700 dark:border-sky-700 dark:bg-sky-950/40 dark:text-sky-300'
+                  : 'border-border/60 bg-muted/40 text-muted-foreground hover:bg-muted/70',
+                loading === emoji && 'opacity-50 pointer-events-none',
+              )}
+            >
+              <span className="text-sm leading-none">{emoji}</span>
+              <span className="tabular-nums">{r.count}</span>
+            </button>
+          </MemberPopover>
+        );
+      })}
+
+      {/* Add reaction picker */}
+      <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className="inline-flex items-center justify-center h-7 w-7 rounded-full border border-dashed border-border/60 text-muted-foreground hover:bg-muted/70 hover:text-foreground transition-colors"
+            aria-label="리액션 추가"
+          >
+            <Plus className="h-3.5 w-3.5" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="w-auto p-1.5"
+          side="top"
+          sideOffset={6}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
+          <div className="flex items-center gap-0.5">
+            {EMOJIS.map((emoji) => (
+              <button
+                key={emoji}
+                type="button"
+                onClick={() => handlePickerSelect(emoji)}
+                className={cn(
+                  'h-8 w-8 rounded-md text-base flex items-center justify-center hover:bg-muted/80 transition-colors',
+                  reactions[emoji]?.reacted && 'bg-sky-50 dark:bg-sky-950/40',
+                )}
+              >
+                {emoji}
+              </button>
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/packages/web/src/components/board/reaction-bar.tsx
+++ b/packages/web/src/components/board/reaction-bar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Plus } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
@@ -10,7 +10,8 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 // Constants
 // ─────────────────────────────────────────────
 
-const EMOJIS = ['\u{1F44D}', '\u{1F440}', '\u{1F525}', '\u{1F4A1}', '\u{1F602}', '\u2705'] as const;
+// Synced with REACTION_EMOJIS in packages/shared/src/db/schema.ts (server validates)
+const EMOJIS = ['👍', '👀', '🔥', '💡', '😂', '✅'] as const;
 
 const LONG_PRESS_MS = 500;
 
@@ -75,6 +76,13 @@ function MemberPopover({
       e.stopPropagation();
       didLongPress.current = false;
     }
+  }, []);
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (longPressTimer.current) clearTimeout(longPressTimer.current);
+    };
   }, []);
 
   if (members.length === 0) return <>{children}</>;
@@ -172,6 +180,8 @@ export function ReactionBar({ postId, reactions, onUpdate }: ReactionBarProps) {
               type="button"
               disabled={loading === emoji}
               onClick={() => toggle(emoji)}
+              aria-label={`${emoji} 리액션, ${r.count}명`}
+              aria-pressed={r.reacted}
               className={cn(
                 'inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors select-none',
                 r.reacted

--- a/packages/web/src/components/board/reaction-bar.tsx
+++ b/packages/web/src/components/board/reaction-bar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Plus } from 'lucide-react';
+import { SmilePlus } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
@@ -69,7 +69,6 @@ function MemberPopover({
     clearTimer();
   }, [clearTimer]);
 
-  // Prevent click after long-press on mobile
   const handleClick = useCallback((e: React.MouseEvent) => {
     if (didLongPress.current) {
       e.preventDefault();
@@ -78,7 +77,6 @@ function MemberPopover({
     }
   }, []);
 
-  // Cleanup timer on unmount
   useEffect(() => {
     return () => {
       if (longPressTimer.current) clearTimeout(longPressTimer.current);
@@ -92,10 +90,8 @@ function MemberPopover({
       <PopoverTrigger asChild>
         <div
           className="inline-flex"
-          // Desktop hover
           onMouseEnter={() => setOpen(true)}
           onMouseLeave={() => setOpen(false)}
-          // Mobile long-press
           onPointerDown={handlePointerDown}
           onPointerUp={handlePointerUp}
           onPointerCancel={handlePointerCancel}
@@ -110,7 +106,6 @@ function MemberPopover({
         sideOffset={6}
         onOpenAutoFocus={(e) => e.preventDefault()}
         onPointerDownOutside={() => setOpen(false)}
-        // Keep open on hover (desktop)
         onMouseEnter={() => setOpen(true)}
         onMouseLeave={() => setOpen(false)}
       >
@@ -127,12 +122,11 @@ function MemberPopover({
 }
 
 // ─────────────────────────────────────────────
-// ReactionBar
+// ReactionBar — Slim toolbar style
 // ─────────────────────────────────────────────
 
 export function ReactionBar({ postId, reactions, onUpdate }: ReactionBarProps) {
   const [loading, setLoading] = useState<string | null>(null);
-  const [pickerOpen, setPickerOpen] = useState(false);
 
   const toggle = useCallback(
     async (emoji: string) => {
@@ -159,19 +153,12 @@ export function ReactionBar({ postId, reactions, onUpdate }: ReactionBarProps) {
     [postId, loading, onUpdate],
   );
 
-  const handlePickerSelect = useCallback(
-    (emoji: string) => {
-      setPickerOpen(false);
-      toggle(emoji);
-    },
-    [toggle],
-  );
-
-  // Active reactions (count > 0)
+  const [pickerOpen, setPickerOpen] = useState(false);
   const activeEmojis = EMOJIS.filter((e) => (reactions[e]?.count ?? 0) > 0);
 
   return (
     <div className="flex flex-wrap items-center gap-1.5">
+      {/* 활성 이모지 칩 — 호버/클릭 시 닉네임 팝오버 */}
       {activeEmojis.map((emoji) => {
         const r = reactions[emoji]!;
         return (
@@ -197,7 +184,7 @@ export function ReactionBar({ postId, reactions, onUpdate }: ReactionBarProps) {
         );
       })}
 
-      {/* Add reaction picker */}
+      {/* 리액션 추가 피커 */}
       <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
         <PopoverTrigger asChild>
           <button
@@ -205,12 +192,12 @@ export function ReactionBar({ postId, reactions, onUpdate }: ReactionBarProps) {
             className="inline-flex items-center justify-center h-7 w-7 rounded-full border border-dashed border-border/60 text-muted-foreground hover:bg-muted/70 hover:text-foreground transition-colors"
             aria-label="리액션 추가"
           >
-            <Plus className="h-3.5 w-3.5" />
+            <SmilePlus className="h-3.5 w-3.5" />
           </button>
         </PopoverTrigger>
         <PopoverContent
-          className="w-auto p-1.5"
           side="top"
+          className="w-auto p-1.5"
           sideOffset={6}
           onOpenAutoFocus={(e) => e.preventDefault()}
         >
@@ -219,10 +206,15 @@ export function ReactionBar({ postId, reactions, onUpdate }: ReactionBarProps) {
               <button
                 key={emoji}
                 type="button"
-                onClick={() => handlePickerSelect(emoji)}
+                onClick={() => {
+                  setPickerOpen(false);
+                  toggle(emoji);
+                }}
+                disabled={loading === emoji}
                 className={cn(
                   'h-8 w-8 rounded-md text-base flex items-center justify-center hover:bg-muted/80 transition-colors',
                   reactions[emoji]?.reacted && 'bg-sky-50 dark:bg-sky-950/40',
+                  loading === emoji && 'opacity-50',
                 )}
               >
                 {emoji}

--- a/packages/web/src/components/board/reaction-bar.tsx
+++ b/packages/web/src/components/board/reaction-bar.tsx
@@ -27,6 +27,7 @@ interface ReactionData {
 
 interface ReactionBarProps {
   postId: string;
+  apiPath?: 'board' | 'posts';
   reactions: Record<string, ReactionData>;
   onUpdate: () => void;
 }
@@ -125,7 +126,7 @@ function MemberPopover({
 // ReactionBar — Slim toolbar style
 // ─────────────────────────────────────────────
 
-export function ReactionBar({ postId, reactions, onUpdate }: ReactionBarProps) {
+export function ReactionBar({ postId, apiPath = 'board', reactions, onUpdate }: ReactionBarProps) {
   const [loading, setLoading] = useState<string | null>(null);
 
   const toggle = useCallback(
@@ -133,7 +134,7 @@ export function ReactionBar({ postId, reactions, onUpdate }: ReactionBarProps) {
       if (loading) return;
       setLoading(emoji);
       try {
-        const res = await fetch(`/api/board/${postId}/reactions`, {
+        const res = await fetch(`/api/${apiPath}/${postId}/reactions`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ emoji }),
@@ -150,7 +151,7 @@ export function ReactionBar({ postId, reactions, onUpdate }: ReactionBarProps) {
         setLoading(null);
       }
     },
-    [postId, loading, onUpdate],
+    [apiPath, postId, loading, onUpdate],
   );
 
   const [pickerOpen, setPickerOpen] = useState(false);


### PR DESCRIPTION
## Summary
- 게시판 글 + 포스트에 고정 6종 이모지 리액션 기능 추가 (👍👀🔥💡😂✅)
- `board_post_reactions`, `post_reactions` 테이블 신규 생성
- ReactionBar 공용 컴포넌트 (`apiPath` prop으로 board/posts 구분)
- 포스트 목록 카드에 리액션 칩 + SmilePlus 피커 표시
- 인기글 점수 공식 변경: `댓글×3 + 조회수×2 + 리액션×1`
- 게시판 공지 Discord 알림에 본문 미리보기 (최대 500자) 추가

## Changes
- `packages/shared/src/db/schema.ts` — boardPostReactions, postReactions 테이블 + relations
- `packages/web/src/components/board/reaction-bar.tsx` — ReactionBar 공용 컴포넌트
- `packages/web/src/app/api/board/[id]/reactions/route.ts` — 게시판 리액션 토글 API
- `packages/web/src/app/api/posts/[id]/reactions/route.ts` — 포스트 리액션 GET + 토글 API
- `packages/web/src/app/api/board/[id]/route.ts` — GET 응답에 reactions 추가
- `packages/web/src/app/api/posts/route.ts` — 리스트에 reactionCount 추가
- `packages/web/src/app/(user)/board/[id]/page.tsx` — 게시판 상세 ReactionBar
- `packages/web/src/app/(user)/posts/[id]/page.tsx` — 포스트 상세 ReactionBar
- `packages/web/src/app/(user)/posts/page.tsx` — 포스트 목록 리액션 칩

## DDL (이미 적용됨)
```sql
-- board_post_reactions (이미 push 완료)
-- post_reactions (수동 적용 완료)
```

## Test plan
- [x] 게시판 상세에서 이모지 토글 (추가/제거) 확인
- [x] 포스트 상세에서 이모지 토글 확인
- [x] 포스트 목록 카드에서 리액션 칩 표시 + 피커 동작 확인
- [x] 호버(PC) / 클릭(모바일) 시 닉네임 팝오버 확인
- [x] 복수 이모지 동시 선택 가능 확인
- [x] 다크모드 UI 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)