### PR TITLE
fix: D-Day 라벨 off-by-one 수정 + 주간랭킹 수동부여 점수 포함

### DIFF
--- a/packages/bot/src/schedulers/weekly-ranking.ts
+++ b/packages/bot/src/schedulers/weekly-ranking.ts
@@ -62,7 +62,7 @@ async function getMemberRankings(): Promise<MemberRanking[]> {
     .select({
       memberId: activityScores.memberId,
       totalScore: sql<number>`COALESCE(SUM(${activityScores.points}), 0)`,
-      webActivityScore: sql<number>`COALESCE(SUM(CASE WHEN ${activityScores.type} IN (${ActivityScoreType.BOARD_POST}, ${ActivityScoreType.POST_COMMENT}, ${ActivityScoreType.BOARD_COMMENT}, ${ActivityScoreType.POST_VIEW}) THEN ${activityScores.points} ELSE 0 END), 0)`,
+      webActivityScore: sql<number>`COALESCE(SUM(CASE WHEN ${activityScores.type} IN (${ActivityScoreType.BOARD_POST}, ${ActivityScoreType.POST_COMMENT}, ${ActivityScoreType.BOARD_COMMENT}, ${ActivityScoreType.POST_VIEW}, ${ActivityScoreType.ADMIN_MANUAL}) THEN ${activityScores.points} ELSE 0 END), 0)`,
     })
     .from(activityScores)
     .groupBy(activityScores.memberId);

--- a/packages/web/src/app/(user)/dashboard/page.tsx
+++ b/packages/web/src/app/(user)/dashboard/page.tsx
@@ -126,7 +126,7 @@ function getMotivation(round: RoundInfo | null): {
 
 function getDdayLabel(days: number, isGrace: boolean): string {
   if (isGrace) return '지각 마감';
-  if (days <= 1) return 'D-Day';
+  if (days <= 0) return 'D-Day';
   return `D-${days}`;
 }
 


### PR DESCRIPTION
## Summary
- D-Day 라벨: `days <= 1` → `days <= 0` (마감 하루 전에 D-Day로 표시되던 버그 수정)
- 주간랭킹 Discord 메시지: `webActivityScore`에 `ADMIN_MANUAL` 타입 추가 (수동부여 점수가 활동 점수 괄호 안에 표시)

## Test plan
- [x] 마감일 하루 전 대시보드에서 D-1 표시 확인
- [x] 마감 당일 D-Day 표시 확인
- [x] 수동부여 점수가 있는 멤버의 주간랭킹 활동 점수에 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)