### PR TITLE
fix: 마감 리마인더 푸시 마크다운 볼드 제거

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ pnpm --filter @blog-study/bot rss-collect      # 수동 RSS 수집 (봇 없이)
 - **포스트 수정**: 본인 또는 관리자만 제목/설명 수정 가능 (`PATCH /api/posts/[id]`)
 - **공지 알림**: 게시판 공지 작성 시 FCM 푸시 + Discord 공지채널(`notice_channel_id`) `@everyone` + embed(제목+본문 미리보기 500자) + 웹 딥링크 버튼
 - **벌금 납부**: 웹 `/profile/fines`에서 본인 납부 처리 (atomic update), 납부 시 관리자 Discord 채널 알림. 계좌 정보: 3333333114501 카카오뱅크
-- **리마인더 푸시**: 벌금 알림(`fine_notification`)/벌금 리마인더(`fine_reminder`)/마감 리마인더(`deadline_reminder`)/지각 독촉(`grace_nudge`)/투표 리마인더(`poll_reminder`) 5종은 Discord DM 대신 FCM 푸시로 발송. 봇→웹 내부 API(`/api/internal/reminder-push`) 경유. `FORCE_SEND_TYPES`로 유저가 끌 수 없음
+- **리마인더 푸시**: 벌금 알림(`fine_notification`)/벌금 리마인더(`fine_reminder`)/마감 리마인더(`deadline_reminder`)/지각 독촉(`grace_nudge`)/투표 리마인더(`poll_reminder`) 5종은 Discord DM 대신 FCM 푸시로 발송. 봇→웹 내부 API(`/api/internal/reminder-push`) 경유. `FORCE_SEND_TYPES`로 유저가 끌 수 없음. **FCM 푸시 body는 plain text** (`**bold**` 등 마크다운 렌더 안 됨 — 강조 시 따옴표 `'X'` 사용)
 - **D-Day 계산**: KST 캘린더 날짜 기준 (midnight 비교, 당일=D-Day=0), 제출률은 active 유저만 카운트
 - **알림 로그**: `discord_notification_logs` 테이블에 봇/웹 모든 채널+DM+푸시 알림 성공/실패 기록 (target: `channel`/`dm`/`push`), `logNotification()` 헬퍼 (봇: `notification-logger.ts`, 웹: `notification-log.ts`), 관리자 페이지 "알림 로그" 탭에서 조회 (타입/소스/대상/상태 필터 + 무한 스크롤, 푸시 로그에 수신자 닉네임 표시)
 - **비밀답글 가시성**: 비밀 답글은 작성자/포스트작성자/부모댓글작성자/관리자가 열람 가능

--- a/packages/bot/src/schedulers/deadline-reminder.ts
+++ b/packages/bot/src/schedulers/deadline-reminder.ts
@@ -34,7 +34,7 @@ function getDeadlineMessage(dDay: number, roundNumber: number, endDate: string):
       return {
         title: '"📝 글 제출 마감이 이틀 남았어요"',
         body: [
-          `${roundNumber}회차 마감일은 **${formattedDate}**이에요.`,
+          `${roundNumber}회차 마감일은 '${formattedDate}'이에요.`,
           ``,
           `아직 여유가 있지만, 미리 준비하면 마음이 편하겠죠?`,
           `주제가 안 떠오르면 최근에 배운 걸 짧게 정리하는 것도 좋아요 ✍️`,
@@ -44,7 +44,7 @@ function getDeadlineMessage(dDay: number, roundNumber: number, endDate: string):
       return {
         title: '"⏳ 내일이 마감이에요!"',
         body: [
-          `${roundNumber}회차 마감이 **내일 ${formattedDate}**이에요.`,
+          `${roundNumber}회차 마감이 '내일 ${formattedDate}'이에요.`,
           ``,
           `완벽하지 않아도 괜찮아요.`,
           `짧은 글이라도 꾸준히 쓰는 게 중요하니까요 💪`,
@@ -54,7 +54,7 @@ function getDeadlineMessage(dDay: number, roundNumber: number, endDate: string):
       return {
         title: '"🔥 오늘이 마감일이에요!"',
         body: [
-          `${roundNumber}회차 마감이 **오늘**까지입니다.`,
+          `${roundNumber}회차 마감이 '오늘'까지입니다.`,
           ``,
           `아직 시간이 있어요! 지금 시작해도 충분합니다.`,
           `오늘 안에 제출하면 정상 출석 처리돼요 ✅`,


### PR DESCRIPTION
## Summary
- FCM 푸시는 마크다운을 렌더링하지 않아 `**X**` 가 body에 그대로 노출되던 문제 수정
- `deadline_reminder` 푸시 body의 3군데 (`**date**`, `**내일 date**`, `**오늘**`)를 작은따옴표 `'X'` 강조로 변경
- CLAUDE.md 리마인더 푸시 규칙에 "plain text, 마크다운 렌더 안 됨" 명시

## Test plan
- [ ] `sendReminderPush` 호출 경로 크로스체크 (fine_notification / fine_reminder / grace_nudge / poll_reminder는 이미 plain text)
- [ ] 실제 FCM 푸시 발송 시 `'10월 20일 (월)'` 형태로 표시되는지 수동 확인 (다음 D-2 리마인더 발송 타이밍)

🤖 Generated with [Claude Code](https://claude.com/claude-code)